### PR TITLE
HV-927 update JSR303 TCK version (in addition, add property jboss.home)

### DIFF
--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -34,6 +34,7 @@
         <jsr303.tck.version>1.0.7.GA</jsr303.tck.version>
         <arquillian.version>1.0.0.CR7</arquillian.version>
         <jbossas.version>7.1.0.Beta1b</jbossas.version>
+        <jboss.home>${project.build.directory}/jboss-as-${jbossas.version}</jboss.home>
         <validation.provider>org.hibernate.validator.HibernateValidator</validation.provider>
         <remote.debug />
     </properties>
@@ -250,7 +251,7 @@
                                 <validation.provider>${validation.provider}</validation.provider>
                             </systemPropertyVariables>
                             <environmentVariables>
-                                 <JBOSS_HOME>${project.build.directory}/jboss-as-${jbossas.version}</JBOSS_HOME>
+                                 <JBOSS_HOME>${jboss.home}</JBOSS_HOME>
                             </environmentVariables>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-927

jboss.home property added to allow testing against latest EAP version.
