### PR TITLE
HV-924 Restore compatibility with Java 6

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -644,7 +644,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 	 * @return An iterator over the value of a cascaded property.
 	 */
 	private Iterator<?> createIteratorForCascadedValue(Type type, Object value, ValueContext<?, ?> valueContext) {
-		Iterator<?> iter = Collections.emptyIterator();
+		Iterator<?> iter = Collections.emptyList().iterator();
 		if ( ReflectionHelper.isIterable( type ) ) {
 			iter = ( (Iterable<?>) value ).iterator();
 			valueContext.markCurrentPropertyAsIterable();


### PR DESCRIPTION
Restore compatibility with Java 6 by not using Collections#emptyIterator() and instead using Collections.emptyList().iterator()

https://hibernate.atlassian.net/browse/HV-924
