### PR TITLE
HV-879 Recognizing Java 8 date/time types in the annotation processor

### DIFF
--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/util/ConstraintHelper.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/util/ConstraintHelper.java
@@ -38,6 +38,7 @@ import javax.lang.model.util.Types;
 
 import org.hibernate.validator.ap.util.TypeNames.BeanValidationTypes;
 import org.hibernate.validator.ap.util.TypeNames.HibernateValidatorTypes;
+import org.hibernate.validator.ap.util.TypeNames.Java8DateTime;
 import org.hibernate.validator.ap.util.TypeNames.JodaTypes;
 
 /**
@@ -169,6 +170,16 @@ public class ConstraintHelper {
 				JodaTypes.READABLE_PARTIAL,
 				JodaTypes.READABLE_INSTANT
 		);
+		registerAllowedTypesForBuiltInConstraint(
+				BeanValidationTypes.FUTURE,
+				Java8DateTime.CHRONO_LOCAL_DATE,
+				Java8DateTime.CHRONO_LOCAL_DATE_TIME,
+				Java8DateTime.CHRONO_ZONED_DATE_TIME,
+				Java8DateTime.OFFSET_DATE_TIME,
+				Java8DateTime.INSTANT,
+				Java8DateTime.YEAR,
+				Java8DateTime.YEAR_MONTH
+		);
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.MAX, Number.class, String.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.MIN, Number.class, String.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NOT_NULL, Object.class );
@@ -178,6 +189,16 @@ public class ConstraintHelper {
 				BeanValidationTypes.PAST,
 				JodaTypes.READABLE_PARTIAL,
 				JodaTypes.READABLE_INSTANT
+		);
+		registerAllowedTypesForBuiltInConstraint(
+				BeanValidationTypes.PAST,
+				Java8DateTime.CHRONO_LOCAL_DATE,
+				Java8DateTime.CHRONO_LOCAL_DATE_TIME,
+				Java8DateTime.CHRONO_ZONED_DATE_TIME,
+				Java8DateTime.OFFSET_DATE_TIME,
+				Java8DateTime.INSTANT,
+				Java8DateTime.YEAR,
+				Java8DateTime.YEAR_MONTH
 		);
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.PATTERN, String.class );
 		registerAllowedTypesForBuiltInConstraint(

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/util/TypeNames.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/util/TypeNames.java
@@ -81,4 +81,17 @@ public class TypeNames {
 		public static final String READABLE_PARTIAL = ORG_JODA_TIME + ".ReadablePartial";
 		public static final String READABLE_INSTANT = ORG_JODA_TIME + ".ReadableInstant";
 	}
+
+	public static class Java8DateTime {
+
+		private static final String JAVA_TIME = "java.time";
+
+		public static final String CHRONO_LOCAL_DATE = JAVA_TIME + ".chrono.ChronoLocalDate";
+		public static final String CHRONO_LOCAL_DATE_TIME = JAVA_TIME + ".chrono.ChronoLocalDateTime";
+		public static final String CHRONO_ZONED_DATE_TIME = JAVA_TIME + ".chrono.ChronoZonedDateTime";
+		public static final String OFFSET_DATE_TIME = JAVA_TIME + ".OffsetDateTime";
+		public static final String INSTANT = JAVA_TIME + ".Instant";
+		public static final String YEAR = JAVA_TIME + ".Year";
+		public static final String YEAR_MONTH = JAVA_TIME + ".YearMonth";
+	}
 }

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorTest.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.ap.testmodel.FieldLevelValidationUsingBuiltInConstraints;
 import org.hibernate.validator.ap.testmodel.MethodLevelValidationUsingBuiltInConstraints;
 import org.hibernate.validator.ap.testmodel.ModelWithDateConstraints;
+import org.hibernate.validator.ap.testmodel.ModelWithJava8DateTime;
 import org.hibernate.validator.ap.testmodel.ModelWithJodaTypes;
 import org.hibernate.validator.ap.testmodel.ModelWithoutConstraints;
 import org.hibernate.validator.ap.testmodel.MultipleConstraintsOfSameType;
@@ -538,5 +539,17 @@ public class ConstraintValidationProcessorTest extends ConstraintValidationProce
 				new DiagnosticExpectation( Kind.ERROR, 59 ),
 				new DiagnosticExpectation( Kind.ERROR, 60 )
 		);
+	}
+
+	@Test
+	public void timeConstraintsAllowedAtJava8DateTime() {
+
+		File sourceFile = compilerHelper.getSourceFile( ModelWithJava8DateTime.class );
+
+		boolean compilationResult = compilerHelper.compile(
+				new ConstraintValidationProcessor(), diagnostics, sourceFile
+		);
+
+		assertTrue( compilationResult, "Java 8 date/time API types fails at @Future/@Past." );
 	}
 }

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/ModelWithJava8DateTime.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/ModelWithJava8DateTime.java
@@ -1,0 +1,60 @@
+/*
+* JBoss, Home of Professional Open Source
+* Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual contributors
+* by the @authors tag. See the copyright.txt in the distribution for a
+* full listing of individual contributors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+* http://www.apache.org/licenses/LICENSE-2.0
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.hibernate.validator.ap.testmodel;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import javax.validation.constraints.Future;
+import javax.validation.constraints.Past;
+
+/**
+ * @author Khalid Alqinyah
+ */
+public class ModelWithJava8DateTime {
+	@Past
+	@Future
+	public LocalDate localDate;
+
+	@Past
+	@Future
+	public LocalDateTime localDateTime;
+
+	@Past
+	@Future
+	public ZonedDateTime zonedDateTime;
+
+	@Past
+	@Future
+	public Instant instant;
+
+	@Past
+	@Future
+	public OffsetDateTime offsetDateTime;
+
+	@Past
+	@Future
+	public Year year;
+
+	@Past
+	@Future
+	public YearMonth yearMonth;
+}


### PR DESCRIPTION
Next is recognizing type use constraints.
