### PR TITLE
HV-877 Discovering and registering type use constraints

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
@@ -28,11 +28,13 @@ import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOption
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider;
+import org.hibernate.validator.internal.metadata.provider.TypeUseAnnotationMetaDataProvider;
 import org.hibernate.validator.internal.metadata.provider.MetaDataProvider;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.util.ConcurrentReferenceHashMap;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.ExecutableHelper;
+import org.hibernate.validator.internal.util.Version;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.hibernate.validator.internal.util.ConcurrentReferenceHashMap.Option.IDENTITY_COMPARISONS;
@@ -121,11 +123,21 @@ public class BeanMetaDataManager {
 
 
 		AnnotationProcessingOptions annotationProcessingOptions = getAnnotationProcessingOptionsFromNonDefaultProviders();
-		AnnotationMetaDataProvider defaultProvider = new AnnotationMetaDataProvider(
-				constraintHelper,
-				parameterNameProvider,
-				annotationProcessingOptions
-		);
+		AnnotationMetaDataProvider defaultProvider = null;
+		if ( Version.getJavaRelease() >= 8 ) {
+			defaultProvider = new TypeUseAnnotationMetaDataProvider(
+					constraintHelper,
+					parameterNameProvider,
+					annotationProcessingOptions
+			);
+		}
+		else {
+			defaultProvider = new AnnotationMetaDataProvider(
+					constraintHelper,
+					parameterNameProvider,
+					annotationProcessingOptions
+			);
+		}
 		this.metaDataProviders.add( defaultProvider );
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/location/ConstraintLocation.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/location/ConstraintLocation.java
@@ -74,6 +74,14 @@ public class ConstraintLocation {
 		);
 	}
 
