### PR TITLE
HV-461 Package org.hibernate.validator.test.util

### DIFF
--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/cfg/CascadingWithConstraintMappingTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/cfg/CascadingWithConstraintMappingTest.java
@@ -28,13 +28,13 @@ import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.cfg.defs.NotNullDef;
 import org.hibernate.validator.method.MethodConstraintViolation;
 import org.hibernate.validator.method.MethodValidator;
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 import org.hibernate.validator.util.ReflectionHelper;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 public class CascadingWithConstraintMappingTest {
 	@Test(description = "HV-433")

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/cfg/ConstraintMappingTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/cfg/ConstraintMappingTest.java
@@ -44,13 +44,13 @@ import org.hibernate.validator.cfg.defs.RangeDef;
 import org.hibernate.validator.cfg.defs.SizeDef;
 import org.hibernate.validator.group.DefaultGroupSequenceProvider;
 import org.hibernate.validator.group.GroupSequenceProvider;
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertConstraintViolation;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.testng.Assert.assertTrue;
 
 /**

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/ClassValidatorWithTypeVariableTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/ClassValidatorWithTypeVariableTest.java
@@ -27,10 +27,11 @@ import javax.validation.constraints.NotNull;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
+
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * HV-250

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/ConstraintTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/ConstraintTest.java
@@ -22,10 +22,10 @@ import javax.validation.Validator;
 
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertConstraintViolation;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * @author Hardy Ferentschik

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextImplTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextImplTest.java
@@ -24,7 +24,7 @@ import org.hibernate.validator.engine.ConstraintValidatorContextImpl;
 import org.hibernate.validator.engine.MessageAndPath;
 import org.hibernate.validator.engine.PathImpl;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.pathsAreEqual;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.pathsAreEqual;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextTest.java
@@ -29,11 +29,11 @@ import javax.validation.constraints.NotNull;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * Tests for the {@link javax.validation.ConstraintValidatorContext} API.

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/ValidatorResolutionTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/ValidatorResolutionTest.java
@@ -25,10 +25,10 @@ import javax.validation.Validator;
 
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertConstraintViolation;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * @author Hardy Ferentschik

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/boolcomposition/BoolCompositeConstraintTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/boolcomposition/BoolCompositeConstraintTest.java
@@ -23,11 +23,11 @@ import javax.validation.Validator;
 
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * @author Federico Mancini

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/boolcomposition/localconstrval/LocalConstrValTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/boolcomposition/localconstrval/LocalConstrValTest.java
@@ -24,11 +24,11 @@ import javax.validation.constraints.Pattern;
 
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * @author Federico Mancini

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/composition/CompositeConstraintTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/composition/CompositeConstraintTest.java
@@ -25,11 +25,11 @@ import javax.validation.constraints.Size;
 import static org.testng.Assert.assertEquals;
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * @author Gerhard Petracek

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/impl/BlankValidatorTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/impl/BlankValidatorTest.java
@@ -26,8 +26,8 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.constraints.impl.NotBlankValidator;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.test.util.ValidatorUtil.getValidator;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getValidator;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/impl/DecimalMinMaxValidatorBoundaryTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/impl/DecimalMinMaxValidatorBoundaryTest.java
@@ -26,11 +26,11 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.cfg.defs.DecimalMaxDef;
 import org.hibernate.validator.cfg.defs.DecimalMinDef;
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
 import static java.lang.annotation.ElementType.FIELD;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * @author Hardy Ferentschik

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/impl/FutureValidatorTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/impl/FutureValidatorTest.java
@@ -23,7 +23,7 @@ import javax.validation.Validator;
 import static org.testng.Assert.assertEquals;
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
 /**
  * @author Hardy Ferentschik

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/impl/MinMaxValidatorBoundaryTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/impl/MinMaxValidatorBoundaryTest.java
@@ -24,10 +24,10 @@ import javax.validation.constraints.Min;
 
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * Check correct behavior of {@link org.hibernate.validator.constraints.impl.MinValidatorForNumber} and

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/impl/URLValidatorTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/constraints/impl/URLValidatorTest.java
@@ -27,14 +27,14 @@ import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.cfg.defs.URLDef;
 import org.hibernate.validator.constraints.URL;
 import org.hibernate.validator.constraints.impl.URLValidator;
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 import org.hibernate.validator.util.annotationfactory.AnnotationDescriptor;
 import org.hibernate.validator.util.annotationfactory.AnnotationFactory;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.test.util.ValidatorUtil.getValidatorForProgrammaticMapping;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getValidatorForProgrammaticMapping;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/PathImplTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/PathImplTest.java
@@ -29,9 +29,9 @@ import javax.validation.constraints.NotNull;
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.engine.PathImpl;
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/ValidatorTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/ValidatorTest.java
@@ -31,12 +31,12 @@ import javax.validation.metadata.BeanDescriptor;
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.constraints.Length;
-import org.hibernate.validator.test.util.CountValidationCalls;
-import org.hibernate.validator.test.util.CountValidationCallsValidator;
+import org.hibernate.validator.test.testutil.CountValidationCalls;
+import org.hibernate.validator.test.testutil.CountValidationCallsValidator;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.test.util.ValidatorUtil.getValidator;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getValidator;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/customerror/CustomErrorMessageTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/customerror/CustomErrorMessageTest.java
@@ -23,8 +23,8 @@ import javax.validation.Validator;
 
 import org.testng.annotations.Test;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ValidatorUtil.getValidator;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getValidator;
 
 /**
  * @author Hardy Ferentschik

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/failfast/FailFastTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/failfast/FailFastTest.java
@@ -22,12 +22,12 @@ import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.method.MethodConstraintViolationException;
 import org.hibernate.validator.method.MethodValidator;
-import org.hibernate.validator.test.util.ValidatorUtil;
-import org.hibernate.validator.test.util.ValidationInvocationHandler;
+import org.hibernate.validator.test.testutil.ValidationInvocationHandler;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 import org.hibernate.validator.util.LoggerFactory;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.test.util.ValidatorUtil.getMethodValidationProxy;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getMethodValidationProxy;
 import static org.testng.Assert.fail;
 
 /**

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/groups/defaultgroupsequenceprovider/DefaultGroupSequenceProviderTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/groups/defaultgroupsequenceprovider/DefaultGroupSequenceProviderTest.java
@@ -35,9 +35,9 @@ import org.hibernate.validator.group.GroupSequenceProvider;
 import org.hibernate.validator.method.MethodConstraintViolation;
 import org.hibernate.validator.method.MethodValidator;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.test.util.ValidatorUtil.getValidator;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getValidator;
 
 /**
  * @author Kevin Pollet - SERLI - (kevin.pollet@serli.com)

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/groups/inheritance/GroupInheritanceTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/groups/inheritance/GroupInheritanceTest.java
@@ -22,10 +22,10 @@ import javax.validation.Validator;
 
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * @author Hardy Ferentschik

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/groups/redefiningdefaultgroup/RedefiningDefaultGroupTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/groups/redefiningdefaultgroup/RedefiningDefaultGroupTest.java
@@ -27,10 +27,10 @@ import javax.validation.groups.Default;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.test.util.ValidatorUtil.getValidator;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getValidator;
 
 /**
  * @author Hardy Ferentschik

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/messageinterpolation/MessageInterpolationWithDefaultBundleTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/messageinterpolation/MessageInterpolationWithDefaultBundleTest.java
@@ -27,10 +27,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * Tests for correct message interpolation for messages from the default bundle.

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/messageinterpolation/MessageInterpolatorContextTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/messageinterpolation/MessageInterpolatorContextTest.java
@@ -32,14 +32,14 @@ import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.cfg.defs.MinDef;
 import org.hibernate.validator.engine.MessageInterpolatorContext;
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static org.easymock.EasyMock.createMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.testng.Assert.assertTrue;
 
 /**

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/messageinterpolation/ValueFormatterMessageInterpolatorTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/messageinterpolation/ValueFormatterMessageInterpolatorTest.java
@@ -35,11 +35,11 @@ import org.hibernate.validator.cfg.defs.FutureDef;
 import org.hibernate.validator.cfg.defs.NotNullDef;
 import org.hibernate.validator.cfg.defs.NullDef;
 import org.hibernate.validator.messageinterpolation.ValueFormatterMessageInterpolator;
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
 import static java.lang.annotation.ElementType.FIELD;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * Test for {@link org.hibernate.validator.messageinterpolation.ValueFormatterMessageInterpolator}.

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/methodlevel/IllegalMethodParameterConstraintsTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/methodlevel/IllegalMethodParameterConstraintsTest.java
@@ -28,9 +28,9 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.engine.ValidatorImpl;
 import org.hibernate.validator.metadata.BeanMetaDataImpl;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ValidatorUtil.getMethodValidator;
-import static org.hibernate.validator.test.util.ValidatorUtil.getValidator;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getMethodValidator;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getValidator;
 
 /**
  * Integration test for {@link ValidatorImpl} and {@link BeanMetaDataImpl} which

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/methodlevel/MethodLevelValidationGroupSequenceTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/methodlevel/MethodLevelValidationGroupSequenceTest.java
@@ -30,11 +30,11 @@ import org.hibernate.validator.test.engine.methodlevel.service.CustomerRepositor
 import org.hibernate.validator.test.engine.methodlevel.service.CustomerRepositoryWithRedefinedDefaultGroup.ValidationGroup2;
 import org.hibernate.validator.test.engine.methodlevel.service.CustomerRepositoryWithRedefinedDefaultGroup.ValidationSequence;
 import org.hibernate.validator.test.engine.methodlevel.service.CustomerRepositoryWithRedefinedDefaultGroupImpl;
-import org.hibernate.validator.test.util.ValidationInvocationHandler;
+import org.hibernate.validator.test.testutil.ValidationInvocationHandler;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ValidatorUtil.getMethodValidationProxy;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertConstraintViolation;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getMethodValidationProxy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/methodlevel/MethodLevelValidationTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/methodlevel/MethodLevelValidationTest.java
@@ -39,12 +39,12 @@ import org.hibernate.validator.test.engine.methodlevel.model.Customer;
 import org.hibernate.validator.test.engine.methodlevel.service.CustomerRepository;
 import org.hibernate.validator.test.engine.methodlevel.service.CustomerRepositoryImpl;
 import org.hibernate.validator.test.engine.methodlevel.service.RepositoryBase;
-import org.hibernate.validator.test.util.ValidationInvocationHandler;
+import org.hibernate.validator.test.testutil.ValidationInvocationHandler;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.test.util.ValidatorUtil.getMethodValidationProxy;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertConstraintViolation;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getMethodValidationProxy;
 import static org.hibernate.validator.util.CollectionHelper.newHashMap;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/proxy/ProxyTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/proxy/ProxyTest.java
@@ -26,8 +26,9 @@ import javax.validation.Validator;
 import static org.testng.Assert.assertEquals;
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
+
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * See HV-257

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/serialization/ConstraintViolationSerializationTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/serialization/ConstraintViolationSerializationTest.java
@@ -28,9 +28,9 @@ import javax.validation.Validator;
 
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 
 /**
  * @author Hardy Ferentschik

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/serialization/CustomConstraintSerializableTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/serialization/CustomConstraintSerializableTest.java
@@ -25,7 +25,7 @@ import javax.validation.Validator;
 
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
 
 /**

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/traversableresolver/JpaTraversableResolverTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/engine/traversableresolver/JpaTraversableResolverTest.java
@@ -25,7 +25,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.engine.resolver.DefaultTraversableResolver;
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
 import static org.testng.Assert.assertTrue;
 

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/AggregatedMethodMetaDataTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/AggregatedMethodMetaDataTest.java
@@ -29,7 +29,7 @@ import org.hibernate.validator.metadata.BeanMetaDataImpl;
 import org.hibernate.validator.metadata.ConstraintHelper;
 import org.hibernate.validator.metadata.ParameterMetaData;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertIterableSize;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertIterableSize;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/BeanMetaDataImplTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/BeanMetaDataImplTest.java
@@ -31,7 +31,7 @@ import org.hibernate.validator.metadata.ConstraintHelper;
 import org.hibernate.validator.test.engine.methodlevel.service.CustomerRepository;
 import org.hibernate.validator.test.engine.methodlevel.service.CustomerRepositoryImpl;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertIterableSize;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertIterableSize;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/ElementDescriptorTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/ElementDescriptorTest.java
@@ -26,9 +26,9 @@ import javax.validation.metadata.PropertyDescriptor;
 
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
-import static org.hibernate.validator.test.util.ValidatorUtil.getValidator;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getValidator;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/MethodDescriptorTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/MethodDescriptorTest.java
@@ -30,7 +30,7 @@ import org.hibernate.validator.method.metadata.ParameterDescriptor;
 import org.hibernate.validator.test.metadata.CustomerRepository.ValidationGroup;
 import org.hibernate.validator.test.metadata.CustomerRepositoryExt.CustomerExtension;
 
-import static org.hibernate.validator.test.util.ValidatorUtil.getMethodDescriptor;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getMethodDescriptor;
 import static org.hibernate.validator.util.Contracts.assertNotNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/MethodMetaDataTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/MethodMetaDataTest.java
@@ -28,7 +28,7 @@ import org.hibernate.validator.metadata.BeanMetaDataImpl;
 import org.hibernate.validator.metadata.ConstraintHelper;
 import org.hibernate.validator.metadata.MethodMetaData;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertIterableSize;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertIterableSize;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/ParameterDescriptorTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/ParameterDescriptorTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 
 import org.hibernate.validator.method.metadata.ParameterDescriptor;
 
-import static org.hibernate.validator.test.util.ValidatorUtil.getParameterDescriptor;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getParameterDescriptor;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/ParameterMetaDataTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/ParameterMetaDataTest.java
@@ -29,7 +29,7 @@ import org.hibernate.validator.metadata.ConstraintHelper;
 import org.hibernate.validator.metadata.MethodMetaData;
 import org.hibernate.validator.metadata.ParameterMetaData;
 
-import static org.hibernate.validator.test.util.ConstraintViolationAssert.assertIterableSize;
+import static org.hibernate.validator.test.testutil.ConstraintViolationAssert.assertIterableSize;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/TypeDescriptorTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/metadata/TypeDescriptorTest.java
@@ -29,7 +29,7 @@ import org.hibernate.validator.constraints.ScriptAssert;
 import org.hibernate.validator.method.metadata.MethodDescriptor;
 import org.hibernate.validator.method.metadata.TypeDescriptor;
 
-import static org.hibernate.validator.test.util.ValidatorUtil.getTypeDescriptor;
+import static org.hibernate.validator.test.testutil.ValidatorUtil.getTypeDescriptor;
 import static org.hibernate.validator.util.CollectionHelper.asSet;
 import static org.hibernate.validator.util.CollectionHelper.newHashSet;
 import static org.hibernate.validator.util.Contracts.assertNotNull;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/ConstraintViolationAssert.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/ConstraintViolationAssert.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hibernate.validator.test.util;
+package org.hibernate.validator.test.testutil;
 
 import java.util.ArrayList;
 import java.util.Iterator;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/CountValidationCalls.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/CountValidationCalls.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hibernate.validator.test.util;
+package org.hibernate.validator.test.testutil;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/CountValidationCallsValidator.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/CountValidationCallsValidator.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hibernate.validator.test.util;
+package org.hibernate.validator.test.testutil;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/DummyTraversableResolver.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/DummyTraversableResolver.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.hibernate.validator.test.util;
+package org.hibernate.validator.test.testutil;
 
 import java.lang.annotation.ElementType;
 import javax.validation.Path;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/HibernateTestCase.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/HibernateTestCase.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.hibernate.validator.test.util;
+package org.hibernate.validator.test.testutil;
 
 import java.io.InputStream;
 import java.util.Properties;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/ValidationInvocationHandler.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/ValidationInvocationHandler.java
@@ -14,7 +14,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package org.hibernate.validator.test.util;
+package org.hibernate.validator.test.testutil;
 
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/ValidatorUtil.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/testutil/ValidatorUtil.java
@@ -14,7 +14,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package org.hibernate.validator.test.util;
+package org.hibernate.validator.test.testutil;
 
 import java.lang.reflect.Proxy;
 import java.util.Locale;

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/xml/XmlMappingTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/xml/XmlMappingTest.java
@@ -28,7 +28,7 @@ import javax.validation.groups.Default;
 import static org.testng.Assert.assertEquals;
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 
 /**
  * @author Hardy Ferentschik

--- a/hibernate-validator/src/test/java/org/hibernate/validator/test/xml/mixedconfiguration/InheritanceMappingsTest.java
+++ b/hibernate-validator/src/test/java/org/hibernate/validator/test/xml/mixedconfiguration/InheritanceMappingsTest.java
@@ -26,8 +26,8 @@ import javax.validation.constraints.NotNull;
 
 import org.testng.annotations.Test;
 
-import org.hibernate.validator.test.util.DummyTraversableResolver;
-import org.hibernate.validator.test.util.ValidatorUtil;
+import org.hibernate.validator.test.testutil.DummyTraversableResolver;
+import org.hibernate.validator.test.testutil.ValidatorUtil;
 import org.hibernate.validator.test.xml.mixedconfiguration.annotation.Competition;
 import org.hibernate.validator.test.xml.mixedconfiguration.annotation.Fixture;
 import org.hibernate.validator.test.xml.mixedconfiguration.annotation.PersonCompetition;


### PR DESCRIPTION
Currently the package _org.hibernate.validator.test.util_ contains:
- tests for helpers (located in _org.hibernate.validator.util_)
- helpers  for tests

This commit divides this package in two packages named _util_ and _testutil_.
