### PR TITLE
[HV-838] Make resolved type cache not static.

### DIFF
--- a/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidationExtension.java
+++ b/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidationExtension.java
@@ -57,6 +57,7 @@ import org.hibernate.validator.cdi.HibernateValidator;
 import org.hibernate.validator.internal.cdi.interceptor.ValidationEnabledAnnotatedType;
 import org.hibernate.validator.internal.cdi.interceptor.ValidationInterceptor;
 import org.hibernate.validator.internal.util.Contracts;
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -77,6 +78,7 @@ public class ValidationExtension implements Extension {
 	private static final EnumSet<ExecutableType> DEFAULT_EXECUTABLE_TYPES =
 			EnumSet.of( ExecutableType.CONSTRUCTORS, ExecutableType.NON_GETTER_METHODS );
 
+	private final OverrideHelper overrideHelper;
 	private final Validator validator;
 	private final Set<ExecutableType> globalExecutableTypes;
 	private final boolean isExecutableValidationEnabled;
@@ -92,6 +94,7 @@ public class ValidationExtension implements Extension {
 		globalExecutableTypes = bootstrap.getDefaultValidatedExecutableTypes();
 		isExecutableValidationEnabled = bootstrap.isExecutableValidationEnabled();
 		validator = config.buildValidatorFactory().getValidator();
+		overrideHelper = new OverrideHelper();
 	}
 
 	/**
@@ -386,7 +389,7 @@ public class ValidationExtension implements Extension {
 		Iterator<Method> iterator = list.descendingIterator();
 		while ( iterator.hasNext() ) {
 			Method overriddenOrInterfaceMethod = iterator.next();
-			if ( ReflectionHelper.overrides( method, overriddenOrInterfaceMethod ) ) {
+			if ( overrideHelper.overrides( method, overriddenOrInterfaceMethod ) ) {
 				if ( method.getAnnotation( ValidateOnExecution.class ) != null ) {
 					throw log.getValidateOnExecutionOnOverriddenOrInterfaceMethodException( method );
 				}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -38,6 +38,7 @@ import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.provider.MetaDataProvider;
 import org.hibernate.validator.internal.metadata.provider.ProgrammaticMetaDataProvider;
 import org.hibernate.validator.internal.metadata.provider.XmlMetaDataProvider;
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
@@ -89,6 +90,11 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 	private final ConstraintHelper constraintHelper;
 
 	/**
+	 * Used for resolving type parameters. Thread-safe.
+	 */
+	private final OverrideHelper overrideHelper;
+
+	/**
 	 * Hibernate Validator specific flag to abort validation on first constraint violation.
 	 */
 	private final boolean failFast;
@@ -113,6 +119,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		this.parameterNameProvider = configurationState.getParameterNameProvider();
 		this.beanMetaDataManagerMap = Collections.synchronizedMap( new IdentityHashMap<ParameterNameProvider, BeanMetaDataManager>() );
 		this.constraintHelper = new ConstraintHelper();
+		this.overrideHelper = new OverrideHelper();
 		this.constraintMappings = newHashSet();
 
 		// HV-302; don't load XmlMappingParser if not necessary
@@ -206,6 +213,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		if ( !beanMetaDataManagerMap.containsKey( parameterNameProvider ) ) {
 			beanMetaDataManager = new BeanMetaDataManager(
 					constraintHelper,
+					overrideHelper,
 					parameterNameProvider,
 					buildDataProviders( parameterNameProvider )
 			);

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
@@ -33,6 +33,7 @@ import org.hibernate.validator.internal.metadata.provider.MetaDataProvider;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.util.ConcurrentReferenceHashMap;
 import org.hibernate.validator.internal.util.Contracts;
+import org.hibernate.validator.internal.util.OverrideHelper;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.hibernate.validator.internal.util.ConcurrentReferenceHashMap.Option.IDENTITY_COMPARISONS;
@@ -89,13 +90,18 @@ public class BeanMetaDataManager {
 	private final ConcurrentReferenceHashMap<Class<?>, BeanMetaData<?>> beanMetaDataCache;
 
 	/**
+	 * Used for resolving type parameters. Thread-safe.
+	 */
+	private final OverrideHelper overrideHelper;
+
+	/**
 	 * Creates a new {@code BeanMetaDataManager}. {@link DefaultParameterNameProvider} is used as parameter name
 	 * provider, no meta data providers besides the annotation-based providers are used.
 	 *
 	 * @param constraintHelper The constraint helper
 	 */
-	public BeanMetaDataManager(ConstraintHelper constraintHelper) {
-		this( constraintHelper, new DefaultParameterNameProvider(), Collections.<MetaDataProvider>emptyList() );
+	public BeanMetaDataManager(ConstraintHelper constraintHelper, OverrideHelper overrideHelper) {
+		this( constraintHelper, overrideHelper, new DefaultParameterNameProvider(), Collections.<MetaDataProvider>emptyList() );
 	}
 
 	/**
@@ -106,11 +112,13 @@ public class BeanMetaDataManager {
 	 * @param optionalMetaDataProviders optional meta data provider used on top of the annotation based provider
 	 */
 	public BeanMetaDataManager(ConstraintHelper constraintHelper,
+							   OverrideHelper overrideHelper,
 							   ParameterNameProvider parameterNameProvider,
 							   List<MetaDataProvider> optionalMetaDataProviders) {
 		this.constraintHelper = constraintHelper;
 		this.metaDataProviders = newArrayList();
 		this.metaDataProviders.addAll( optionalMetaDataProviders );
+		this.overrideHelper = overrideHelper;
 
 		this.beanMetaDataCache = new ConcurrentReferenceHashMap<Class<?>, BeanMetaData<?>>(
 				DEFAULT_INITIAL_CAPACITY,
@@ -171,7 +179,7 @@ public class BeanMetaDataManager {
 	 * @return A bean meta data object for the given type.
 	 */
 	private <T> BeanMetaDataImpl<T> createBeanMetaData(Class<T> clazz) {
-		BeanMetaDataBuilder<T> builder = BeanMetaDataBuilder.getInstance( constraintHelper, clazz );
+		BeanMetaDataBuilder<T> builder = BeanMetaDataBuilder.getInstance( constraintHelper, overrideHelper, clazz );
 
 		for ( MetaDataProvider provider : metaDataProviders ) {
 			for ( BeanConfiguration<? super T> beanConfiguration : provider.getBeanConfigurationForHierarchy( clazz ) ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -9,7 +9,7 @@
 * You may obtain a copy of the License at
 * http://www.apache.org/licenses/LICENSE-2.0
 * Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,  
+* distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
@@ -45,6 +45,7 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
 import org.hibernate.validator.internal.util.CollectionHelper.Partitioner;
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
 import org.hibernate.validator.internal.util.classhierarchy.Filters;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -438,6 +439,8 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 
 		private final Set<BuilderDelegate> builders = newHashSet();
 
+		private final OverrideHelper overrideHelper;
+
 		private ConfigurationSource sequenceSource;
 
 		private ConfigurationSource providerSource;
@@ -447,13 +450,14 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 		private DefaultGroupSequenceProvider<? super T> defaultGroupSequenceProvider;
 
 
-		public BeanMetaDataBuilder(ConstraintHelper constraintHelper, Class<T> beanClass) {
+		public BeanMetaDataBuilder(ConstraintHelper constraintHelper, OverrideHelper overrideHelper, Class<T> beanClass) {
 			this.beanClass = beanClass;
 			this.constraintHelper = constraintHelper;
+			this.overrideHelper = overrideHelper;
 		}
 
-		public static <T> BeanMetaDataBuilder<T> getInstance(ConstraintHelper constraintHelper, Class<T> beanClass) {
-			return new BeanMetaDataBuilder<T>( constraintHelper, beanClass );
+		public static <T> BeanMetaDataBuilder<T> getInstance(ConstraintHelper constraintHelper, OverrideHelper overrideHelper, Class<T> beanClass) {
+			return new BeanMetaDataBuilder<T>( constraintHelper, overrideHelper, beanClass );
 		}
 
 		public void add(BeanConfiguration<? super T> configuration) {
@@ -493,7 +497,8 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 					new BuilderDelegate(
 							beanClass,
 							constrainableElement,
-							constraintHelper
+							constraintHelper,
+							overrideHelper
 					)
 			);
 		}
@@ -517,12 +522,14 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	private static class BuilderDelegate {
 		private final Class<?> beanClass;
 		private final ConstraintHelper constraintHelper;
+		private final OverrideHelper overrideHelper;
 		private MetaDataBuilder propertyBuilder;
 		private ExecutableMetaData.Builder methodBuilder;
 
-		public BuilderDelegate(Class<?> beanClass, ConstrainedElement constrainedElement, ConstraintHelper constraintHelper) {
+		public BuilderDelegate(Class<?> beanClass, ConstrainedElement constrainedElement, ConstraintHelper constraintHelper, OverrideHelper overrideHelper) {
 			this.beanClass = beanClass;
 			this.constraintHelper = constraintHelper;
+			this.overrideHelper = overrideHelper;
 
 			switch ( constrainedElement.getKind() ) {
 				case FIELD:
@@ -530,7 +537,8 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 					propertyBuilder = new PropertyMetaData.Builder(
 							beanClass,
 							constrainedField,
-							constraintHelper
+							constraintHelper,
+							overrideHelper
 					);
 					break;
 				case CONSTRUCTOR:
@@ -539,14 +547,16 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 					methodBuilder = new ExecutableMetaData.Builder(
 							beanClass,
 							constrainedExecutable,
-							constraintHelper
+							constraintHelper,
+							overrideHelper
 					);
 
 					if ( constrainedExecutable.isGetterMethod() ) {
 						propertyBuilder = new PropertyMetaData.Builder(
 								beanClass,
 								constrainedExecutable,
-								constraintHelper
+								constraintHelper,
+								overrideHelper
 						);
 					}
 					break;
@@ -555,7 +565,8 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 					propertyBuilder = new PropertyMetaData.Builder(
 							beanClass,
 							constrainedType,
-							constraintHelper
+							constraintHelper,
+							overrideHelper
 					);
 					break;
 			}
@@ -577,7 +588,8 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 					methodBuilder = new ExecutableMetaData.Builder(
 							beanClass,
 							constrainedMethod,
-							constraintHelper
+							constraintHelper,
+							overrideHelper
 					);
 				}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
@@ -41,6 +41,7 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
 import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
@@ -298,8 +299,8 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 		 * executable with a given signature within a type hierarchy.
 		 * @param constraintHelper the constraint helper
 		 */
-		public Builder(Class<?> beanClass, ConstrainedExecutable constrainedExecutable, ConstraintHelper constraintHelper) {
-			super( beanClass, constraintHelper );
+		public Builder(Class<?> beanClass, ConstrainedExecutable constrainedExecutable, ConstraintHelper constraintHelper, OverrideHelper overrideHelper) {
+			super( beanClass, constraintHelper, overrideHelper );
 
 			kind = constrainedExecutable.getKind();
 			location = constrainedExecutable.getLocation();
@@ -319,9 +320,10 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 			//does one of the executables override the other one?
 			return
 					location.getExecutableElement().equals( executableElement ) ||
-							location.getExecutableElement().overrides( executableElement ) ||
+							location.getExecutableElement().overrides( executableElement, overrideHelper ) ||
 							executableElement.overrides(
-									location.getExecutableElement()
+									location.getExecutableElement(),
+									overrideHelper
 							);
 		}
 
@@ -398,7 +400,8 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 								new ParameterMetaData.Builder(
 										location.getBeanClass(),
 										oneParameter,
-										constraintHelper
+										constraintHelper,
+										overrideHelper
 								)
 						);
 					}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/MetaDataBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/MetaDataBuilder.java
@@ -27,6 +27,7 @@ import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
@@ -45,15 +46,17 @@ public abstract class MetaDataBuilder {
 	private static final Log log = LoggerFactory.make();
 
 	protected final ConstraintHelper constraintHelper;
+	protected final OverrideHelper overrideHelper;
 
 	private final Class<?> beanClass;
 	private final Set<MetaConstraint<?>> constraints = newHashSet();
 	private final Map<Class<?>, Class<?>> groupConversions = newHashMap();
 	private boolean isCascading = false;
 
-	protected MetaDataBuilder(Class<?> beanClass, ConstraintHelper constraintHelper) {
+	protected MetaDataBuilder(Class<?> beanClass, ConstraintHelper constraintHelper, OverrideHelper overrideHelper) {
 		this.beanClass = beanClass;
 		this.constraintHelper = constraintHelper;
+		this.overrideHelper = overrideHelper;
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ParameterMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ParameterMetaData.java
@@ -31,6 +31,7 @@ import org.hibernate.validator.internal.metadata.facets.Cascadable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement.ConstrainedElementKind;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
+import org.hibernate.validator.internal.util.OverrideHelper;
 
 /**
  * An aggregated view of the constraint related meta data for a single method
@@ -116,8 +117,8 @@ public class ParameterMetaData extends AbstractConstraintMetaData implements Cas
 		private final int parameterIndex;
 		private String name;
 
-		public Builder(Class<?> beanClass, ConstrainedParameter constrainedParameter, ConstraintHelper constraintHelper) {
-			super( beanClass, constraintHelper );
+		public Builder(Class<?> beanClass, ConstrainedParameter constrainedParameter, ConstraintHelper constraintHelper, OverrideHelper overrideHelper) {
+			super( beanClass, constraintHelper, overrideHelper );
 
 			this.parameterType = constrainedParameter.getLocation().getParameterType();
 			this.parameterIndex = constrainedParameter.getLocation().getParameterIndex();

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/PropertyMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/PropertyMetaData.java
@@ -36,6 +36,7 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedElement.Constrai
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 
 /**
@@ -163,24 +164,24 @@ public class PropertyMetaData extends AbstractConstraintMetaData implements Casc
 		private final Type propertyType;
 		private Member cascadingMember;
 
-		public Builder(Class<?> beanClass, ConstrainedField constrainedField, ConstraintHelper constraintHelper) {
-			super( beanClass, constraintHelper );
+		public Builder(Class<?> beanClass, ConstrainedField constrainedField, ConstraintHelper constraintHelper, OverrideHelper overrideHelper) {
+			super( beanClass, constraintHelper, overrideHelper );
 
 			this.propertyName = ReflectionHelper.getPropertyName( constrainedField.getLocation().getMember() );
 			this.propertyType = ( (Field) constrainedField.getLocation().getMember() ).getGenericType();
 			add( constrainedField );
 		}
 
-		public Builder(Class<?> beanClass, ConstrainedType constrainedType, ConstraintHelper constraintHelper) {
-			super( beanClass, constraintHelper );
+		public Builder(Class<?> beanClass, ConstrainedType constrainedType, ConstraintHelper constraintHelper, OverrideHelper overrideHelper) {
+			super( beanClass, constraintHelper, overrideHelper );
 
 			this.propertyName = null;
 			this.propertyType = null;
 			add( constrainedType );
 		}
 
-		public Builder(Class<?> beanClass, ConstrainedExecutable constrainedMethod, ConstraintHelper constraintHelper) {
-			super( beanClass, constraintHelper );
+		public Builder(Class<?> beanClass, ConstrainedExecutable constrainedMethod, ConstraintHelper constraintHelper, OverrideHelper overrideHelper) {
+			super( beanClass, constraintHelper, overrideHelper );
 
 			this.propertyName = ReflectionHelper.getPropertyName( constrainedMethod.getLocation().getMember() );
 			this.propertyType = constrainedMethod.getLocation().typeOfAnnotatedElement();

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ExecutableElement.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ExecutableElement.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import javax.validation.ParameterNameProvider;
 
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
@@ -101,13 +102,13 @@ public abstract class ExecutableElement {
 	 * @return {@code true} If this methods overrides the passed method,
 	 *         {@code false} otherwise.
 	 */
-	public boolean overrides(ExecutableElement other) {
+	public boolean overrides(ExecutableElement other, OverrideHelper overrideHelper) {
 		//constructors never override another constructor
 		if ( getMember() instanceof Constructor || other.getMember() instanceof Constructor ) {
 			return false;
 		}
 
-		return ReflectionHelper.overrides( (Method) getMember(), (Method) other.getMember() );
+		return overrideHelper.overrides( (Method) getMember(), (Method) other.getMember() );
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/util/OverrideHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/OverrideHelper.java
@@ -1,0 +1,143 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2010, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.internal.util;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+import com.fasterxml.classmate.Filter;
+import com.fasterxml.classmate.MemberResolver;
+import com.fasterxml.classmate.ResolvedType;
+import com.fasterxml.classmate.ResolvedTypeWithMembers;
+import com.fasterxml.classmate.TypeResolver;
+import com.fasterxml.classmate.members.RawMethod;
+import com.fasterxml.classmate.members.ResolvedMethod;
+
+/**
+ * Some reflection utility methods. Where necessary calls will be performed as {@code PrivilegedAction} which is necessary
+ * for situations where a security manager is in place.
+ *
+ * @author Hardy Ferentschik
+ * @author Gunnar Morling
+ * @author Kevin Pollet <kevin.pollet@serli.com> (C) 2011 SERLI
+ */
+public final class OverrideHelper {
+
+	private final TypeResolver typeResolver = new TypeResolver();
+
+	/**
+	 * Checks, whether {@code subTypeMethod} overrides {@code superTypeMethod}.
+	 *
+	 * @param subTypeMethod The sub type method (cannot be {@code null}).
+	 * @param superTypeMethod The super type method (cannot be {@code null}).
+	 *
+	 * @return Returns {@code true} if {@code subTypeMethod} overrides {@code superTypeMethod},
+	 *         {@code false} otherwise.
+	 */
+	public boolean overrides(Method subTypeMethod, Method superTypeMethod) {
+		Contracts.assertValueNotNull( subTypeMethod, "subTypeMethod" );
+		Contracts.assertValueNotNull( superTypeMethod, "superTypeMethod" );
+
+		if ( subTypeMethod.equals( superTypeMethod ) ) {
+			return false;
+		}
+
+		if ( !subTypeMethod.getName().equals( superTypeMethod.getName() ) ) {
+			return false;
+		}
+
+		if ( subTypeMethod.getParameterTypes().length != superTypeMethod.getParameterTypes().length ) {
+			return false;
+		}
+
+		if ( !superTypeMethod.getDeclaringClass().isAssignableFrom( subTypeMethod.getDeclaringClass() ) ) {
+			return false;
+		}
+
+		if ( Modifier.isStatic( superTypeMethod.getModifiers() ) || Modifier.isStatic( subTypeMethod.getModifiers() ) ) {
+			return false;
+		}
+
+		return instanceMethodParametersResolveToSameTypes( subTypeMethod, superTypeMethod );
+	}
+
+	/**
+	 * Whether the parameters of the two given instance methods resolve to the same types or not. Takes type parameters into account.
+	 *
+	 * @param subTypeMethod a method on a supertype
+	 * @param superTypeMethod a method on a subtype
+	 *
+	 * @return {@code true} if the parameters of the two methods resolve to the same types, {@code false otherwise}.
+	 */
+	private boolean instanceMethodParametersResolveToSameTypes(Method subTypeMethod, Method superTypeMethod) {
+		if ( subTypeMethod.getParameterTypes().length == 0 ) {
+			return true;
+		}
+
+		ResolvedType resolvedSubType = typeResolver.resolve( subTypeMethod.getDeclaringClass() );
+
+		MemberResolver memberResolver = new MemberResolver( typeResolver );
+		memberResolver.setMethodFilter( new SimpleMethodFilter( subTypeMethod, superTypeMethod ) );
+		ResolvedTypeWithMembers typeWithMembers = memberResolver.resolve(
+				resolvedSubType,
+				null,
+				null
+		);
+
+		ResolvedMethod[] resolvedMethods = typeWithMembers.getMemberMethods();
+
+		// The ClassMate doc says that overridden methods are flattened to one
+		// resolved method. But that is the case only for methods without any
+		// generic parameters.
+		if ( resolvedMethods.length == 1 ) {
+			return true;
+		}
+
+		// For methods with generic parameters I have to compare the argument
+		// types (which are resolved) of the two filtered member methods.
+		for ( int i = 0; i < resolvedMethods[0].getArgumentCount(); i++ ) {
+
+			if ( !resolvedMethods[0].getArgumentType( i )
+					.equals( resolvedMethods[1].getArgumentType( i ) ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * A filter implementation filtering methods matching given methods.
+	 *
+	 * @author Gunnar Morling
+	 */
+	private static class SimpleMethodFilter implements Filter<RawMethod> {
+		private final Method method1;
+		private final Method method2;
+
+		private SimpleMethodFilter(Method method1, Method method2) {
+			this.method1 = method1;
+			this.method2 = method2;
+		}
+
+		@Override
+		public boolean include(RawMethod element) {
+			return element.getRawMember().equals( method1 ) || element.getRawMember()
+					.equals( method2 );
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
@@ -33,6 +33,7 @@ import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.testutil.ValidatorUtil;
 
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
@@ -188,7 +189,7 @@ public class PathImplTest {
 						Item.class
 				)
 		);
-		ExecutableMetaData executableMetaData = new BeanMetaDataManager( new ConstraintHelper() ).getBeanMetaData(
+		ExecutableMetaData executableMetaData = new BeanMetaDataManager( new ConstraintHelper(), new OverrideHelper() ).getBeanMetaData(
 				Container.class
 		).getMetaDataFor( executable );
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
@@ -21,12 +21,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 
+import org.testng.annotations.Test;
+
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
-import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.fail;
@@ -41,7 +43,7 @@ public class BeanMetaDataManagerTest {
 
 	@Test
 	public void testBeanMetaDataCanBeGarbageCollected() throws Exception {
-		BeanMetaDataManager metaDataManager = new BeanMetaDataManager( new ConstraintHelper() );
+		BeanMetaDataManager metaDataManager = new BeanMetaDataManager( new ConstraintHelper(), new OverrideHelper() );
 
 		Class<?> lastIterationsBean = null;
 		int totalCreatedMetaDataInstances = 0;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
@@ -23,6 +23,7 @@ import javax.validation.ElementKind;
 import javax.validation.constraints.NotNull;
 import javax.validation.groups.Default;
 
+import com.fasterxml.classmate.TypeResolver;
 import org.joda.time.DateMidnight;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -33,6 +34,7 @@ import org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.test.internal.metadata.ConsistentDateParameters;
 import org.hibernate.validator.test.internal.metadata.Customer;
 import org.hibernate.validator.test.internal.metadata.CustomerRepository.ValidationGroup;
@@ -54,7 +56,7 @@ public class ExecutableMetaDataTest {
 
 	@BeforeMethod
 	public void setupBeanMetaData() {
-		beanMetaData = new BeanMetaDataManager( new ConstraintHelper() ).getBeanMetaData( CustomerRepositoryExt.class );
+		beanMetaData = new BeanMetaDataManager( new ConstraintHelper(), new OverrideHelper() ).getBeanMetaData( CustomerRepositoryExt.class );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
@@ -31,6 +31,7 @@ import org.hibernate.validator.internal.metadata.aggregated.ParameterMetaData;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.test.internal.metadata.Customer;
 import org.hibernate.validator.test.internal.metadata.CustomerRepository;
 import org.hibernate.validator.test.internal.metadata.CustomerRepository.ValidationGroup;
@@ -51,7 +52,7 @@ public class ParameterMetaDataTest {
 
 	@BeforeMethod
 	public void setupBeanMetaData() {
-		beanMetaData = new BeanMetaDataManager( new ConstraintHelper() ).getBeanMetaData( CustomerRepository.class );
+		beanMetaData = new BeanMetaDataManager( new ConstraintHelper(), new OverrideHelper() ).getBeanMetaData( CustomerRepository.class );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
@@ -16,8 +16,6 @@
 */
 package org.hibernate.validator.test.internal.metadata.aggregated;
 
-import static org.fest.assertions.Assertions.assertThat;
-
 import java.util.Set;
 import javax.validation.ConstraintDeclarationException;
 import javax.validation.Valid;
@@ -30,6 +28,9 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.aggregated.PropertyMetaData;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.util.OverrideHelper;
+
+import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * @author Gunnar Morling
@@ -40,7 +41,7 @@ public class PropertyMetaDataTest {
 
 	@BeforeMethod
 	public void setupBeanMetaDataManager() {
-		beanMetaDataManager = new BeanMetaDataManager( new ConstraintHelper() );
+		beanMetaDataManager = new BeanMetaDataManager( new ConstraintHelper(), new OverrideHelper() );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/raw/ExecutableElementTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/raw/ExecutableElementTest.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
+import org.hibernate.validator.internal.util.OverrideHelper;
 
 import static org.fest.assertions.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
@@ -34,6 +35,8 @@ import static org.testng.Assert.assertEquals;
  */
 public class ExecutableElementTest {
 
+	private final OverrideHelper overrideHelper = new OverrideHelper();
+
 	@Test
 	public void methodFromSubTypeOverridesSuperTypeMethod() throws Exception {
 
@@ -42,7 +45,7 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isTrue();
 	}
 
@@ -54,7 +57,7 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isTrue();
 	}
 
@@ -66,7 +69,7 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromBase )
-						.overrides( ExecutableElement.forMethod( methodFromImpl ) )
+						.overrides( ExecutableElement.forMethod( methodFromImpl ), overrideHelper )
 		).isFalse();
 	}
 
@@ -78,7 +81,7 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isFalse();
 	}
 
@@ -90,7 +93,7 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isFalse();
 	}
 
@@ -102,7 +105,7 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( other )
-						.overrides( ExecutableElement.forMethod( first ) )
+						.overrides( ExecutableElement.forMethod( first ), overrideHelper )
 		).isFalse();
 	}
 
@@ -114,7 +117,7 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forConstructor( other )
-						.overrides( ExecutableElement.forConstructor( first ) )
+						.overrides( ExecutableElement.forConstructor( first ), overrideHelper )
 		).isFalse();
 	}
 
@@ -126,7 +129,7 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( other )
-						.overrides( ExecutableElement.forConstructor( first ) )
+						.overrides( ExecutableElement.forConstructor( first ), overrideHelper )
 		).isFalse();
 	}
 
@@ -139,14 +142,14 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isTrue();
 
 		methodFromImpl = SimpleServiceImpl1.class.getDeclaredMethod( "doSomething", Integer.class );
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isFalse();
 	}
 
@@ -160,14 +163,14 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isTrue();
 
 		methodFromImpl = SimpleServiceImpl2.class.getDeclaredMethod( "doSomething", Integer.class );
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isFalse();
 	}
 
@@ -180,14 +183,14 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isTrue();
 
 		methodFromImpl = GenericServiceImpl1.class.getDeclaredMethod( "doSomething", Integer.class );
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isFalse();
 	}
 
@@ -200,14 +203,14 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isTrue();
 
 		methodFromImpl = GenericServiceImpl2.class.getDeclaredMethod( "doSomething", Integer.class );
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isFalse();
 	}
 
@@ -220,14 +223,14 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isTrue();
 
 		methodFromImpl = GenericServiceImpl2.class.getDeclaredMethod( "doSomething", Integer.class );
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isFalse();
 	}
 
@@ -240,14 +243,14 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isTrue();
 
 		methodFromImpl = ParameterizedSubType.class.getDeclaredMethod( "doSomething", Integer.class );
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isFalse();
 	}
 
@@ -260,14 +263,14 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isTrue();
 
 		methodFromImpl = GenericInterfaceImpl1.class.getDeclaredMethod( "doSomething", Integer.class );
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isFalse();
 	}
 
@@ -280,14 +283,14 @@ public class ExecutableElementTest {
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isTrue();
 
 		methodFromImpl = WildcardInterfaceImpl.class.getDeclaredMethod( "doSomething", Long.class );
 
 		assertThat(
 				ExecutableElement.forMethod( methodFromImpl )
-						.overrides( ExecutableElement.forMethod( methodFromBase ) )
+						.overrides( ExecutableElement.forMethod( methodFromBase ), overrideHelper )
 		).isFalse();
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/ReflectionHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/ReflectionHelperTest.java
@@ -34,6 +34,7 @@ import javax.validation.groups.Default;
 
 import org.testng.annotations.Test;
 
+import org.hibernate.validator.internal.util.OverrideHelper;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.testutil.TestForIssue;
 
@@ -203,25 +204,27 @@ public class ReflectionHelperTest {
 		Method getStaticFooInteger = Foo.class.getMethod( "getFoo", Integer.class );
 		Method getSuperTypeStaticFoo = Bar.class.getMethod( "getFoo" );
 
-		assertTrue( ReflectionHelper.overrides( getSubTypeBar, getBar ) );
-		assertTrue( ReflectionHelper.overrides( getSubTypeBarString, getBarString ) );
+		final OverrideHelper overrideHelper = new OverrideHelper();
 
-		assertFalse( ReflectionHelper.overrides( getBar, getBarString ) );
-		assertFalse( ReflectionHelper.overrides( getBar, getBarInteger ) );
-		assertFalse( ReflectionHelper.overrides( getBarString, getBarInteger ) );
-		assertFalse( ReflectionHelper.overrides( getSubTypeBar, getBarInteger ) );
-		assertFalse( ReflectionHelper.overrides( getSubTypeBar, getBarString ) );
-		assertFalse( ReflectionHelper.overrides( getSubTypeBarString, getBarInteger ) );
-		assertFalse( ReflectionHelper.overrides( getSubTypeBarString, getBar ) );
-		assertFalse( ReflectionHelper.overrides( getSubTypeBarString, getSubTypeBar ) );
+		assertTrue( overrideHelper.overrides( getSubTypeBar, getBar ) );
+		assertTrue( overrideHelper.overrides( getSubTypeBarString, getBarString ) );
 
-		assertFalse( ReflectionHelper.overrides( getStaticFoo, getStaticFooString ) );
-		assertFalse( ReflectionHelper.overrides( getStaticFoo, getStaticFooInteger ) );
-		assertFalse( ReflectionHelper.overrides( getStaticFooString, getStaticFooInteger ) );
-		assertFalse( ReflectionHelper.overrides( getFooLong, getStaticFoo ) );
-		assertFalse( ReflectionHelper.overrides( getFooLong, getStaticFooInteger ) );
-		assertFalse( ReflectionHelper.overrides( getFooLong, getStaticFooString ) );
-		assertFalse( ReflectionHelper.overrides( getStaticFoo, getSuperTypeStaticFoo ) );
+		assertFalse( overrideHelper.overrides( getBar, getBarString ) );
+		assertFalse( overrideHelper.overrides( getBar, getBarInteger ) );
+		assertFalse( overrideHelper.overrides( getBarString, getBarInteger ) );
+		assertFalse( overrideHelper.overrides( getSubTypeBar, getBarInteger ) );
+		assertFalse( overrideHelper.overrides( getSubTypeBar, getBarString ) );
+		assertFalse( overrideHelper.overrides( getSubTypeBarString, getBarInteger ) );
+		assertFalse( overrideHelper.overrides( getSubTypeBarString, getBar ) );
+		assertFalse( overrideHelper.overrides( getSubTypeBarString, getSubTypeBar ) );
+
+		assertFalse( overrideHelper.overrides( getStaticFoo, getStaticFooString ) );
+		assertFalse( overrideHelper.overrides( getStaticFoo, getStaticFooInteger ) );
+		assertFalse( overrideHelper.overrides( getStaticFooString, getStaticFooInteger ) );
+		assertFalse( overrideHelper.overrides( getFooLong, getStaticFoo ) );
+		assertFalse( overrideHelper.overrides( getFooLong, getStaticFooInteger ) );
+		assertFalse( overrideHelper.overrides( getFooLong, getStaticFooString ) );
+		assertFalse( overrideHelper.overrides( getStaticFoo, getSuperTypeStaticFoo ) );
 	}
 
 	@SuppressWarnings("unused")


### PR DESCRIPTION
The CDI module would probably better be served by caching a TypeResolver for the life of the extension however then it would require a dependency on classmate and that seems a bit out of scope of this fix.
