### PR TITLE
HV-877 Supporting type use constraints on type arguments

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ExecutableConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ExecutableConstraintMappingContextImpl.java
@@ -130,12 +130,14 @@ class ExecutableConstraintMappingContextImpl
 	}
 
 	public ConstrainedElement build(ConstraintHelper constraintHelper, ParameterNameProvider parameterNameProvider) {
+		// TODO HV-919 Support specification of type parameter constraints via XML and API
 		return new ConstrainedExecutable(
 				ConfigurationSource.API,
 				ConstraintLocation.forReturnValue( executable ),
 				getParameters( constraintHelper, parameterNameProvider ),
 				crossParameterContext != null ? crossParameterContext.getConstraints( constraintHelper ) : Collections.<MetaConstraint<?>>emptySet(),
 				returnValueContext != null ? returnValueContext.getConstraints( constraintHelper ) : Collections.<MetaConstraint<?>>emptySet(),
+				Collections.<MetaConstraint<?>>emptySet(),
 				returnValueContext != null ? returnValueContext.getGroupConversions() : Collections.<Class<?>, Class<?>>emptyMap(),
 				returnValueContext != null ? returnValueContext.isCascading() : false,
 				returnValueContext != null ? returnValueContext.isUnwrapValidatedValue() : false

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ParameterConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ParameterConstraintMappingContextImpl.java
@@ -16,6 +16,7 @@
  */
 package org.hibernate.validator.internal.cfg.context;
 
+import java.util.Collections;
 import javax.validation.ParameterNameProvider;
 
 import org.hibernate.validator.cfg.ConstraintDef;
@@ -25,6 +26,7 @@ import org.hibernate.validator.cfg.context.MethodConstraintMappingContext;
 import org.hibernate.validator.cfg.context.ParameterConstraintMappingContext;
 import org.hibernate.validator.cfg.context.ReturnValueConstraintMappingContext;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl.ConstraintType;
 import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
@@ -95,6 +97,7 @@ final class ParameterConstraintMappingContextImpl
 	}
 
 	public ConstrainedParameter build(ConstraintHelper constraintHelper, ParameterNameProvider parameterNameProvider) {
+		// TODO HV-919 Support specification of type parameter constraints via XML and API
 		return new ConstrainedParameter(
 				ConfigurationSource.API,
 				ConstraintLocation.forParameter( executableContext.getExecutable(), parameterIndex ),
@@ -102,6 +105,7 @@ final class ParameterConstraintMappingContextImpl
 				parameterIndex,
 				executableContext.getExecutable().getParameterNames( parameterNameProvider ).get( parameterIndex ),
 				getConstraints( constraintHelper ),
+				Collections.<MetaConstraint<?>>emptySet(),
 				groupConversions,
 				isCascading,
 				isUnwrapValidatedValue()

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/PropertyConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/PropertyConstraintMappingContextImpl.java
@@ -20,12 +20,14 @@ import java.lang.annotation.ElementType;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
+import java.util.Collections;
 
 import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.cfg.context.ConstructorConstraintMappingContext;
 import org.hibernate.validator.cfg.context.MethodConstraintMappingContext;
 import org.hibernate.validator.cfg.context.PropertyConstraintMappingContext;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl.ConstraintType;
 import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
@@ -100,11 +102,13 @@ final class PropertyConstraintMappingContextImpl
 	}
 
 	ConstrainedElement build(ConstraintHelper constraintHelper) {
+		// TODO HV-919 Support specification of type parameter constraints via XML and API
 		if ( member instanceof Field ) {
 			return new ConstrainedField(
 					ConfigurationSource.API,
 					ConstraintLocation.forProperty( member ),
 					getConstraints( constraintHelper ),
+					Collections.<MetaConstraint<?>>emptySet(),
 					groupConversions,
 					isCascading,
 					isUnwrapValidatedValue()

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
@@ -28,11 +28,13 @@ import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOption
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider;
+import org.hibernate.validator.internal.metadata.provider.TypeAnnotationAwareMetaDataProvider;
 import org.hibernate.validator.internal.metadata.provider.MetaDataProvider;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.util.ConcurrentReferenceHashMap;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.ExecutableHelper;
+import org.hibernate.validator.internal.util.Version;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.hibernate.validator.internal.util.ConcurrentReferenceHashMap.Option.IDENTITY_COMPARISONS;
@@ -121,11 +123,21 @@ public class BeanMetaDataManager {
 
 
 		AnnotationProcessingOptions annotationProcessingOptions = getAnnotationProcessingOptionsFromNonDefaultProviders();
-		AnnotationMetaDataProvider defaultProvider = new AnnotationMetaDataProvider(
-				constraintHelper,
-				parameterNameProvider,
-				annotationProcessingOptions
-		);
+		AnnotationMetaDataProvider defaultProvider = null;
+		if ( Version.getJavaRelease() >= 8 ) {
+			defaultProvider = new TypeAnnotationAwareMetaDataProvider(
+					constraintHelper,
+					parameterNameProvider,
+					annotationProcessingOptions
+			);
+		}
+		else {
+			defaultProvider = new AnnotationMetaDataProvider(
+					constraintHelper,
+					parameterNameProvider,
+					annotationProcessingOptions
+			);
+		}
 		this.metaDataProviders.add( defaultProvider );
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
@@ -91,6 +91,7 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 			Set<MetaConstraint<?>> returnValueConstraints,
 			List<ParameterMetaData> parameterMetaData,
 			Set<MetaConstraint<?>> crossParameterConstraints,
+			Set<MetaConstraint<?>> typeArgumentsConstraints,
 			Map<Class<?>, Class<?>> returnValueGroupConversions,
 			boolean isCascading,
 			boolean isConstrained,
@@ -113,6 +114,7 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 		this.returnValueMetaData = new ReturnValueMetaData(
 				returnType,
 				returnValueConstraints,
+				typeArgumentsConstraints,
 				isCascading,
 				returnValueGroupConversions,
 				requiresUnwrapping
@@ -286,6 +288,7 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 		private final Set<ConstrainedExecutable> constrainedExecutables = newHashSet();
 		private final ExecutableElement executable;
 		private final Set<MetaConstraint<?>> crossParameterConstraints = newHashSet();
+		private final Set<MetaConstraint<?>> typeArgumentsConstraints = newHashSet();
 		private boolean isConstrained = false;
 
 		/**
@@ -340,6 +343,7 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 			constrainedExecutables.add( constrainedExecutable );
 			isConstrained = isConstrained || constrainedExecutable.isConstrained();
 			crossParameterConstraints.addAll( constrainedExecutable.getCrossParameterConstraints() );
+			typeArgumentsConstraints.addAll( constrainedExecutable.getTypeArgumentsConstraints() );
 
 			addToExecutablesByDeclaringType( constrainedExecutable );
 		}
@@ -376,6 +380,7 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 					adaptOriginsAndImplicitGroups( getConstraints() ),
 					findParameterMetaData(),
 					adaptOriginsAndImplicitGroups( crossParameterConstraints ),
+					typeArgumentsConstraints,
 					getGroupConversions(),
 					isCascading(),
 					isConstrained,

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ReturnValueMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ReturnValueMetaData.java
@@ -46,8 +46,14 @@ public class ReturnValueMetaData extends AbstractConstraintMetaData
 	private final List<Cascadable> cascadables;
 	private final GroupConversionHelper groupConversionHelper;
 
+	/**
+	 * Type arguments constraints for this return value
+	 */
+	private final Set<MetaConstraint<?>> typeArgumentsConstraints;
+
 	public ReturnValueMetaData(Type type,
 							   Set<MetaConstraint<?>> constraints,
+							   Set<MetaConstraint<?>> typeArgumentsConstraints,
 							   boolean isCascading,
 							   Map<Class<?>, Class<?>> groupConversions,
 							   boolean requiresUnwrapping) {
@@ -61,6 +67,7 @@ public class ReturnValueMetaData extends AbstractConstraintMetaData
 				requiresUnwrapping
 		);
 
+		this.typeArgumentsConstraints = Collections.unmodifiableSet( typeArgumentsConstraints );
 		this.cascadables = Collections.unmodifiableList( isCascading ? Arrays.asList( this ) : Collections.<Cascadable>emptyList() );
 		this.groupConversionHelper = new GroupConversionHelper( groupConversions );
 		this.groupConversionHelper.validateGroupConversions( isCascading(), this.toString() );
@@ -84,6 +91,11 @@ public class ReturnValueMetaData extends AbstractConstraintMetaData
 	@Override
 	public ElementType getElementType() {
 		return ElementType.METHOD;
+	}
+
+	@Override
+	public Set<MetaConstraint<?>> getTypeArgumentsConstraints() {
+		return this.typeArgumentsConstraints;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/facets/Cascadable.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/facets/Cascadable.java
@@ -21,6 +21,8 @@ import java.util.Set;
 import javax.validation.ElementKind;
 import javax.validation.metadata.GroupConversionDescriptor;
 
+import org.hibernate.validator.internal.metadata.core.MetaConstraint;
+
 /**
  * Provides a unified view on cascadable elements of all kinds, be it properties
  * of a Java bean, the arguments passed to an executable or the value returned
@@ -67,4 +69,12 @@ public interface Cascadable {
 	 * @return The kind of this cascadable.
 	 */
 	ElementKind getKind();
+
+	/**
+	 * Returns the type arguments constraints for this cascadable.
+	 *
+	 * @return the type arguments constraints for this cascadable, or an empty set if no constrained type arguments are
+	 * found
+	 */
+	Set<MetaConstraint<?>> getTypeArgumentsConstraints();
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/location/ConstraintLocation.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/location/ConstraintLocation.java
@@ -74,6 +74,14 @@ public class ConstraintLocation {
 		);
 	}
 
+	public static ConstraintLocation forTypeArgument(Member member, Type type) {
+		return new ConstraintLocation(
+				member.getDeclaringClass(),
+				member,
+				type
+		);
+	}
+
 	public static ConstraintLocation forReturnValue(ExecutableElement executable) {
 		return new ConstraintLocation(
 				executable.getMember().getDeclaringClass(),

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/TypeAnnotationAwareMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/TypeAnnotationAwareMetaDataProvider.java
@@ -1,0 +1,192 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.internal.metadata.provider;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import javax.validation.ParameterNameProvider;
+
+import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptions;
+import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.metadata.core.MetaConstraint;
+import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
+import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
+import org.hibernate.validator.internal.util.ReflectionHelper;
+import org.hibernate.validator.internal.util.TypeHelper;
+import org.hibernate.validator.internal.util.logging.Log;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
+
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
+/**
+ * Extends {@code AnnotationMetaDataProvider} by discovering and registering type use constraints defined on type
+ * arguments.
+ *
+ * @author Khalid Alqinyah
+ */
+public class TypeAnnotationAwareMetaDataProvider extends AnnotationMetaDataProvider {
+
+	private static final Log log = LoggerFactory.make();
+
+	public TypeAnnotationAwareMetaDataProvider(ConstraintHelper constraintHelper,
+											   ParameterNameProvider parameterNameProvider,
+											   AnnotationProcessingOptions annotationProcessingOptions) {
+		super( constraintHelper, parameterNameProvider, annotationProcessingOptions );
+	}
+
+	@Override
+	protected Set<MetaConstraint<?>> findTypeArgumentsConstraints(Member member) {
+		AnnotatedType annotatedType = null;
+
+		if ( member instanceof Field ) {
+			annotatedType = ( (Field) member ).getAnnotatedType();
+		}
+
+		if ( member instanceof Method ) {
+			annotatedType = ( (Method) member ).getAnnotatedReturnType();
+		}
+
+		return findTypeArgumentsConstraints( member, annotatedType );
+	}
+
+	@Override
+	protected Set<MetaConstraint<?>> findTypeArgumentsConstraints(Member member, int i) {
+		Parameter parameter = ( (Executable) member ).getParameters()[i];
+		try {
+			return findTypeArgumentsConstraints( member, parameter.getAnnotatedType() );
+		}
+		catch ( ArrayIndexOutOfBoundsException ex ) {
+			String message = "Constraints on the parameters of constructors of non-static inner classes " +
+					"are not supported if those parameters have a generic type due to JDK bug JDK-5087240.";
+			log.warn( message, ex );
+			return Collections.emptySet();
+		}
+	}
+
+	private Set<MetaConstraint<?>> findTypeArgumentsConstraints(Member member, AnnotatedType annotatedType) {
+		Set<MetaConstraint<?>> typeArgumentsConstraints = newHashSet();
+		Optional<AnnotatedType> typeArgument = getAnnotatedActualTypeArguments( annotatedType );
+		if ( !typeArgument.isPresent() ) {
+			return Collections.emptySet();
+		}
+
+		List<ConstraintDescriptorImpl<?>> metaData = findTypeUseConstraints( member, typeArgument.get() );
+		Set<MetaConstraint<?>> constraints = convertToTypeArgumentMetaConstraints(
+				metaData,
+				member,
+				typeArgument.get().getType()
+		);
+		typeArgumentsConstraints.addAll( constraints );
+		return typeArgumentsConstraints;
+	}
+
+	/**
+	 * Finds type use annotation constraints defined on the type argument.
+	 */
+	private List<ConstraintDescriptorImpl<?>> findTypeUseConstraints(Member member, AnnotatedType typeArgument) {
+		List<ConstraintDescriptorImpl<?>> metaData = newArrayList();
+
+		for ( Annotation annotation : typeArgument.getAnnotations() ) {
+			metaData.addAll( findConstraintAnnotations( member, annotation, ElementType.TYPE_USE ) );
+		}
+
+		return metaData;
+	}
+
+	/**
+	 * Creates meta constraints for type arguments constraints.
+	 */
+	private Set<MetaConstraint<?>> convertToTypeArgumentMetaConstraints(List<ConstraintDescriptorImpl<?>> constraintDescriptors, Member member, Type type) {
+		Set<MetaConstraint<?>> constraints = newHashSet( constraintDescriptors.size() );
+		for ( ConstraintDescriptorImpl<?> constraintDescription : constraintDescriptors ) {
+			MetaConstraint<?> metaConstraint = createTypeArgumentMetaConstraint( member, constraintDescription, type );
+			constraints.add( metaConstraint );
+		}
+		return constraints;
+	}
+
+	/**
+	 * Creates a {@code MetaConstraint} for a type argument constraint.
+	 */
+	private <A extends Annotation> MetaConstraint<?> createTypeArgumentMetaConstraint(Member member, ConstraintDescriptorImpl<A> descriptor, Type type) {
+		return new MetaConstraint<A>( descriptor, ConstraintLocation.forTypeArgument( member, type ) );
+	}
+
+	/**
+	 * Returns the type argument of a parameterized type. If the type is a {@code Map}, the method returns the value
+	 * type argument. If the type has more than one type argument and is not a Map, the method returns an empty {@code
+	 * Optional}.
+	 */
+	private Optional<AnnotatedType> getAnnotatedActualTypeArguments(AnnotatedType annotatedType) {
+		if ( annotatedType == null ) {
+			return Optional.empty();
+		}
+
+		if ( !TypeHelper.isAssignable( AnnotatedParameterizedType.class, annotatedType.getClass() ) ) {
+			return Optional.empty();
+		}
+
+		AnnotatedType[] annotatedArguments = ( (AnnotatedParameterizedType) annotatedType ).getAnnotatedActualTypeArguments();
+
+		// One type argument, return it
+		if ( annotatedArguments.length == 1 ) {
+			return Optional.of( annotatedArguments[0] );
+		}
+
+		// More than one type argument
+		if ( annotatedArguments.length > 1 ) {
+
+			// If it is a Map, return the value type argument
+			if ( ReflectionHelper.isMap( annotatedType.getType() ) ) {
+				return Optional.of( annotatedArguments[1] );
+			}
+
+			// If it is not a Map, log a message and ignore
+			log.info(
+					"Custom parameterized types with more than one type argument will not be checked for type use constraints."
+			);
+		}
+
+		return Optional.empty();
+	}
+
+	@Override
+	protected boolean unwrapBasedOnType(Class<?> clazz, boolean hasConstrainedTypeArguments) {
+		if ( ReflectionHelper.isIterable( clazz ) ||  ReflectionHelper.isMap( clazz ) ) {
+			return false;
+		}
+
+		if ( hasConstrainedTypeArguments ) {
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedElement.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedElement.java
@@ -55,7 +55,7 @@ public interface ConstrainedElement extends Iterable<MetaConstraint<?>> {
 	 * @author Gunnar Morling
 	 */
 	public enum ConstrainedElementKind {
-		TYPE, FIELD, CONSTRUCTOR, METHOD, PARAMETER
+		TYPE, FIELD, CONSTRUCTOR, METHOD, PARAMETER, TYPE_USE
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedExecutable.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedExecutable.java
@@ -52,6 +52,8 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 	 */
 	private final List<ConstrainedParameter> parameterMetaData;
 
+	private final Set<MetaConstraint<?>> typeArgumentsConstraints;
+
 	private final boolean hasParameterConstraints;
 
 	private final Set<MetaConstraint<?>> crossParameterConstraints;
@@ -61,8 +63,7 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 	 *
 	 * @param source The source of meta data.
 	 * @param location The location of the represented executable.
-	 * @param returnValueConstraints The return value constraints of the represented executable, if
-	 * any.
+	 * @param returnValueConstraints Type arguments constraints, if any.
 	 * @param groupConversions The group conversions of the represented executable, if any.
 	 * @param isCascading Whether a cascaded validation of the represented executable's
 	 * return value shall be performed or not.
@@ -82,6 +83,7 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 				Collections.<ConstrainedParameter>emptyList(),
 				Collections.<MetaConstraint<?>>emptySet(),
 				returnValueConstraints,
+				Collections.<MetaConstraint<?>>emptySet(),
 				groupConversions,
 				isCascading,
 				requiresUnwrapping
@@ -100,6 +102,8 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 	 * @param crossParameterConstraints the cross parameter constraints
 	 * @param returnValueConstraints The return value constraints of the represented executable, if
 	 * any.
+	 * @param typeArgumentsConstraints The return value constraints of the represented executable, if
+	 * any.
 	 * @param groupConversions The group conversions of the represented executable, if any.
 	 * @param isCascading Whether a cascaded validation of the represented executable's
 	 * return value shall be performed or not.
@@ -112,6 +116,7 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 			List<ConstrainedParameter> parameterMetaData,
 			Set<MetaConstraint<?>> crossParameterConstraints,
 			Set<MetaConstraint<?>> returnValueConstraints,
+			Set<MetaConstraint<?>> typeArgumentsConstraints,
 			Map<Class<?>, Class<?>> groupConversions,
 			boolean isCascading,
 			boolean requiresUnwrapping) {
@@ -137,6 +142,9 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 			);
 		}
 
+		this.typeArgumentsConstraints = typeArgumentsConstraints != null ? Collections.unmodifiableSet(
+				typeArgumentsConstraints
+		) : Collections.<MetaConstraint<?>>emptySet();
 		this.crossParameterConstraints = crossParameterConstraints;
 		this.parameterMetaData = Collections.unmodifiableList( parameterMetaData );
 		this.hasParameterConstraints = hasParameterConstraints( parameterMetaData ) || !crossParameterConstraints.isEmpty();
@@ -220,6 +228,10 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 		return executable;
 	}
 
+	public Set<MetaConstraint<?>> getTypeArgumentsConstraints() {
+		return this.typeArgumentsConstraints;
+	}
+
 	@Override
 	public String toString() {
 		return "ConstrainedExecutable [location=" + getLocation()
@@ -290,6 +302,9 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 		Set<MetaConstraint<?>> mergedReturnValueConstraints = newHashSet( constraints );
 		mergedReturnValueConstraints.addAll( other.constraints );
 
+		Set<MetaConstraint<?>> mergedTypeArgumentsConstraints = newHashSet( typeArgumentsConstraints );
+		mergedTypeArgumentsConstraints.addAll( other.typeArgumentsConstraints );
+
 		Map<Class<?>, Class<?>> mergedGroupConversions = newHashMap( groupConversions );
 		mergedGroupConversions.putAll( other.groupConversions );
 
@@ -299,6 +314,7 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 				mergedParameterMetaData,
 				mergedCrossParameterConstraints,
 				mergedReturnValueConstraints,
+				mergedTypeArgumentsConstraints,
 				mergedGroupConversions,
 				isCascading || other.isCascading,
 				requiresUnwrapping || other.requiresUnwrapping

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedField.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedField.java
@@ -16,6 +16,7 @@
 */
 package org.hibernate.validator.internal.metadata.raw;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,12 +31,15 @@ import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
  */
 public class ConstrainedField extends AbstractConstrainedElement {
 
+	private final Set<MetaConstraint<?>> typeArgumentsConstraints;
+
 	/**
 	 * Creates a new field meta data object.
 	 *
 	 * @param source The source of meta data.
 	 * @param location The location of the represented field.
 	 * @param constraints The constraints of the represented field, if any.
+	 * @param typeArgumentsConstraints Type arguments constraints, if any.
 	 * @param groupConversions The group conversions of the represented field, if any.
 	 * @param isCascading Whether a cascaded validation of the represented field shall
 	 * be performed or not.
@@ -44,11 +48,20 @@ public class ConstrainedField extends AbstractConstrainedElement {
 	public ConstrainedField(ConfigurationSource source,
 							ConstraintLocation location,
 							Set<MetaConstraint<?>> constraints,
+							Set<MetaConstraint<?>> typeArgumentsConstraints,
 							Map<Class<?>, Class<?>> groupConversions,
 							boolean isCascading,
 							boolean requiresUnwrapping) {
 
 		super( source, ConstrainedElementKind.FIELD, location, constraints, groupConversions, isCascading, requiresUnwrapping );
+
+		this.typeArgumentsConstraints = typeArgumentsConstraints != null ? Collections.unmodifiableSet(
+				typeArgumentsConstraints
+		) : Collections.<MetaConstraint<?>>emptySet();
+	}
+
+	public Set<MetaConstraint<?>> getTypeArgumentsConstraints() {
+		return this.typeArgumentsConstraints;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedParameter.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedParameter.java
@@ -37,6 +37,7 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 	private final Type type;
 	private final String name;
 	private final int index;
+	private final Set<MetaConstraint<?>> typeArgumentsConstraints;
 
 	public ConstrainedParameter(ConfigurationSource source,
 								ConstraintLocation location,
@@ -49,6 +50,7 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 				type,
 				index,
 				name,
+				Collections.<MetaConstraint<?>>emptySet(),
 				Collections.<MetaConstraint<?>>emptySet(),
 				Collections.<Class<?>, Class<?>>emptyMap(),
 				false,
@@ -66,6 +68,7 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 	 * @param name The name of the represented parameter.
 	 * @param constraints The constraints of the represented method parameter, if
 	 * any.
+	 * @param typeArgumentsConstraints Type arguments constraints, if any.
 	 * @param groupConversions The group conversions of the represented method parameter, if any.
 	 * @param isCascading Whether a cascaded validation of the represented method
 	 * parameter shall be performed or not.
@@ -77,6 +80,7 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 								int index,
 								String name,
 								Set<MetaConstraint<?>> constraints,
+								Set<MetaConstraint<?>> typeArgumentsConstraints,
 								Map<Class<?>, Class<?>> groupConversions,
 								boolean isCascading,
 								boolean requiresUnwrapping) {
@@ -93,6 +97,9 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 		this.type = type;
 		this.name = name;
 		this.index = index;
+		this.typeArgumentsConstraints = typeArgumentsConstraints != null ? Collections.unmodifiableSet(
+				typeArgumentsConstraints
+		) : Collections.<MetaConstraint<?>>emptySet();
 	}
 
 	public Type getType() {
@@ -105,6 +112,10 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 
 	public int getIndex() {
 		return index;
+	}
+
+	public Set<MetaConstraint<?>> getTypeArgumentsConstraints() {
+		return this.typeArgumentsConstraints;
 	}
 
 	/**
@@ -130,6 +141,9 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 		Set<MetaConstraint<?>> mergedConstraints = newHashSet( constraints );
 		mergedConstraints.addAll( other.constraints );
 
+		Set<MetaConstraint<?>> mergedTypeArgumentsConstraints = newHashSet( typeArgumentsConstraints );
+		mergedTypeArgumentsConstraints.addAll( other.typeArgumentsConstraints );
+
 		Map<Class<?>, Class<?>> mergedGroupConversions = newHashMap( groupConversions );
 		mergedGroupConversions.putAll( other.groupConversions );
 
@@ -140,6 +154,7 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 				index,
 				mergedName,
 				mergedConstraints,
+				mergedTypeArgumentsConstraints,
 				mergedGroupConversions,
 				isCascading || other.isCascading,
 				requiresUnwrapping || other.requiresUnwrapping

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedExecutableBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedExecutableBuilder.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -227,12 +228,14 @@ class ConstrainedExecutableBuilder {
 				annotationProcessingOptions
 		);
 
+		// TODO HV-919 Support specification of type parameter constraints via XML and API
 		return new ConstrainedExecutable(
 				ConfigurationSource.XML,
 				ConstraintLocation.forReturnValue( executableElement ),
 				parameterMetaData,
 				crossParameterConstraints,
 				returnValueConstraints,
+				Collections.<MetaConstraint<?>>emptySet(),
 				groupConversions,
 				isCascaded,
 				false

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedFieldBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedFieldBuilder.java
@@ -19,6 +19,7 @@ package org.hibernate.validator.internal.xml;
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -74,10 +75,12 @@ class ConstrainedFieldBuilder {
 					defaultPackage
 			);
 
+			// TODO HV-919 Support specification of type parameter constraints via XML and API
 			ConstrainedField constrainedField = new ConstrainedField(
 					ConfigurationSource.XML,
 					constraintLocation,
 					metaConstraints,
+					Collections.<MetaConstraint<?>>emptySet(),
 					groupConversions,
 					fieldType.getValid() != null,
 					false

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedGetterBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedGetterBuilder.java
@@ -78,12 +78,14 @@ class ConstrainedGetterBuilder {
 					defaultPackage
 			);
 
+			// TODO HV-919 Support specification of type parameter constraints via XML and API
 			ConstrainedExecutable constrainedGetter = new ConstrainedExecutable(
 					ConfigurationSource.XML,
 					constraintLocation,
 					Collections.<ConstrainedParameter>emptyList(),
 					Collections.<MetaConstraint<?>>emptySet(),
 					metaConstraints,
+					Collections.<MetaConstraint<?>>emptySet(),
 					groupConversions,
 					getterType.getValid() != null,
 					false

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedParameterBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedParameterBuilder.java
@@ -17,6 +17,7 @@
 package org.hibernate.validator.internal.xml;
 
 import java.lang.annotation.ElementType;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,6 +83,7 @@ class ConstrainedParameterBuilder {
 				);
 			}
 
+			// TODO HV-919 Support specification of type parameter constraints via XML and API
 			ConstrainedParameter constrainedParameter = new ConstrainedParameter(
 					ConfigurationSource.XML,
 					constraintLocation,
@@ -89,6 +91,7 @@ class ConstrainedParameterBuilder {
 					i,
 					parameterNames.get( i ),
 					metaConstraints,
+					Collections.<MetaConstraint<?>>emptySet(),
 					groupConversions,
 					parameterType.getValid() != null,
 					false

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeuse/model/TypeUseValidationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeuse/model/TypeUseValidationTest.java
@@ -1,0 +1,264 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.engine.typeuse.model;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+import javax.validation.constraints.Min;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import org.hibernate.validator.test.internal.util.constraints.NotBlankTypeUse;
+import org.hibernate.validator.test.internal.util.constraints.NotNullTypeUse;
+
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutil.ValidatorUtil.getValidator;
+
+/**
+ * @author Khalid Alqinyah
+ */
+public class TypeUseValidationTest {
+
+	private Validator validator;
+
+	@BeforeClass
+	public void setup() {
+		validator = getValidator();
+	}
+
+	@Test
+	public void testTypeUseWithList() {
+		A a = new A();
+		a.names = Arrays.asList( "First", "", null );
+		Set<ConstraintViolation<A>> constraintViolations = validator.validate( a );
+		assertNumberOfViolations( constraintViolations, 3 );
+		assertCorrectPropertyPaths( constraintViolations, "names[1]", "names[2]", "names[2]" );
+		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class, NotBlankTypeUse.class, NotNullTypeUse.class );
+	}
+
+	@Test
+	public void testTypeUseWithMap() {
+		F f = new F();
+		f.namesMap = newHashMap();
+		f.namesMap.put("first", "Name 1");
+		f.namesMap.put("second", "");
+		f.namesMap.put("third", "Name 3");
+		Set<ConstraintViolation<F>> constraintViolations = validator.validate( f );
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "namesMap[second]" );
+		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class );
+	}
+
+	@Test
+	public void testTypeUseWithCustomBean() {
+		B b = new B();
+		b.bars = Arrays.asList( new Bar( 2 ), null );
+		Set<ConstraintViolation<B>> constraintViolations = validator.validate( b );
+		assertNumberOfViolations( constraintViolations, 2 );
+		assertCorrectPropertyPaths( constraintViolations, "bars[1]", "bars[0].number" );
+		assertCorrectConstraintTypes( constraintViolations, Min.class, NotNullTypeUse.class );
+	}
+
+	@Test
+	public void testTypeUseWithOptional() {
+		C c = new C();
+		c.stringOptional = Optional.of( "" );
+		Set<ConstraintViolation<C>> constraintViolations = validator.validate( c );
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "stringOptional" );
+		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class );
+	}
+
+	@Test( expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000182.*" )
+	public void testTypeUseWithCustomType() {
+		// No unwrapper is registered for Baz
+		BazHolder bazHolder = new BazHolder();
+		bazHolder.baz = null;
+		validator.validate( bazHolder );
+	}
+
+	@Test
+	public void testTypeUseWithGetter() {
+		D d = new D();
+		d.strings = Arrays.asList( "", "First", null );
+		Set<ConstraintViolation<D>> constraintViolations = validator.validate( d );
+		assertNumberOfViolations( constraintViolations, 3 );
+		assertCorrectPropertyPaths( constraintViolations, "strings[0]", "strings[2]", "strings[2]" );
+		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class, NotBlankTypeUse.class, NotNullTypeUse.class );
+	}
+
+	@Test
+	public void testTypeUseWithReturnValue() throws Exception {
+		Method method = E.class.getDeclaredMethod( "returnStrings" );
+		Set<ConstraintViolation<E>> constraintViolations = validator.forExecutables().validateReturnValue(
+				new E(),
+				method,
+				Arrays.asList( "First", "", null ) );
+		assertNumberOfViolations( constraintViolations, 3 );
+		assertCorrectPropertyPaths( constraintViolations,
+				"returnStrings.<return value>[1]",
+				"returnStrings.<return value>[2]",
+				"returnStrings.<return value>[2]" );
+		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class, NotBlankTypeUse.class, NotNullTypeUse.class );
+	}
+
+	@Test
+	public void testTypeUseWithExecutableParameter() throws Exception {
+		Method method = H.class.getDeclaredMethod( "setValues", List.class, Optional.class );
+		Object[] values = new Object[] {Arrays.asList( "", "First", null ), Optional.of( "" ) };
+
+		Set<ConstraintViolation<H>> constraintViolations = validator.forExecutables().validateParameters(
+				new H(),
+				method,
+				values );
+		assertNumberOfViolations( constraintViolations, 4 );
+		assertCorrectPropertyPaths( constraintViolations,
+				"setValues.arg0[0]",
+				"setValues.arg0[2]",
+				"setValues.arg0[2]",
+				"setValues.arg1" );
+		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class, NotBlankTypeUse.class, NotNullTypeUse.class, NotBlankTypeUse.class );
+	}
+
+	@Test
+	public void testTypeUseWithConstructorParameter() throws Exception {
+		Constructor<G> constructor = G.class.getDeclaredConstructor( List.class, Optional.class );
+		Object[] values = new Object[] {Arrays.asList( "", "First", null ), Optional.of( "" ) };
+
+		Set<ConstraintViolation<G>> constraintViolations = validator.forExecutables().validateConstructorParameters(
+				constructor,
+				values
+		);
+		assertNumberOfViolations( constraintViolations, 4 );
+		assertCorrectPropertyPaths( constraintViolations,
+				"G.arg0[0]",
+				"G.arg0[2]",
+				"G.arg0[2]",
+				"G.arg1" );
+		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class, NotBlankTypeUse.class, NotNullTypeUse.class, NotBlankTypeUse.class );
+	}
+
+	@Test
+	public void testTypeUseWithMoreThanOneTypeArgument() {
+		// No unwrapper exception shouldn't be thrown, type use constraints are ignored
+		FooHolder fooHolder = new FooHolder();
+		fooHolder.foo = null;
+		validator.validate( fooHolder );
+	}
+
+	@Test
+	public void testTypeUseWithoutValidAnnotation() {
+		I i = new I();
+		i.names = Arrays.asList( "First", "", null );
+		Set<ConstraintViolation<I>> constraintViolations = validator.validate( i );
+		assertNumberOfViolations( constraintViolations, 0 );
+	}
+
+	static class A {
+		@Valid
+		List<@NotNullTypeUse @NotBlankTypeUse String> names;
+	}
+
+	static class B {
+		@Valid
+		List<@NotNullTypeUse Bar> bars;
+	}
+
+	static class C {
+		@Valid
+		Optional<@NotBlankTypeUse String> stringOptional;
+	}
+
+	static class D {
+		List<String> strings;
+
+		@Valid
+		public List<@NotNullTypeUse @NotBlankTypeUse String> getStrings() {
+			return strings;
+		}
+	}
+
+	static class E {
+		List<String> strings;
+
+		@Valid
+		public List<@NotNullTypeUse @NotBlankTypeUse String> returnStrings() {
+			return strings;
+		}
+	}
+
+	static class F {
+		@Valid
+		Map<String, @NotBlankTypeUse String> namesMap;
+	}
+
+	static class G {
+		public G(@Valid List<@NotNullTypeUse @NotBlankTypeUse String> names, @Valid Optional<@NotBlankTypeUse String> optionalParameter) {
+
+		}
+	}
+
+	static class H {
+		public void setValues(@Valid List<@NotNullTypeUse @NotBlankTypeUse String> listParameter, @Valid Optional<@NotBlankTypeUse String> optionalParameter) {
+
+		}
+	}
+
+	static class I {
+		List<@NotNullTypeUse @NotBlankTypeUse String> names;
+	}
+
+	static class Bar {
+		@Min(4)
+		Integer number;
+
+		public Bar(Integer number) {
+			this.number = number;
+		}
+	}
+
+	static class BazHolder {
+		@Valid
+		Baz<@NotNullTypeUse String> baz;
+	}
+
+	class Baz<T> {
+
+	}
+
+	class FooHolder {
+		@Valid
+		Foo<@NotNullTypeUse Integer, @NotBlankTypeUse String> foo;
+	}
+
+	class Foo<T, V> {
+
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
@@ -21,7 +21,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
-import java.lang.reflect.Member;
 import java.util.List;
 import java.util.Map;
 
@@ -46,7 +45,6 @@ import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
-import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement.ConstrainedElementKind;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
@@ -65,7 +63,7 @@ import static org.testng.Assert.assertTrue;
  *
  * @author Gunnar Morling
  */
-public class AnnotationMetaDataProviderTest {
+public class AnnotationMetaDataProviderTest extends AnnotationMetaDataProviderTestBase {
 
 	private AnnotationMetaDataProvider provider;
 
@@ -412,57 +410,6 @@ public class AnnotationMetaDataProviderTest {
 		);
 
 		assertTrue( constrainedMethod.getParameterMetaData( 0 ).requiresUnwrapping() );
-	}
-
-	private <T> ConstrainedField findConstrainedField(Iterable<BeanConfiguration<? super T>> beanConfigurations,
-			Class<? super T> clazz, String fieldName) throws Exception {
-		return (ConstrainedField) findConstrainedElement( beanConfigurations, clazz.getDeclaredField( fieldName ) );
-	}
-
-	private <T> ConstrainedExecutable findConstrainedMethod(Iterable<BeanConfiguration<? super T>> beanConfigurations,
-			Class<? super T> clazz, String methodName, Class<?>... parameterTypes) throws Exception {
-		return (ConstrainedExecutable) findConstrainedElement(
-				beanConfigurations,
-				clazz.getMethod( methodName, parameterTypes )
-		);
-	}
-
-	private <T> ConstrainedExecutable findConstrainedConstructor(
-			Iterable<BeanConfiguration<? super T>> beanConfigurations, Class<? super T> clazz,
-			Class<?>... parameterTypes) throws Exception {
-		return (ConstrainedExecutable) findConstrainedElement(
-				beanConfigurations,
-				clazz.getConstructor( parameterTypes )
-		);
-	}
-
-	private <T> ConstrainedType findConstrainedType(Iterable<BeanConfiguration<? super T>> beanConfigurations,
-			Class<? super T> type) {
-		for ( BeanConfiguration<?> oneConfiguration : beanConfigurations ) {
-			for ( ConstrainedElement constrainedElement : oneConfiguration.getConstrainedElements() ) {
-				if ( constrainedElement.getLocation().getMember() == null ) {
-					ConstrainedType constrainedType = (ConstrainedType) constrainedElement;
-					if ( constrainedType.getLocation().getDeclaringClass().equals( type ) ) {
-						return constrainedType;
-					}
-				}
-			}
-		}
-
-		throw new RuntimeException( "Found no constrained element for type " + type );
-	}
-
-	private ConstrainedElement findConstrainedElement(Iterable<? extends BeanConfiguration<?>> beanConfigurations,
-			Member member) {
-		for ( BeanConfiguration<?> oneConfiguration : beanConfigurations ) {
-			for ( ConstrainedElement constrainedElement : oneConfiguration.getConstrainedElements() ) {
-				if ( constrainedElement.getLocation().getMember().equals( member ) ) {
-					return constrainedElement;
-				}
-			}
-		}
-
-		throw new RuntimeException( "Found no constrained element for " + member );
 	}
 
 	private static class Foo {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTestBase.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTestBase.java
@@ -1,0 +1,83 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.metadata.provider;
+
+import java.lang.reflect.Member;
+
+import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
+
+/**
+ * @author Gunnar Morling
+ */
+public abstract class AnnotationMetaDataProviderTestBase {
+
+	protected <T> ConstrainedField findConstrainedField(Iterable<BeanConfiguration<? super T>> beanConfigurations,
+														Class<? super T> clazz, String fieldName) throws Exception {
+		return (ConstrainedField) findConstrainedElement( beanConfigurations, clazz.getDeclaredField( fieldName ) );
+	}
+
+	protected <T> ConstrainedExecutable findConstrainedMethod(Iterable<BeanConfiguration<? super T>> beanConfigurations,
+															  Class<? super T> clazz, String methodName, Class<?>... parameterTypes)
+			throws Exception {
+		return (ConstrainedExecutable) findConstrainedElement(
+				beanConfigurations,
+				clazz.getMethod( methodName, parameterTypes )
+		);
+	}
+
+	protected <T> ConstrainedExecutable findConstrainedConstructor(
+			Iterable<BeanConfiguration<? super T>> beanConfigurations, Class<? super T> clazz,
+			Class<?>... parameterTypes) throws Exception {
+		return (ConstrainedExecutable) findConstrainedElement(
+				beanConfigurations,
+				clazz.getConstructor( parameterTypes )
+		);
+	}
+
+	protected <T> ConstrainedType findConstrainedType(Iterable<BeanConfiguration<? super T>> beanConfigurations,
+													  Class<? super T> type) {
+		for ( BeanConfiguration<?> oneConfiguration : beanConfigurations ) {
+			for ( ConstrainedElement constrainedElement : oneConfiguration.getConstrainedElements() ) {
+				if ( constrainedElement.getLocation().getMember() == null ) {
+					ConstrainedType constrainedType = (ConstrainedType) constrainedElement;
+					if ( constrainedType.getLocation().getDeclaringClass().equals( type ) ) {
+						return constrainedType;
+					}
+				}
+			}
+		}
+
+		throw new RuntimeException( "Found no constrained element for type " + type );
+	}
+
+	protected ConstrainedElement findConstrainedElement(Iterable<? extends BeanConfiguration<?>> beanConfigurations,
+														Member member) {
+		for ( BeanConfiguration<?> oneConfiguration : beanConfigurations ) {
+			for ( ConstrainedElement constrainedElement : oneConfiguration.getConstrainedElements() ) {
+				if ( constrainedElement.getLocation().getMember().equals( member ) ) {
+					return constrainedElement;
+				}
+			}
+		}
+
+		throw new RuntimeException( "Found no constrained element for " + member );
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationAwareMetaDataProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationAwareMetaDataProviderTest.java
@@ -1,0 +1,178 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.metadata.provider;
+
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
+import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.metadata.core.MetaConstraint;
+import org.hibernate.validator.internal.metadata.provider.TypeAnnotationAwareMetaDataProvider;
+import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
+import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
+import org.hibernate.validator.test.internal.util.constraints.NotBlankTypeUse;
+import org.hibernate.validator.test.internal.util.constraints.NotNullTypeUse;
+
+import static org.fest.assertions.Assertions.assertThat;
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+
+/**
+ * Tests for {@link org.hibernate.validator.internal.metadata.provider.TypeAnnotationAwareMetaDataProvider}.
+ *
+ * @author Khalid Alqinyah
+ */
+public class TypeAnnotationAwareMetaDataProviderTest extends AnnotationMetaDataProviderTestBase {
+
+	private TypeAnnotationAwareMetaDataProvider provider;
+
+	@BeforeClass
+	public void setup() {
+		provider = new TypeAnnotationAwareMetaDataProvider(
+				new ConstraintHelper(),
+				new DefaultParameterNameProvider(),
+				new AnnotationProcessingOptionsImpl()
+		);
+	}
+
+	@Test
+	public void testFieldTypeArgument() throws Exception {
+		List<BeanConfiguration<? super A>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				A.class
+		);
+
+		ConstrainedField field = findConstrainedField( beanConfigurations, A.class, "names" );
+		assertThat( field.getTypeArgumentsConstraints() ).hasSize( 2 );
+		assertThat( getAnnotationsTypes( field.getTypeArgumentsConstraints() ) ).contains(
+				NotNullTypeUse.class, NotBlankTypeUse.class
+		);
+	}
+
+	@Test
+	public void testGetterTypeArgument() throws Exception {
+		List<BeanConfiguration<? super B>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				B.class
+		);
+
+		ConstrainedExecutable executable = findConstrainedMethod( beanConfigurations, B.class, "getNames" );
+		assertThat( executable.getTypeArgumentsConstraints() ).hasSize( 2 );
+		assertThat( getAnnotationsTypes( executable.getTypeArgumentsConstraints() ) ).contains(
+				NotNullTypeUse.class, NotBlankTypeUse.class
+		);
+	}
+
+	@Test
+	public void testReturnValueTypeArgument() throws Exception {
+		List<BeanConfiguration<? super C>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				C.class
+		);
+
+		ConstrainedExecutable executable = findConstrainedMethod( beanConfigurations, C.class, "returnNames" );
+		assertThat( executable.getTypeArgumentsConstraints() ).hasSize( 2 );
+		assertThat( getAnnotationsTypes( executable.getTypeArgumentsConstraints() ) ).contains(
+				NotNullTypeUse.class, NotBlankTypeUse.class
+		);
+	}
+
+	@Test
+	public void testExecutableParameterTypeArgument() throws Exception {
+		List<BeanConfiguration<? super D>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				D.class
+		);
+
+		ConstrainedExecutable executable = findConstrainedMethod(
+				beanConfigurations,
+				D.class,
+				"setValues",
+				String.class,
+				Integer.class,
+				List.class
+		);
+		ConstrainedParameter parameter = executable.getParameterMetaData( 2 );
+		assertThat( parameter.getTypeArgumentsConstraints() ).hasSize( 2 );
+		assertThat( getAnnotationsTypes( parameter.getTypeArgumentsConstraints() ) ).contains(
+				NotNullTypeUse.class, NotBlankTypeUse.class
+		);
+	}
+
+	@Test
+	public void testConstructorParameterTypeArgument() throws Exception {
+		List<BeanConfiguration<? super E>> beanConfigurations = provider.getBeanConfigurationForHierarchy(
+				E.class
+		);
+
+		ConstrainedExecutable executable = findConstrainedConstructor(
+				beanConfigurations,
+				E.class,
+				String.class,
+				Integer.class,
+				List.class
+		);
+
+		ConstrainedParameter parameter = executable.getParameterMetaData( 2 );
+		assertThat( parameter.getTypeArgumentsConstraints() ).hasSize( 2 );
+		assertThat( getAnnotationsTypes( parameter.getTypeArgumentsConstraints() ) ).contains(
+				NotNullTypeUse.class, NotBlankTypeUse.class
+		);
+	}
+
+	private List<Class<? extends Annotation>> getAnnotationsTypes(Set<MetaConstraint<?>> metaConstraints) {
+		List<Class<? extends Annotation>> annotationsTypes = newArrayList();
+		Iterator<MetaConstraint<?>> iter = metaConstraints.iterator();
+		while ( iter.hasNext() ) {
+			annotationsTypes.add( iter.next().getDescriptor().getAnnotation().annotationType() );
+		}
+		return annotationsTypes;
+	}
+
+	static class A {
+		List<@NotNullTypeUse @NotBlankTypeUse String> names;
+	}
+
+	static class B {
+		public List<@NotNullTypeUse @NotBlankTypeUse String> getNames() {
+			return Collections.emptyList();
+		}
+	}
+
+	static class C {
+		public List<@NotNullTypeUse @NotBlankTypeUse String> returnNames() {
+			return Collections.emptyList();
+		}
+	}
+
+	static class D {
+		public void setValues(String s, Integer i, List<@NotNullTypeUse @NotBlankTypeUse String> numbers) {
+
+		}
+	}
+
+	static class E {
+		public E(String s, Integer i, List<@NotNullTypeUse @NotBlankTypeUse String> numbers) {
+
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/constraints/NotBlankTypeUse.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/constraints/NotBlankTypeUse.java
@@ -1,0 +1,52 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.util.constraints;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+
+import org.hibernate.validator.constraints.NotBlank;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A modified version of {@link org.hibernate.validator.constraints.NotBlank} used for testing type arguments
+ * constraints defined as TYPE_USE.
+ *
+ * @author Khalid Alqinyah
+ */
+@Documented
+@Constraint(validatedBy = { })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@ReportAsSingleViolation
+@NotBlank
+public @interface NotBlankTypeUse {
+	String message() default "{org.hibernate.validator.constraints.NotBlank.message}";
+	Class<?>[] groups() default { };
+	Class<? extends Payload>[] payload() default { };
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/constraints/NotNullTypeUse.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/constraints/NotNullTypeUse.java
@@ -1,0 +1,51 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.test.internal.util.constraints;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.NotNull;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A modified version of {@link javax.validation.constraints.NotNull} used for testing type arguments
+ * constraints defined as TYPE_USE.
+ *
+ * @author Khalid Alqinyah
+ */
+@Documented
+@Constraint(validatedBy = { })
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@ReportAsSingleViolation
+@NotNull
+public @interface NotNullTypeUse {
+	String message() default "{javax.validation.constraints.NotNull.message}";
+	Class<?>[] groups() default { };
+	Class<? extends Payload>[] payload() default { };
+}

--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,7 @@
                 <configuration>
                     <rules>
                         <requireJavaVersion>
-                            <version>[1.8,)</version>
+                            <version>[1.8.0-20,)</version>
                         </requireJavaVersion>
                         <requireMavenVersion>
                             <version>3.0.3</version>
@@ -307,6 +307,8 @@
                     <configuration>
                         <source>1.6</source>
                         <target>1.6</target>
+                        <testSource>1.8</testSource>
+                        <testTarget>1.8</testTarget>
                         <testCompilerArgument>-parameters</testCompilerArgument>
                     </configuration>
                 </plugin>
@@ -320,8 +322,9 @@
                         <failsOnError>true</failsOnError>
                         <violationSeverity>error</violationSeverity>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                        <!-- These classes are imported from other sources and are not re-formatted-->
-                        <excludes>**/ConcurrentReferenceHashMap.java,**/TypeHelper*.java</excludes>
+                        <!-- These classes are imported from other sources and are not re-formatted.
+                        The tests use Java 8 type annotation syntax which is not supported yet by CheckStyle-->
+                        <excludes>**/ConcurrentReferenceHashMap.java,**/TypeHelper*.java,**/TypeAnnotationAwareMetaDataProviderTest.java,**/TypeUseValidationTest.java</excludes>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
This applies to `PropertyMetaData`. After your feedback, I'll continue the work on parameters and return values and I'll extend `ParameterMetaData` and `ReturnValueMetaData`.
