### PR TITLE
HV-931 - Using NaN and Infinity triggers an Exception

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/DecimalMaxValidatorForNumber.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/DecimalMaxValidatorForNumber.java
@@ -88,4 +88,3 @@ public class DecimalMaxValidatorForNumber implements ConstraintValidator<Decimal
 		return inclusive ? comparisonResult <= 0 : comparisonResult < 0;
 	}
 }
-

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/DecimalMinValidatorForNumber.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/DecimalMinValidatorForNumber.java
@@ -89,4 +89,3 @@ public class DecimalMinValidatorForNumber implements ConstraintValidator<Decimal
 		return inclusive ? comparisonResult >= 0 : comparisonResult > 0;
 	}
 }
-

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/MaxValidatorForNumber.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/MaxValidatorForNumber.java
@@ -72,4 +72,3 @@ public class MaxValidatorForNumber implements ConstraintValidator<Max, Number> {
 		}
 	}
 }
-

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/MinValidatorForNumber.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/MinValidatorForNumber.java
@@ -72,4 +72,3 @@ public class MinValidatorForNumber implements ConstraintValidator<Min, Number> {
 		}
 	}
 }
-

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MaxValidatorForNumberTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MaxValidatorForNumberTest.java
@@ -131,4 +131,3 @@ public class MaxValidatorForNumberTest {
                 assertFalse( constraint.isValid( Float.NaN, null ) );
 	}
 }
-

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MinValidatorForNumberTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MinValidatorForNumberTest.java
@@ -131,4 +131,3 @@ public class MinValidatorForNumberTest {
                 assertFalse( constraint.isValid( Float.NaN, null ) );
 	}
 }
-


### PR DESCRIPTION
This is a proposed fix for https://hibernate.atlassian.net/browse/HV-931.

New tests for NaN, positive and negative infinity have been added to MaxValidatorForNumberTest.java and MinValidatorForNumberTest.java.

The following rules are proposed:
- When the value is NaN, max and min validation will fail.
- When the value is positive infinity, min validation will pass, while max validation will fail.
- When the value is negative infinity, min validation will fail, while max validation will pass.

In addition, an "else if" might have been missing in DecimalMinValidatorForNumber (on line 65 in the original file, line 83 in this pull request).
