### PR TITLE
HV-540 removing the repository settings from the pom. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>1.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jboss.maven.plugins</groupId>
@@ -465,37 +465,6 @@
             <url>https://repository.jboss.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
-
-    <!-- HV-396 to allow building with Maven 3 (final version) we have to add the repository configuration to the pom -->
-    <repositories>
-        <repository>
-            <id>jboss-public-repository-group</id>
-            <name>JBoss Public Repository Group</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-            <layout>default</layout>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>jboss-public-repository-group</id>
-            <name>JBoss Public Repository Group</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
 
     <profiles>
         <profile>

--- a/settings-example.xml
+++ b/settings-example.xml
@@ -1,0 +1,321 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!--
+ | This is the configuration file for Maven. It can be specified at two levels:
+ |
+ |  1. User Level. This settings.xml file provides configuration for a single user,
+ |                 and is normally provided in ${user.home}/.m2/settings.xml.
+ |
+ |                 NOTE: This location can be overridden with the CLI option:
+ |
+ |                 -s /path/to/user/settings.xml
+ |
+ |  2. Global Level. This settings.xml file provides configuration for all Maven
+ |                 users on a machine (assuming they're all using the same Maven
+ |                 installation). It's normally provided in
+ |                 ${maven.home}/conf/settings.xml.
+ |
+ |                 NOTE: This location can be overridden with the CLI option:
+ |
+ |                 -gs /path/to/global/settings.xml
+ |
+ | The sections in this sample file are intended to give you a running start at
+ | getting the most out of your Maven installation. Where appropriate, the default
+ | values (values used when the setting is not specified) are provided.
+ |
+ |-->
+<settings xmlns="http://maven.apache.org/settings/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <!-- localRepository
+       | The path to the local repository maven will use to store artifacts.
+       |
+       | Default: ~/.m2/repository
+      <localRepository>/path/to/local/repo</localRepository>
+      -->
+
+    <!-- interactiveMode
+       | This will determine whether maven prompts you when it needs input. If set to false,
+       | maven will use a sensible default value, perhaps based on some other setting, for
+       | the parameter in question.
+       |
+       | Default: true
+      <interactiveMode>true</interactiveMode>
+      -->
+
+    <!-- offline
+       | Determines whether maven should attempt to connect to the network when executing a build.
+       | This will have an effect on artifact downloads, artifact deployment, and others.
+       |
+       | Default: false
+      <offline>false</offline>
+      -->
+
+    <!-- pluginGroups
+       | This is a list of additional group identifiers that will be searched when resolving plugins by their prefix, i.e.
+       | when invoking a command line like "mvn prefix:goal". Maven will automatically add the group identifiers
+       | "org.apache.maven.plugins" and "org.codehaus.mojo" if these are not already contained in the list.
+       |-->
+    <pluginGroups>
+        <!-- pluginGroup
+             | Specifies a further group identifier to use for plugin lookup.
+            <pluginGroup>com.your.plugins</pluginGroup>
+            -->
+
+        <!-- jboss.org config start -->
+        <pluginGroup>org.jboss.maven.plugins</pluginGroup>
+        <!-- jboss.org config end -->
+
+
+    </pluginGroups>
+
+    <!-- proxies
+       | This is a list of proxies which can be used on this machine to connect to the network.
+       | Unless otherwise specified (by system property or command-line switch), the first proxy
+       | specification in this list marked as active will be used.
+       |-->
+    <proxies>
+        <!-- proxy
+             | Specification for one proxy, to be used in connecting to the network.
+             |
+            <proxy>
+              <id>optional</id>
+              <active>true</active>
+              <protocol>http</protocol>
+              <username>proxyuser</username>
+              <password>proxypass</password>
+              <host>proxy.host.net</host>
+              <port>80</port>
+              <nonProxyHosts>local.net|some.host.com</nonProxyHosts>
+            </proxy>
+            -->
+    </proxies>
+
+    <!-- servers
+       | This is a list of authentication profiles, keyed by the server-id used within the system.
+       | Authentication profiles can be used whenever maven must make a connection to a remote server.
+       |-->
+    <servers>
+        <!-- server
+             | Specifies the authentication information to use when connecting to a particular server, identified by
+             | a unique name within the system (referred to by the 'id' attribute below).
+             |
+             | NOTE: You should either specify username/password OR privateKey/passphrase, since these pairings are
+             |       used together.
+             |
+            <server>
+              <id>deploymentRepo</id>
+              <username>repouser</username>
+              <password>repopwd</password>
+            </server>
+            -->
+
+        <!-- Another sample, using keys to authenticate.
+            <server>
+              <id>siteServer</id>
+              <privateKey>/path/to/private/key</privateKey>
+              <passphrase>optional; leave empty if not used.</passphrase>
+            </server>
+            -->
+    </servers>
+
+    <!-- mirrors
+       | This is a list of mirrors to be used in downloading artifacts from remote repositories.
+       |
+       | It works like this: a POM may declare a repository to use in resolving certain artifacts.
+       | However, this repository may have problems with heavy traffic at times, so people have mirrored
+       | it to several places.
+       |
+       | That repository definition will have a unique id, so we can create a mirror reference for that
+       | repository, to be used as an alternate download site. The mirror site will be the preferred
+       | server for that repository.
+       |-->
+    <mirrors>
+        <!-- mirror
+             | Specifies a repository mirror site to use instead of a given repository. The repository that
+             | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
+             | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
+             |
+            <mirror>
+              <id>mirrorId</id>
+              <mirrorOf>repositoryId</mirrorOf>
+              <name>Human Readable Name for this Mirror.</name>
+              <url>http://my.repository.com/repo/path</url>
+            </mirror>
+             -->
+    </mirrors>
+
+    <!-- profiles
+       | This is a list of profiles which can be activated in a variety of ways, and which can modify
+       | the build process. Profiles provided in the settings.xml are intended to provide local machine-
+       | specific paths and repository locations which allow the build to work in the local environment.
+       |
+       | For example, if you have an integration testing plugin - like cactus - that needs to know where
+       | your Tomcat instance is installed, you can provide a variable here such that the variable is
+       | dereferenced during the build process to configure the cactus plugin.
+       |
+       | As noted above, profiles can be activated in a variety of ways. One way - the activeProfiles
+       | section of this document (settings.xml) - will be discussed later. Another way essentially
+       | relies on the detection of a system property, either matching a particular value for the property,
+       | or merely testing its existence. Profiles can also be activated by JDK version prefix, where a
+       | value of '1.4' might activate a profile when the build is executed on a JDK version of '1.4.2_07'.
+       | Finally, the list of active profiles can be specified directly from the command line.
+       |
+       | NOTE: For profiles defined in the settings.xml, you are restricted to specifying only artifact
+       |       repositories, plugin repositories, and free-form properties to be used as configuration
+       |       variables for plugins in the POM.
+       |
+       |-->
+    <profiles>
+        <!-- profile
+             | Specifies a set of introductions to the build process, to be activated using one or more of the
+             | mechanisms described above. For inheritance purposes, and to activate profiles via <activatedProfiles/>
+             | or the command line, profiles have to have an ID that is unique.
+             |
+             | An encouraged best practice for profile identification is to use a consistent naming convention
+             | for profiles, such as 'env-dev', 'env-test', 'env-production', 'user-jdcasey', 'user-brett', etc.
+             | This will make it more intuitive to understand what the set of introduced profiles is attempting
+             | to accomplish, particularly when you only have a list of profile id's for debug.
+             |
+             | This profile example uses the JDK version to trigger activation, and provides a JDK-specific repo.
+            <profile>
+              <id>jdk-1.4</id>
+
+              <activation>
+                <jdk>1.4</jdk>
+              </activation>
+
+              <repositories>
+                <repository>
+                  <id>jdk14</id>
+                  <name>Repository for JDK 1.4 builds</name>
+                  <url>http://www.myhost.com/maven/jdk14</url>
+                  <layout>default</layout>
+                  <snapshotPolicy>always</snapshotPolicy>
+                </repository>
+              </repositories>
+            </profile>
+            -->
+
+        <!--
+             | Here is another profile, activated by the system property 'target-env' with a value of 'dev',
+             | which provides a specific path to the Tomcat instance. To use this, your plugin configuration
+             | might hypothetically look like:
+             |
+             | ...
+             | <plugin>
+             |   <groupId>org.myco.myplugins</groupId>
+             |   <artifactId>myplugin</artifactId>
+             |
+             |   <configuration>
+             |     <tomcatLocation>${tomcatPath}</tomcatLocation>
+             |   </configuration>
+             | </plugin>
+             | ...
+             |
+             | NOTE: If you just wanted to inject this configuration whenever someone set 'target-env' to
+             |       anything, you could just leave off the <value/> inside the activation-property.
+             |
+            <profile>
+              <id>env-dev</id>
+
+              <activation>
+                <property>
+                  <name>target-env</name>
+                  <value>dev</value>
+                </property>
+              </activation>
+
+              <properties>
+                <tomcatPath>/path/to/tomcat/instance</tomcatPath>
+              </properties>
+            </profile>
+            -->
+
+        <!-- jboss.org config start -->
+        <profile>
+            <id>jboss-public-repository</id>
+            <repositories>
+                <repository>
+                    <id>jboss-public-repository-group</id>
+                    <name>JBoss Public Maven Repository Group</name>
+                    <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>jboss-public-repository-group</id>
+                    <name>JBoss Public Maven Repository Group</name>
+                    <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+
+
+        <profile>
+            <id>jboss-deprecated-repository</id>
+            <repositories>
+                <repository>
+                    <id>jboss-deprecated-repository</id>
+                    <name>JBoss Deprecated Maven Repository</name>
+                    <url>https://repository.jboss.org/nexus/content/repositories/deprecated/</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+        </profile>
+        <!-- jboss.org config end -->
+
+    </profiles>
+
+    <!-- jboss.org config start -->
+    <activeProfiles>
+        <activeProfile>jboss-public-repository</activeProfile>
+    </activeProfiles>
+    <!-- jboss.org config end -->
+
+</settings>


### PR DESCRIPTION
adding a sample settings.xml to make it easier to get started. The settings file comes from the jboss wiki - http://community.jboss.org/wiki/MavenSettingsExample-Users

Not sure whether we should really have all these examples in the settings.xml or whether only what's needed for the JBoss repo. Thoughts?
