### PR TITLE
HV-844 Making the validator version used in TCK run configurable

### DIFF
--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -32,6 +32,7 @@
     <name>Hibernate Validator TCK Runner</name>
     <description>Aggregates dependencies and runs the JSR-349 TCK</description>
     <properties>
+        <hv.version>${project.version}</hv.version>
         <tck.version>1.1.2.Final</tck.version>
         <tck.suite.file>${project.build.directory}/dependency/beanvalidation-tck-tests-suite.xml</tck.suite.file>
         <arquillian.version>1.0.0.Final</arquillian.version>
@@ -48,10 +49,12 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
+            <version>${hv.version}</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator-cdi</artifactId>
+            <version>${hv.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>

--- a/tck-runner/src/script/setupModules.groovy
+++ b/tck-runner/src/script/setupModules.groovy
@@ -8,14 +8,14 @@ def processFileInplace(file, Closure processText) {
 }
 
 hvModuleXml = new File( project.properties['wildflyTargetDir'], 'modules/system/layers/base/org/hibernate/validator/main/module.xml' )
-def hvArtifactName = 'hibernate-validator-' + project.version + '.jar';
+def hvArtifactName = 'hibernate-validator-' + project.properties['hv.version'] + '.jar';
 println "[INFO] Using HV version " + hvArtifactName;
 processFileInplace( hvModuleXml ) { text ->
     text.replaceAll( /hibernate-validator.*jar/, hvArtifactName )
 }
 
 hvCdiModuleXml = new File( project.properties['wildflyTargetDir'], 'modules/system/layers/base/org/hibernate/validator/cdi/main/module.xml' )
-def hvCdiArtifactName = 'hibernate-validator-cdi-' + project.version + '.jar';
+def hvCdiArtifactName = 'hibernate-validator-cdi-' + project.properties['hv.version'] + '.jar';
 println "[INFO] Using HV CDI Portable Extension version " + hvCdiArtifactName;
 processFileInplace( hvCdiModuleXml ) { text ->
     text.replaceAll( /hibernate-validator-cdi.*jar/, hvCdiArtifactName )


### PR DESCRIPTION
Just a minor improvement to run the TCK against a given validator version.
