### PR TITLE
HV-528

### DIFF
--- a/hibernate-validator/pom.xml
+++ b/hibernate-validator/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <parent>
         <artifactId>hibernate-validator-parent</artifactId>
         <groupId>org.hibernate</groupId>
@@ -106,8 +108,8 @@
         <jdbc.driver>org.h2.Driver</jdbc.driver>
         <jdbc.url>jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1</jdbc.url>
         <jdbc.user>sa</jdbc.user>
-        <jdbc.pass />
-        <jdbc.isolation />
+        <jdbc.pass/>
+        <jdbc.isolation/>
     </properties>
 
     <build>
@@ -152,6 +154,18 @@
                     <outputDirectory>${basedir}/target/generated-sources</outputDirectory>
                     <extension>true</extension>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>javax.xml.bind</groupId>
+                        <artifactId>jaxb-api</artifactId>
+                        <version>2.2.5</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.sun.xml.bind</groupId>
+                        <artifactId>jaxb-impl</artifactId>
+                        <version>2.1.13</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -236,7 +250,7 @@
                                 </relocation>
                             </relocations>
                             <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ComponentsXmlResourceTransformer"/>
                             </transformers>
                         </configuration>
                     </execution>
@@ -264,7 +278,7 @@
                     </execution>
                 </executions>
             </plugin>
-             <plugin>
+            <plugin>
                 <groupId>org.jboss.maven.plugins</groupId>
                 <artifactId>maven-jdocbook-style-plugin</artifactId>
             </plugin>

--- a/hibernate-validator/src/main/java/org/hibernate/validator/xml/XmlMappingParser.java
+++ b/hibernate-validator/src/main/java/org/hibernate/validator/xml/XmlMappingParser.java
@@ -96,7 +96,7 @@ public class XmlMappingParser {
 			for ( BeanType bean : mapping.getBean() ) {
 				Class<?> beanClass = getClass( bean.getClazz(), defaultPackage );
 				checkClassHasNotBeenProcessed( processedClasses, beanClass );
-				annotationIgnores.setDefaultIgnoreAnnotation( beanClass, bean.isIgnoreAnnotations() );
+				annotationIgnores.setDefaultIgnoreAnnotation( beanClass, bean.getIgnoreAnnotations() );
 				parseClassLevelOverrides( bean.getClassType(), beanClass, defaultPackage );
 				parseFieldLevelOverrides( bean.getField(), beanClass, defaultPackage );
 				parsePropertyLevelOverrides( bean.getGetter(), beanClass, defaultPackage );
@@ -146,7 +146,7 @@ public class XmlMappingParser {
 
 			ValidatedByType validatedByType = constraintDefinition.getValidatedBy();
 			List<Class<? extends ConstraintValidator<? extends Annotation, ?>>> constraintValidatorClasses = newArrayList();
-			if ( validatedByType.isIncludeExistingValidators() != null && validatedByType.isIncludeExistingValidators() ) {
+			if ( validatedByType.getIncludeExistingValidators() != null && validatedByType.getIncludeExistingValidators() ) {
 				constraintValidatorClasses.addAll( findConstraintValidatorClasses( annotationClass ) );
 			}
 			for ( String validatorClassName : validatedByType.getValue() ) {
@@ -206,7 +206,7 @@ public class XmlMappingParser {
 			final Field field = ReflectionHelper.getDeclaredField( beanClass, fieldName );
 
 			// ignore annotations
-			boolean ignoreFieldAnnotation = fieldType.isIgnoreAnnotations() == null ? false : fieldType.isIgnoreAnnotations();
+			boolean ignoreFieldAnnotation = fieldType.getIgnoreAnnotations() == null ? false : fieldType.getIgnoreAnnotations();
 			if ( ignoreFieldAnnotation ) {
 				annotationIgnores.setIgnoreAnnotationsOnMember( field );
 			}
@@ -243,7 +243,7 @@ public class XmlMappingParser {
 			final Method method = ReflectionHelper.getMethodFromPropertyName( beanClass, getterName );
 
 			// ignore annotations
-			boolean ignoreGetterAnnotation = getterType.isIgnoreAnnotations() == null ? false : getterType.isIgnoreAnnotations();
+			boolean ignoreGetterAnnotation = getterType.getIgnoreAnnotations() == null ? false : getterType.getIgnoreAnnotations();
 			if ( ignoreGetterAnnotation ) {
 				annotationIgnores.setIgnoreAnnotationsOnMember( method );
 			}
@@ -269,8 +269,8 @@ public class XmlMappingParser {
 		}
 
 		// ignore annotation
-		if ( classType.isIgnoreAnnotations() != null ) {
-			annotationIgnores.setIgnoreAnnotationsOnClass( beanClass, classType.isIgnoreAnnotations() );
+		if ( classType.getIgnoreAnnotations() != null ) {
+			annotationIgnores.setIgnoreAnnotationsOnClass( beanClass, classType.getIgnoreAnnotations() );
 		}
 
 		// group sequence

--- a/hibernate-validator/src/main/xjb/binding-customization.xjb
+++ b/hibernate-validator/src/main/xjb/binding-customization.xjb
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jxb:bindings version="1.0" xmlns:jxb="http://java.sun.com/xml/ns/jaxb"
-    xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc">
+              xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc">
     <jxb:bindings schemaLocation="../xsd/validation-mapping-1.0.xsd" node="/xs:schema">
+        <!-- let jaxb be whitespace tolerant - http://www.highlevelbits.com/2009/08/jaxb-with-maven_16.html -->
         <jxb:globalBindings>
-            <xjc:javaType name="java.lang.String" xmlType="xs:string" 
-                adapter="javax.xml.bind.annotation.adapters.CollapsedStringAdapter"/>
+            <xjc:javaType name="java.lang.String" xmlType="xs:string"
+                          adapter="javax.xml.bind.annotation.adapters.CollapsedStringAdapter"/>
         </jxb:globalBindings>
 
         <jxb:bindings node="//xs:complexType[9]/xs:sequence[1]/xs:element[1]">

--- a/pom.xml
+++ b/pom.xml
@@ -101,12 +101,12 @@
             <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
-                <version>2.2</version>
+                <version>2.2.5</version>
             </dependency>
             <dependency>
                 <groupId>com.sun.xml.bind</groupId>
                 <artifactId>jaxb-impl</artifactId>
-                <version>2.1.12</version>
+                <version>2.1.13</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -329,7 +329,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>jaxb2-maven-plugin</artifactId>
-                    <version>1.3</version>
+                    <version>1.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -504,5 +504,5 @@
                 <module>hibernate-validator-distribution</module>
             </modules>
         </profile>
-    </profiles>  
+    </profiles>
 </project>


### PR DESCRIPTION
Updating to the latest JAXB versions and forcing the jaxb2-maven-plugin to use these updated versions. This aligns the behaviour between JDK6 and JDK7

See also http://www.mojavelinux.com/blog/archives/2006/09/the_great_jaxb_api_blunder/ and http://java.net/jira/browse/JAXB-131

This resolves the basic compilation problem. Now there is a problem with the tests in hibernate-validator-annotation-processor. Most test assertions fail in JDK7. Will create a new issue for that
