### PR TITLE
character encoding error

### DIFF
--- a/engine/src/main/resources/org/hibernate/validator/ValidationMessages_zh_CN.properties
+++ b/engine/src/main/resources/org/hibernate/validator/ValidationMessages_zh_CN.properties
@@ -8,7 +8,7 @@ javax.validation.constraints.Max.message         = \u6700\u5927\u4E0D\u80FD\u8D8
 javax.validation.constraints.Min.message         = \u6700\u5C0F\u4E0D\u80FD\u5C0F\u4E8E{value}
 javax.validation.constraints.NotNull.message     = \u4E0D\u80FD\u4E3Anull
 javax.validation.constraints.Null.message        = \u5FC5\u987B\u4E3Anull
-javax.validation.constraints.Past.message        = \u9700\u8981\u662f\u4e00\u4e2a\u8fc7\u53bb\u7684\u65f6\u95f4
+javax.validation.constraints.Past.message        = \u9700\u8981\u662f\u4e00\u4e2a\u8fc7\u53bb\u7684\u65F6\u95F4
 javax.validation.constraints.Pattern.message     = \u9700\u8981\u5339\u914D\u6B63\u5219\u8868\u8FBE\u5F0F"{regexp}"
 javax.validation.constraints.Size.message        = \u4E2A\u6570\u5FC5\u987B\u5728{min}\u548C{max}\u4E4B\u95F4
 


### PR DESCRIPTION
"\u65f6\u95f4" means "event" in Chinese. It should be "\u65F6\u95F4" which means "date" in Chinese, like "javax.validation.constraints.Future.message".