+	public static ConstraintLocation forTypeArgument(Member member, Type type) {
+		return new ConstraintLocation(
+				member.getDeclaringClass(),
+				member,
+				type
+		);
+	}
+
 	public static ConstraintLocation forReturnValue(ExecutableElement executable) {
 		return new ConstraintLocation(
 				executable.getMember().getDeclaringClass(),

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/TypeUseAnnotationMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/TypeUseAnnotationMetaDataProvider.java
@@ -1,0 +1,322 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.internal.metadata.provider;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.ParameterNameProvider;
+
+import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptions;
+import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.metadata.core.MetaConstraint;
+import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
+import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
+import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
+import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
+import org.hibernate.validator.internal.util.ReflectionHelper;
+import org.hibernate.validator.internal.util.TypeHelper;
+import org.hibernate.validator.internal.util.TypeUseHelper;
+import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
+
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
+/**
+ * Extends the base {@code AnnotationMetaDataProvider} with the following:
+ *
+ * <ul>
+ *     <li>Discover and register constraints defined on formal parameters and actual type arguments.</li>
+ *     <li>Discover and register constraints defined on type arguments for fields, parameters, and return
+ *     values parameterized types.</li>
+ * </ul>
+ *
+ * @author Khalid Alqinyah
+ */
+public class TypeUseAnnotationMetaDataProvider extends AnnotationMetaDataProvider {
+
+	/**
+	 * Keeps track of discovered annotations on formal parameters and actual type arguments for the current hierarchy.
+	 * Each thread will have its own map, so that discovered annotations of different hierarchies don't mix with each
+	 * other.
+	 */
+	private static final ThreadLocal<Map<TypeVariable<?>, Set<Annotation>>> typeUseConstraintsMap = new ThreadLocal<Map<TypeVariable<?>, Set<Annotation>>>() {
+		@Override
+		protected Map<TypeVariable<?>, Set<Annotation>> initialValue() {
+			return newHashMap();
+		}
+	};
+
+	public TypeUseAnnotationMetaDataProvider(ConstraintHelper constraintHelper,
+											 ParameterNameProvider parameterNameProvider,
+											 AnnotationProcessingOptions annotationProcessingOptions) {
+		super( constraintHelper, parameterNameProvider, annotationProcessingOptions );
+	}
+
+	@Override
+	public <T> List<BeanConfiguration<? super T>> getBeanConfigurationForHierarchy(Class<T> beanClass) {
+
+		// Discover and map type parameters and actual type arguments constraints (e.g. class Student<@NotNull T>)
+		for ( Class<? super T> hierarchyClass : ClassHierarchyHelper.getHierarchy( beanClass ) ) {
+			findTypeUseConstraints( hierarchyClass );
+		}
+
+		// Get the constrained elements
+		List<BeanConfiguration<? super T>> configurations = super.getBeanConfigurationForHierarchy( beanClass );
+
+		return configurations;
+	}
+
+	/**
+	 * Discovers and maps annotations constraints on formal type parameters and actual type arguments defined on the
+	 * class, super class, and interfaces.
+	 *
+	 * @param cls the class to examine
+	 */
+	private void findTypeUseConstraints(Class<?> cls) {
+
+		Map<TypeVariable<?>, Set<Annotation>> typeUseConstraintsMap = newHashMap();
+
+		// 1. Formal types (e.g. class Pair<@NotNull T, @NotBlank V extends String>)
+		for ( TypeVariable<?> typeVariable : cls.getTypeParameters() ) {
+			for ( Annotation annotation : typeVariable.getAnnotations() ) {
+				Set<Annotation> constraintAnnotations = findTypeUseConstraintAnnotations( annotation );
+				addTypeUseConstraintsAnnotations( typeVariable, constraintAnnotations );
+			}
+		}
+
+		// 2. Superclass type arguments (e.g. class BarExt extends Bar<@NotNull Integer, @NotBlank String>)
+		if ( cls.getAnnotatedSuperclass() != null ) {
+			Map<TypeVariable<?>, AnnotatedType> superFormalToActualMap = TypeUseHelper.getFormalToActualMap(
+					cls.getAnnotatedSuperclass(),
+					cls.getSuperclass()
+			);
+			addConstraintsToContext( superFormalToActualMap );
+		}
+
+		// 3. Interfaces type arguments (e.g. class BarImpl implements Bar<@NotNull Integer, @NotBlank String>)
+		if ( cls.getAnnotatedInterfaces().length > 0 ) {
+			Class<?>[] interfaces = cls.getInterfaces();
+			AnnotatedType[] annotatedInterfaces = cls.getAnnotatedInterfaces();
+
+			for ( int i = 0; i < annotatedInterfaces.length; i++ ) {
+				Map<TypeVariable<?>, AnnotatedType> interfaceFormalToActualMap = TypeUseHelper.getFormalToActualMap(
+						annotatedInterfaces[i],
+						interfaces[i]
+				);
+				addConstraintsToContext( interfaceFormalToActualMap );
+			}
+		}
+	}
+
+	/**
+	 * Find annotations defined on actual type arguments and map them to formal parameters.
+	 *
+	 * @param formalToActualMap formal parameters to actual type arguments
+	 */
+	private void addConstraintsToContext(Map<TypeVariable<?>, AnnotatedType> formalToActualMap) {
+		for ( Map.Entry<TypeVariable<?>, AnnotatedType> entry : formalToActualMap.entrySet() ) {
+			for ( Annotation annotation : entry.getValue().getAnnotations() ) {
+				Set<Annotation> annotations = findTypeUseConstraintAnnotations( annotation );
+				addTypeUseConstraintsAnnotations( entry.getKey(), annotations );
+			}
+		}
+	}
+
+	/**
+	 * Adds discovered annotations to formal parameters mapping to {@code typeUseConstraintsMap}
+	 */
+	private void addTypeUseConstraintsAnnotations(TypeVariable<?> typeVariable, Set<Annotation> annotations) {
+		Map<TypeVariable<?>, Set<Annotation>> map = typeUseConstraintsMap.get();
+
+		Set<Annotation> existingAnnotations = map.get( typeVariable );
+		if ( existingAnnotations != null ) {
+			existingAnnotations.addAll( annotations );
+		}
+		else {
+			map.put( typeVariable, annotations );
+		}
+	}
+
+	/**
+	 * Gets discovered annotations for type.
+	 */
+	private Set<Annotation> getTypeUseConstraintsAnnotations(Type type) {
+		Map<TypeVariable<?>, Set<Annotation>> map = typeUseConstraintsMap.get();
+
+		Set<Annotation> annotations = Collections.<Annotation>emptySet();
+
+		if ( type != null && TypeHelper.isAssignable( TypeVariable.class, type.getClass() ) ) {
+			TypeVariable<?> typeVariable = (TypeVariable<?>) type;
+			annotations = map.get( typeVariable );
+		}
+
+		return ( annotations == null ? Collections.<Annotation>emptySet() : annotations );
+	}
+
+	/**
+	 * Returns a set of discovered annotations constraints.
+	 */
+	private <A extends Annotation> Set<Annotation> findTypeUseConstraintAnnotations(A annotation) {
+		Set<Annotation> constraints = newHashSet();
+		Class<? extends Annotation> annotationType = annotation.annotationType();
+		if ( constraintHelper.isConstraintAnnotation( annotationType ) ) {
+			constraints.add( annotation );
+		}
+		else if ( constraintHelper.isMultiValueConstraint( annotationType ) ) {
+			constraints.addAll( constraintHelper.getConstraintsFromMultiValueConstraint( annotation ) );
+		}
+
+		return constraints;
+	}
+
+	@Override
+	protected List<ConstraintDescriptorImpl<?>> findConstraints(Member member, ElementType type) {
+		List<ConstraintDescriptorImpl<?>> constraintDescriptors = super.findConstraints( member, type );
+
+		// Add type use constraints
+		Type genericType = ReflectionHelper.genericTypeOf( member );
+		Set<Annotation> typeUseAnnotations = getTypeUseConstraintsAnnotations( genericType );
+		for ( Annotation annotation : typeUseAnnotations ) {
+			constraintDescriptors.addAll( findConstraintAnnotations( member, annotation, type ) );
+		}
+		return constraintDescriptors;
+	}
+
+	@Override
+	protected Set<MetaConstraint<?>> convertToMetaConstraints(List<ConstraintDescriptorImpl<?>> constraintDescriptors, Field field) {
+		Set<MetaConstraint<?>> metaConstraints = super.convertToMetaConstraints( constraintDescriptors, field );
+		// Add type argument constraints for a field
+		metaConstraints.addAll( findConstrainedTypeArguments( field.getAnnotatedType(), field ) );
+		return metaConstraints;
+	}
+
+	@Override
+	protected Set<MetaConstraint<?>> convertToMetaConstraints(List<ConstraintDescriptorImpl<?>> constraintsDescriptors, ExecutableElement executable) {
+		Set<MetaConstraint<?>> metaConstraints = super.convertToMetaConstraints( constraintsDescriptors, executable );
+
+		if ( metaConstraints.isEmpty() ) {
+			metaConstraints = newHashSet();
+		}
+		// Add type argument constraints for an executable
+		Member member = executable.getMember();
+		AnnotatedType annotatedType = ( (Executable) member ).getAnnotatedReturnType();
+		metaConstraints.addAll( findConstrainedTypeArguments( annotatedType, member ) );
+		return metaConstraints;
+	}
+
+	@Override
+	protected Set<MetaConstraint<?>> convertToMetaConstraints(List<ConstraintDescriptorImpl<?>> constraintDescriptors, ExecutableElement executable, int i) {
+		// Add type use constraints
+		Type genericType = ReflectionHelper.genericTypeOf( executable, i );
+		Set<Annotation> annotations = getTypeUseConstraintsAnnotations( genericType );
+		for ( Annotation annotation : annotations ) {
+			constraintDescriptors.addAll(
+					findConstraintAnnotations(
+							executable.getMember(), annotation, ElementType.PARAMETER
+					)
+			);
+		}
+		Set<MetaConstraint<?>> metaConstraints = super.convertToMetaConstraints( constraintDescriptors, executable, i );
+
+		// Add type argument constraints for a parameter
+		try {
+			AnnotatedType annotatedType = ( (Executable) executable.getMember() ).getParameters()[i].getAnnotatedType();
+			metaConstraints.addAll( findConstrainedTypeArguments( annotatedType, executable.getMember() ) );
+		}
+		catch ( ArrayIndexOutOfBoundsException ex ) {
+			// Constructors for inner non-static classes have a default synthetic parameter for the outer class,
+			// it's counted, but cannot be accessed, ignore it
+		}
+
+		return metaConstraints;
+	}
+
+	/**
+	 * Creates meta constraints based on the constraints annotations discovered on the {@code AnnotatedType}.
+	 */
+	private Set<MetaConstraint<?>> findConstrainedTypeArguments(AnnotatedType annotatedType, Member member) {
+		List<AnnotatedType> typeArguments = TypeUseHelper.getAnnotatedActualTypeArguments( annotatedType );
+		Set<MetaConstraint<?>> metaConstraints = newHashSet();
+
+		for ( AnnotatedType typeArgument : typeArguments ) {
+			List<ConstraintDescriptorImpl<?>> metaData = findTypeArgumentConstraints( member, typeArgument );
+
+			Set<MetaConstraint<?>> constraints = convertToTypeArgumentMetaConstraints(
+					metaData,
+					member,
+					typeArgument.getType()
+			);
+
+			metaConstraints.addAll( constraints );
+		}
+
+		return metaConstraints;
+	}
+
+	/**
+	 * Finds annotation constraints defined on the type {@code AnnotatedType}.
+	 */
+	public List<ConstraintDescriptorImpl<?>> findTypeArgumentConstraints(Member member, AnnotatedType typeArgument) {
+		List<ConstraintDescriptorImpl<?>> metaData = newArrayList();
+
+		// Defined directly on the type argument
+		Annotation[] direct = typeArgument.getAnnotations();
+
+		// Matched from the type use context
+		Set<Annotation> annotations = getTypeUseConstraintsAnnotations( typeArgument.getType() );
+
+		// Combine
+		Set<Annotation> combined = newHashSet( annotations );
+		Collections.addAll( combined, direct );
+
+		for ( Annotation annotation : combined ) {
+			metaData.addAll( findConstraintAnnotations( member, annotation, ElementType.TYPE_USE ) );
+		}
+
+		return metaData;
+	}
+
+	/**
+	 * Creates meta constraints for type arguments constraints.
+	 */
+	private Set<MetaConstraint<?>> convertToTypeArgumentMetaConstraints(List<ConstraintDescriptorImpl<?>> constraintDescriptors, Member member, Type type) {
+		Set<MetaConstraint<?>> constraints = newHashSet();
+		for ( ConstraintDescriptorImpl<?> constraintDescription : constraintDescriptors ) {
+			MetaConstraint<?> metaConstraint = createTypeArgumentMetaConstraint( member, constraintDescription, type );
+			constraints.add( metaConstraint );
+		}
+		return constraints;
+	}
+
+	/**
+	 * Creates a {@code MetaConstraint} for a type argument constraint.
+	 */
+	private <A extends Annotation> MetaConstraint<?> createTypeArgumentMetaConstraint(Member member, ConstraintDescriptorImpl<A> descriptor, Type type) {
+		return new MetaConstraint<A>( descriptor, ConstraintLocation.forTypeArgument( member, type ) );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/ReflectionHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/ReflectionHelper.java
@@ -341,10 +341,27 @@ public final class ReflectionHelper {
 	 * @param member The <code>Member</code> instance for which to retrieve the type.
 	 *
 	 * @return Returns the <code>Type</code> of the given <code>Field</code> or <code>Method</code>.
+	 * If the type is a {@code TypeVariable}, the erased type will be returned.
 	 *
 	 * @throws IllegalArgumentException in case <code>member</code> is not a <code>Field</code> or <code>Method</code>.
 	 */
 	public static Type typeOf(Member member) {
+		Type type = genericTypeOf( member );
+		if ( type instanceof TypeVariable ) {
+			type = TypeHelper.getErasedType( type );
+		}
+		return type;
+	}
+
+	/**
+	 * @param member The {@code Member} instance for which to retrieve the type.
+	 *
+	 * @return returns the generic type of the given {@code Field} or {@code Method}.
+	 * If the type is a {@code TypeVariable}, it will be returned as is.
+	 *
+	 * @throws IllegalArgumentException in case {@code member} is not a {@code Field} or {@code Method}.
+	 */
+	public static Type genericTypeOf(Member member) {
 		Type type;
 		if ( member instanceof Field ) {
 			type = ( (Field) member ).getGenericType();
@@ -359,14 +376,12 @@ public final class ReflectionHelper {
 		else {
 			throw log.getMemberIsNeitherAFieldNorAMethodException( member );
 		}
-		if ( type instanceof TypeVariable ) {
-			type = TypeHelper.getErasedType( type );
-		}
 		return type;
 	}
 
 	/**
-	 * Returns the type of the parameter of the given method with the given parameter index.
+	 * Returns the type of the parameter of the given method with the given parameter index. If the type is a
+	 * {@code TypeVariable}, the erased type will be returned.
 	 *
 	 * @param executable The executable of interest.
 	 * @param parameterIndex The index of the parameter for which the type should be returned.
@@ -374,6 +389,25 @@ public final class ReflectionHelper {
 	 * @return The erased type.
 	 */
 	public static Type typeOf(ExecutableElement executable, int parameterIndex) {
+		Type type = genericTypeOf( executable, parameterIndex );
+
+		if ( type instanceof TypeVariable ) {
+			type = TypeHelper.getErasedType( type );
+		}
+		return type;
+	}
+
+
+	/**
+	 * Returns the type of the parameter of the given method with the given parameter index. If the type is a
+	 * {@code TypeVariable}, it will be returned as is.
+	 *
+	 * @param executable The executable of interest.
+	 * @param parameterIndex The index of the parameter for which the type should be returned.
+	 *
+	 * @return the generic type
+	 */
+	public static Type genericTypeOf(ExecutableElement executable, int parameterIndex) {
 		Type[] genericParameterTypes = executable.getGenericParameterTypes();
 
 		// getGenericParameterTypes() doesn't return synthetic parameters; in this case fall back to getParameterTypes()
@@ -383,9 +417,6 @@ public final class ReflectionHelper {
 
 		Type type = genericParameterTypes[parameterIndex];
 
-		if ( type instanceof TypeVariable ) {
-			type = TypeHelper.getErasedType( type );
-		}
 		return type;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/util/TypeUseHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/TypeUseHelper.java
@@ -1,0 +1,100 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.internal.util;
+
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
+
+/**
+ * Provides helper methods for working with formal parameters and actual type arguments of parameterized types.
+ *
+ * @author Khalid Alqinyah
+ */
+public class TypeUseHelper {
+
+	private TypeUseHelper() {
+
+	}
+
+	/**
+	 * Given {@code Bar<Integer, String>}, a list of {@code Integer} and {@code String} annotated types is returned.
+	 *
+	 * @param annotatedType the annotated type that contains the type arguments
+	 *
+	 * @return the type arguments or empty list if no type arguments are found or the {@code AnnotatedType} is not an
+	 * {@code AnnotatedParameterizedType}
+	 *
+	 * @throws IllegalArgumentException if {@code annotatedType} is null
+	 */
+	public static List<AnnotatedType> getAnnotatedActualTypeArguments(AnnotatedType annotatedType) {
+		Contracts.assertNotNull( annotatedType, MESSAGES.mustNotBeNull( "annotatedType" ) );
+
+		if ( !TypeHelper.isAssignable( AnnotatedParameterizedType.class, annotatedType.getClass() ) ) {
+			return Collections.emptyList();
+		}
+
+		AnnotatedType[] annotatedArguments = ( (AnnotatedParameterizedType) annotatedType ).getAnnotatedActualTypeArguments();
+		return Arrays.asList( annotatedArguments );
+	}
+
+	/**
+	 * Given {@code class Bar<T, V>} and {@code Bar<Integer, String>}, a map of {@code T} to {@code Integer} and {@code
+	 * V} to {@code String} is returned.
+	 *
+	 * @param annotatedType the annotated type that contains the type arguments
+	 * @param cls the class that contains the formal parameters
+	 *
+	 * @return a map of formal parameter to actual type arguments
+	 *
+	 * @throws IllegalArgumentException if {@code annotatedType} or {@code cls} is null, or if they're for different types
+	 */
+	public static Map<TypeVariable<?>, AnnotatedType> getFormalToActualMap(AnnotatedType annotatedType, Class<?> cls) {
+		Contracts.assertNotNull( cls, MESSAGES.mustNotBeNull( "cls" ) );
+
+		List<AnnotatedType> annotatedArguments = getAnnotatedActualTypeArguments( annotatedType );
+		List<TypeVariable<?>> formalParameters = Arrays.<TypeVariable<?>>asList( cls.getTypeParameters() );
+
+		if ( annotatedArguments.size() == formalParameters.size() && annotatedArguments.size() > 0 ) {
+
+			// They must be of the same type
+			if ( ! ( (ParameterizedType) annotatedType.getType() ).getRawType().equals( cls ) ) {
+				String error = String.format( "AnnotatedType %s is not of the same type as %s %n", annotatedType.getType(), cls.getName() );
+				throw new IllegalArgumentException( error );
+			}
+
+			Map<TypeVariable<?>, AnnotatedType> map = newHashMap();
+
+			for ( int i = 0; i < annotatedArguments.size(); i++ ) {
+				map.put( formalParameters.get( i ), annotatedArguments.get( i ) );
+			}
+
+			return map;
+		}
+		else {
+			return Collections.emptyMap();
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
@@ -21,7 +21,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.lang.reflect.Member;
 import java.util.List;
 import java.util.Map;
 
@@ -46,7 +45,6 @@ import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
-import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement.ConstrainedElementKind;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
@@ -65,7 +63,7 @@ import static org.testng.Assert.assertTrue;
  *
  * @author Gunnar Morling
  */
-public class AnnotationMetaDataProviderTest {
+public class AnnotationMetaDataProviderTest extends AnnotationMetaDataProviderTestBase {
 
 	private AnnotationMetaDataProvider provider;
 
@@ -412,57 +410,6 @@ public class AnnotationMetaDataProviderTest {
 		);
 
 		assertTrue( constrainedMethod.getParameterMetaData( 0 ).requiresUnwrapping() );
-	}
-
-	private <T> ConstrainedField findConstrainedField(Iterable<BeanConfiguration<? super T>> beanConfigurations,
-			Class<? super T> clazz, String fieldName) throws Exception {
-		return (ConstrainedField) findConstrainedElement( beanConfigurations, clazz.getDeclaredField( fieldName ) );
-	}
-
-	private <T> ConstrainedExecutable findConstrainedMethod(Iterable<BeanConfiguration<? super T>> beanConfigurations,
-			Class<? super T> clazz, String methodName, Class<?>... parameterTypes) throws Exception {
-		return (ConstrainedExecutable) findConstrainedElement(
-				beanConfigurations,
-				clazz.getMethod( methodName, parameterTypes )
-		);
-	}
-
-	private <T> ConstrainedExecutable findConstrainedConstructor(
-			Iterable<BeanConfiguration<? super T>> beanConfigurations, Class<? super T> clazz,
-			Class<?>... parameterTypes) throws Exception {
-		return (ConstrainedExecutable) findConstrainedElement(
-				beanConfigurations,
-				clazz.getConstructor( parameterTypes )
-		);
-	}
-
-	private <T> ConstrainedType findConstrainedType(Iterable<BeanConfiguration<? super T>> beanConfigurations,
-			Class<? super T> type) {
-		for ( BeanConfiguration<?> oneConfiguration : beanConfigurations ) {
-			for ( ConstrainedElement constrainedElement : oneConfiguration.getConstrainedElements() ) {
-				if ( constrainedElement.getLocation().getMember() == null ) {
-					ConstrainedType constrainedType = (ConstrainedType) constrainedElement;
-					if ( constrainedType.getLocation().getDeclaringClass().equals( type ) ) {
-						return constrainedType;
-					}
-				}
-			}
-		}
-
-		throw new RuntimeException( "Found no constrained element for type " + type );
-	}
-
-	private ConstrainedElement findConstrainedElement(Iterable<? extends BeanConfiguration<?>> beanConfigurations,
-			Member member) {
-		for ( BeanConfiguration<?> oneConfiguration : beanConfigurations ) {
-			for ( ConstrainedElement constrainedElement : oneConfiguration.getConstrainedElements() ) {
-				if ( constrainedElement.getLocation().getMember().equals( member ) ) {
-					return constrainedElement;
-				}
-			}
-		}
-
-		throw new RuntimeException( "Found no constrained element for " + member );
 	}
 
 	private static class Foo {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTestBase.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTestBase.java
@@ -1,0 +1,83 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.metadata.provider;
+
+import java.lang.reflect.Member;
+
+import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
+
+/**
+ * @author Gunnar Morling
+ */
+public abstract class AnnotationMetaDataProviderTestBase {
+
+	protected <T> ConstrainedField findConstrainedField(Iterable<BeanConfiguration<? super T>> beanConfigurations,
+														Class<? super T> clazz, String fieldName) throws Exception {
+		return (ConstrainedField) findConstrainedElement( beanConfigurations, clazz.getDeclaredField( fieldName ) );
+	}
+
+	protected <T> ConstrainedExecutable findConstrainedMethod(Iterable<BeanConfiguration<? super T>> beanConfigurations,
+															  Class<? super T> clazz, String methodName, Class<?>... parameterTypes)
+			throws Exception {
+		return (ConstrainedExecutable) findConstrainedElement(
+				beanConfigurations,
+				clazz.getMethod( methodName, parameterTypes )
+		);
+	}
+
+	protected <T> ConstrainedExecutable findConstrainedConstructor(
+			Iterable<BeanConfiguration<? super T>> beanConfigurations, Class<? super T> clazz,
+			Class<?>... parameterTypes) throws Exception {
+		return (ConstrainedExecutable) findConstrainedElement(
+				beanConfigurations,
+				clazz.getConstructor( parameterTypes )
+		);
+	}
+
+	protected <T> ConstrainedType findConstrainedType(Iterable<BeanConfiguration<? super T>> beanConfigurations,
+													  Class<? super T> type) {
+		for ( BeanConfiguration<?> oneConfiguration : beanConfigurations ) {
+			for ( ConstrainedElement constrainedElement : oneConfiguration.getConstrainedElements() ) {
+				if ( constrainedElement.getLocation().getMember() == null ) {
+					ConstrainedType constrainedType = (ConstrainedType) constrainedElement;
+					if ( constrainedType.getLocation().getDeclaringClass().equals( type ) ) {
+						return constrainedType;
+					}
+				}
+			}
+		}
+
+		throw new RuntimeException( "Found no constrained element for type " + type );
+	}
+
+	protected ConstrainedElement findConstrainedElement(Iterable<? extends BeanConfiguration<?>> beanConfigurations,
+														Member member) {
+		for ( BeanConfiguration<?> oneConfiguration : beanConfigurations ) {
+			for ( ConstrainedElement constrainedElement : oneConfiguration.getConstrainedElements() ) {
+				if ( constrainedElement.getLocation().getMember().equals( member ) ) {
+					return constrainedElement;
+				}
+			}
+		}
+
+		throw new RuntimeException( "Found no constrained element for " + member );
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeUseAnnotationMetaDataProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeUseAnnotationMetaDataProviderTest.java
@@ -1,0 +1,293 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.metadata.provider;
+
+import java.lang.annotation.Annotation;
+import java.util.Iterator;
+import java.util.List;
+import javax.validation.constraints.Size;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
+import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.metadata.core.MetaConstraint;
+import org.hibernate.validator.internal.metadata.provider.TypeUseAnnotationMetaDataProvider;
+import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
+import org.hibernate.validator.test.internal.util.NotBlankTypeUse;
+import org.hibernate.validator.test.internal.util.NotNullTypeUse;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+
+/**
+ * Tests for {@link org.hibernate.validator.internal.metadata.provider.TypeUseAnnotationMetaDataProvider}.
+ *
+ * @author Khalid Alqinyah
+ */
+public class TypeUseAnnotationMetaDataProviderTest extends AnnotationMetaDataProviderTestBase {
+
+	private TypeUseAnnotationMetaDataProvider provider;
+
+	@BeforeClass
+	public void setup() {
+		provider = new TypeUseAnnotationMetaDataProvider(
+				new ConstraintHelper(),
+				new DefaultParameterNameProvider(),
+				new AnnotationProcessingOptionsImpl()
+		);
+	}
+
+	@Test
+	public void testFormalParameterField() throws Exception {
+		// T t;
+		List<BeanConfiguration<? super Bar>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				Bar.class
+		);
+
+		ConstrainedField field1 = findConstrainedField( beanConfigurations, Bar.class, "t" );
+		ConstrainedField field2 = findConstrainedField( beanConfigurations, Bar.class, "v" );
+
+		assertThat( field1.getConstraints() ).hasSize( 1 );
+		assertThat( field2.getConstraints() ).hasSize( 2 );
+
+		MetaConstraint<?> constraint = field1.getConstraints().iterator().next();
+		assertThat( constraint.getDescriptor().getAnnotation().annotationType() ).isEqualTo(
+				NotNullTypeUse.class
+		);
+		assertThat( getAnnotationsTypes( field2 ) ).contains(
+				NotBlankTypeUse.class, Size.class
+		);
+	}
+
+	@Test
+	public void testFormalParameterTypeArgument() throws Exception {
+		// List<V> vs;
+		List<BeanConfiguration<? super Bar>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				Bar.class
+		);
+
+		ConstrainedField field = findConstrainedField( beanConfigurations, Bar.class, "vs" );
+		assertThat( field.getConstraints() ).hasSize( 2 );
+		assertThat( getAnnotationsTypes( field ) ).contains(
+				NotNullTypeUse.class, NotBlankTypeUse.class
+		);
+	}
+
+	@Test
+	public void testFormalParameterReturnValue() throws Exception {
+		// V returnV() {..}
+		List<BeanConfiguration<? super Bar>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				Bar.class
+		);
+
+		ConstrainedExecutable executable = findConstrainedMethod( beanConfigurations, Bar.class, "returnV" );
+		assertThat( executable.getConstraints() ).hasSize( 1 );
+		MetaConstraint<?> constraint = executable.getConstraints().iterator().next();
+		assertThat( constraint.getDescriptor().getAnnotation().annotationType() ).isEqualTo(
+				NotBlankTypeUse.class
+		);
+	}
+
+	@Test
+	public void testFormalParameterTypeArgumentReturnValue() throws Exception {
+		// List<V> returnVs() {..}
+		List<BeanConfiguration<? super Bar>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				Bar.class
+		);
+
+		ConstrainedExecutable executable = findConstrainedMethod( beanConfigurations, Bar.class, "returnVs" );
+		assertThat( executable.getConstraints() ).hasSize( 2 );
+		assertThat( getAnnotationsTypes( executable ) ).contains(
+				NotNullTypeUse.class, NotBlankTypeUse.class
+		);
+	}
+
+	@Test
+	public void testFormalParameterForExecutableParameters() throws Exception {
+		// void setValues(T t, V v, List<V> vs) {..}
+		List<BeanConfiguration<? super Bar>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				Bar.class
+		);
+
+		ConstrainedExecutable executable = findConstrainedMethod( beanConfigurations, Bar.class, "setValues", Object.class, CharSequence.class, List.class );
+		ConstrainedParameter firstParameter = executable.getParameterMetaData( 0 );
+		ConstrainedParameter secondParameter = executable.getParameterMetaData( 1 );
+		ConstrainedParameter thirdParameter = executable.getParameterMetaData( 2 );
+
+		assertThat( firstParameter.getConstraints() ).hasSize( 1 );
+		assertThat( secondParameter.getConstraints() ).hasSize( 1 );
+		assertThat( thirdParameter.getConstraints() ).hasSize( 2 );
+
+		MetaConstraint<?> constraint = firstParameter.getConstraints().iterator().next();
+		MetaConstraint<?> constraint2 = secondParameter.getConstraints().iterator().next();
+
+		assertThat( constraint.getDescriptor().getAnnotation().annotationType() ).isEqualTo(
+				NotNullTypeUse.class
+		);
+
+		assertThat( constraint2.getDescriptor().getAnnotation().annotationType() ).isEqualTo(
+				NotBlankTypeUse.class
+		);
+
+		assertThat( getAnnotationsTypes( thirdParameter ) ).contains(
+				NotNullTypeUse.class, NotBlankTypeUse.class
+		);
+	}
+
+	@Test
+	public void testFormalParameterForConstructorParameters() throws Exception {
+		// Bar(T t, V v, List<V> vs) {..}
+		List<BeanConfiguration<? super Bar>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				Bar.class
+		);
+
+		ConstrainedExecutable executable = findConstrainedConstructor( beanConfigurations, Bar.class, Object.class, CharSequence.class, List.class );
+		ConstrainedParameter firstParameter = executable.getParameterMetaData( 0 );
+		ConstrainedParameter secondParameter = executable.getParameterMetaData( 1 );
+		ConstrainedParameter thirdParameter = executable.getParameterMetaData( 2 );
+
+		assertThat( firstParameter.getConstraints() ).hasSize( 1 );
+		assertThat( secondParameter.getConstraints() ).hasSize( 1 );
+		assertThat( thirdParameter.getConstraints() ).hasSize( 2 );
+
+		MetaConstraint<?> constraint = firstParameter.getConstraints().iterator().next();
+		MetaConstraint<?> constraint2 = secondParameter.getConstraints().iterator().next();
+
+		assertThat( constraint.getDescriptor().getAnnotation().annotationType() ).isEqualTo(
+				NotNullTypeUse.class
+		);
+
+		assertThat( constraint2.getDescriptor().getAnnotation().annotationType() ).isEqualTo(
+				NotBlankTypeUse.class
+		);
+
+		assertThat( getAnnotationsTypes( thirdParameter ) ).contains(
+				NotNullTypeUse.class, NotBlankTypeUse.class
+		);
+	}
+
+	@Test
+	public void testFormalParameterSuperclassFields() throws Exception {
+		List<BeanConfiguration<? super Bar>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				Bar.class
+		);
+
+		// For BarBase fields
+		ConstrainedField field1 = findConstrainedField( beanConfigurations, BarBase.class, "s" );
+		ConstrainedField field2 = findConstrainedField( beanConfigurations, BarBase.class, "u" );
+
+		assertThat( field1.getConstraints() ).hasSize( 1 );
+		assertThat( field2.getConstraints() ).hasSize( 1 );
+
+		MetaConstraint<?> constraint1 = field1.getConstraints().iterator().next();
+		MetaConstraint<?> constraint2 = field2.getConstraints().iterator().next();
+
+		assertThat( constraint1.getDescriptor().getAnnotation().annotationType() ).isEqualTo(
+				NotNullTypeUse.class
+		);
+
+		assertThat( constraint2.getDescriptor().getAnnotation().annotationType() ).isEqualTo(
+				NotBlankTypeUse.class
+		);
+	}
+
+	@Test
+	public void testFormalParameterInterfaceReturnValues() throws Exception {
+		List<BeanConfiguration<? super Bar>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				Bar.class
+		);
+
+		// For BarInt return values
+		ConstrainedExecutable executable1 = findConstrainedMethod( beanConfigurations, BarInt.class, "getM" );
+		ConstrainedExecutable executable2 = findConstrainedMethod( beanConfigurations, BarInt.class, "getN" );
+
+		assertThat( executable1.getConstraints() ).hasSize( 1 );
+		assertThat( executable2.getConstraints() ).hasSize( 1 );
+
+		MetaConstraint<?> constraint1 = executable1.getConstraints().iterator().next();
+		MetaConstraint<?> constraint2 = executable2.getConstraints().iterator().next();
+
+		assertThat( constraint1.getDescriptor().getAnnotation().annotationType() ).isEqualTo(
+				NotNullTypeUse.class
+		);
+
+		assertThat( constraint2.getDescriptor().getAnnotation().annotationType() ).isEqualTo(
+				NotBlankTypeUse.class
+		);
+	}
+
+	private List<Class<? extends Annotation>> getAnnotationsTypes(ConstrainedElement constrainedElement) {
+		List<Class<? extends Annotation>> annotationsTypes = newArrayList();
+		Iterator<MetaConstraint<?>> iter = constrainedElement.getConstraints().iterator();
+		while ( iter.hasNext() ) {
+			annotationsTypes.add( iter.next().getDescriptor().getAnnotation().annotationType() );
+		}
+		return annotationsTypes;
+	}
+
+	static class Bar<@NotNullTypeUse T, @NotBlankTypeUse V extends CharSequence> extends BarBase<@NotNullTypeUse Integer, @NotBlankTypeUse String> implements BarInt<@NotNullTypeUse Integer, @NotBlankTypeUse String> {
+		T t;
+
+		@Size
+		V v;
+
+		List<@NotNullTypeUse V> vs;
+
+		public Bar(T t, V v, List<@NotNullTypeUse V> vs) {
+
+		}
+
+		public void setValues(T t, V v, List<@NotNullTypeUse V> vs) {
+
+		}
+
+		public V returnV() {
+			return v;
+		}
+
+		public List<@NotNullTypeUse V> returnVs() {
+			return vs;
+		}
+
+		public Integer getM() {
+			return null;
+		}
+
+		public String getN() {
+			return "";
+		}
+	}
+}
+
+class BarBase<S, U extends CharSequence> {
+	S s;
+
+	U u;
+}
+
+interface BarInt<M, N extends CharSequence> {
+	M getM();
+
+	N getN();
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/NotBlankTypeUse.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/NotBlankTypeUse.java
@@ -1,0 +1,51 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.util;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.NotNull;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A modified version of {@link org.hibernate.validator.constraints.NotBlank} used for testing type arguments
+ * constraints defined as TYPE_USE.
+ *
+ * @author Khalid Alqinyah
+ */
+@Documented
+@Constraint(validatedBy = { NotBlankTypeUseValidator.class })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@ReportAsSingleViolation
+@NotNull
+public @interface NotBlankTypeUse {
+	String message() default "{org.hibernate.validator.constraints.NotBlank.message}";
+	Class<?>[] groups() default { };
+	Class<? extends Payload>[] payload() default { };
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/NotBlankTypeUseValidator.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/NotBlankTypeUseValidator.java
@@ -1,0 +1,39 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.util;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * @see {@link org.hibernate.validator.test.internal.util.NotBlankTypeUse}
+ *
+ * @author Khalid Alqinyah
+ */
+public class NotBlankTypeUseValidator implements ConstraintValidator<NotBlankTypeUse, CharSequence> {
+
+	public void initialize(NotBlankTypeUse annotation) {
+	}
+
+	public boolean isValid(CharSequence charSequence, ConstraintValidatorContext constraintValidatorContext) {
+		if ( charSequence == null ) {
+			return true;
+		}
+
+		return charSequence.toString().trim().length() > 0;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/NotNullTypeUse.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/NotNullTypeUse.java
@@ -1,0 +1,51 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.util;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.NotNull;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A modified version of {@link javax.validation.constraints.NotNull} used for testing type arguments
+ * constraints defined as TYPE_USE.
+ *
+ * @author Khalid Alqinyah
+ */
+@Documented
+@Constraint(validatedBy = { NotNullTypeUseValidator.class })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@ReportAsSingleViolation
+@NotNull
+public @interface NotNullTypeUse {
+	String message() default "{javax.validation.constraints.NotNull.message}";
+	Class<?>[] groups() default { };
+	Class<? extends Payload>[] payload() default { };
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/NotNullTypeUseValidator.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/NotNullTypeUseValidator.java
@@ -1,0 +1,35 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.util;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * @see {@link NotNullTypeUse}
+ *
+ * @author Khalid Alqinyah
+ */
+public class NotNullTypeUseValidator implements ConstraintValidator<NotNullTypeUse, Object> {
+
+	public void initialize(NotNullTypeUse annotation) {
+	}
+
+	public boolean isValid(Object object, ConstraintValidatorContext constraintValidatorContext) {
+		return object != null;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeUseHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeUseHelperTest.java
@@ -1,0 +1,104 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.util;
+
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Field;
+import java.lang.reflect.TypeVariable;
+import java.util.List;
+import java.util.Map;
+
+import org.testng.annotations.Test;
+
+import org.hibernate.validator.internal.util.TypeUseHelper;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests for {@link org.hibernate.validator.internal.util.TypeUseHelper}
+ *
+ * @author Khalid Alqinyah
+ */
+public class TypeUseHelperTest {
+
+	@Test
+	public void testActualTypeArgumentsForAnnotatedType() throws Exception {
+		Field field = Bar.class.getDeclaredField( "map" );
+		List<AnnotatedType> actualArguments = TypeUseHelper.getAnnotatedActualTypeArguments( field.getAnnotatedType() );
+		assertEquals( actualArguments.get( 0 ).getType(), Integer.class, "Actual type argument does not match." );
+		assertEquals( actualArguments.get( 1 ).getType(), String.class, "Actual type argument does not match." );
+	}
+
+	@Test
+	public void testActualTypeArgumentsNotAnnotatedType() throws Exception {
+		Field field = Bar.class.getDeclaredField( "number" );
+		List<AnnotatedType> actualArguments = TypeUseHelper.getAnnotatedActualTypeArguments( field.getAnnotatedType() );
+		assertEquals( actualArguments.size(), 0, "Unexpected actual type arguments" );
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testActualTypeArgumentsNull() {
+		TypeUseHelper.getAnnotatedActualTypeArguments( null );
+	}
+
+	@Test
+	public void testFormalToActual() {
+		Class<?> cls = Bar.class.getSuperclass();
+		AnnotatedType annotatedType = Bar.class.getAnnotatedSuperclass();
+		Map<TypeVariable<?>, AnnotatedType> map = TypeUseHelper.getFormalToActualMap( annotatedType, cls );
+
+		TypeVariable<?> t = BarBase.class.getTypeParameters()[0];
+		TypeVariable<?> v = BarBase.class.getTypeParameters()[1];
+
+		assertEquals( map.get( t ).getType(), Integer.class, "Formal parameter to actual argument mapping does not match." );
+		assertEquals( map.get( v ).getType(), String.class, "Formal parameter to actual argument mapping does not match." );
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testFormalToActualNullClass() {
+		AnnotatedType annotatedType = Bar.class.getAnnotatedSuperclass();
+		TypeUseHelper.getFormalToActualMap( annotatedType, null );
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testFormalToActualNullAnnotatedType() {
+		Class<?> cls = Bar.class.getSuperclass();
+		TypeUseHelper.getFormalToActualMap( null, cls );
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testFormalToActualAllNull() {
+		TypeUseHelper.getFormalToActualMap( null, null );
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testFormalToActualMismatch() throws Exception {
+		Class<?> cls = Bar.class.getSuperclass();
+		AnnotatedType annotatedType = Bar.class.getDeclaredField( "map" ).getAnnotatedType();
+		TypeUseHelper.getFormalToActualMap( annotatedType, cls );
+	}
+
+	class Bar extends BarBase<Integer, String> {
+		Map<Integer, String> map;
+
+		Integer number;
+	}
+
+	class BarBase<T, V> {
+
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -307,6 +307,8 @@
                     <configuration>
                         <source>1.6</source>
                         <target>1.6</target>
+                        <testSource>1.8</testSource>
+                        <testTarget>1.8</testTarget>
                         <testCompilerArgument>-parameters</testCompilerArgument>
                     </configuration>
                 </plugin>

--- a/src/main/build-config/checkstyle.xml
+++ b/src/main/build-config/checkstyle.xml
@@ -45,7 +45,13 @@
         <module name="DefaultComesLast"/>
     </module>
 
+    <!-- Currently, CheckStyle fails on Java 8 syntax. This prevents the testing of new Java 8 features such as type
+    annotations. suppressions.xml contains a list of test files with Java 8 syntax which should not be checked
+    by CheckStyle -->
+    <module name="SuppressionFilter">
+        <property name="file" value="src/main/build-config/suppressions.xml"/>
+    </module>
+
     <!-- Checks that a file ends with a new line  -->
     <module name="NewlineAtEndOfFile"/>
-
 </module>

--- a/src/main/build-config/suppressions.xml
+++ b/src/main/build-config/suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress files="TypeUseAnnotationMetaDataProviderTest.java" checks="[a-zA-Z0-9]*"/>
+</suppressions>


### PR DESCRIPTION
A bit smaller. This PR focuses on discovering and registering type use constraints for the base use cases. 

Cascaded type usage, and the actual validation of the constraints will be in separate PRs to make things easier to track.

Note: you'll need Java 8u20 for this to work. There is a bug with parameters annotated types with earlier JDKs.
