### PR TITLE
HV-951: Make expression variables added via context.addExpressionVariable(String, Object) accessible from the ConstraintViolation object.

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConstraintViolationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConstraintViolationImpl.java
@@ -6,14 +6,16 @@
  */
 package org.hibernate.validator.internal.engine;
 
-import java.io.Serializable;
-import java.lang.annotation.ElementType;
+import org.hibernate.validator.internal.util.logging.Log;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
+
 import javax.validation.ConstraintViolation;
 import javax.validation.Path;
 import javax.validation.metadata.ConstraintDescriptor;
-
-import org.hibernate.validator.internal.util.logging.Log;
-import org.hibernate.validator.internal.util.logging.LoggerFactory;
+import java.io.Serializable;
+import java.lang.annotation.ElementType;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * @author Emmanuel Bernard
@@ -30,6 +32,7 @@ public class ConstraintViolationImpl<T> implements ConstraintViolation<T>, Seria
 	private final Object leafBeanInstance;
 	private final ConstraintDescriptor<?> constraintDescriptor;
 	private final String messageTemplate;
+	private final Map<String, Object> expressionVariables;
 	private final Class<T> rootBeanClass;
 	private final ElementType elementType;
 	private final Object[] executableParameters;
@@ -37,16 +40,44 @@ public class ConstraintViolationImpl<T> implements ConstraintViolation<T>, Seria
 	private final int hashCode;
 
 	public static <T> ConstraintViolation<T> forBeanValidation(String messageTemplate,
-			String interpolatedMessage,
-			Class<T> rootBeanClass,
-			T rootBean,
-			Object leafBeanInstance,
-			Object value,
-			Path propertyPath,
-			ConstraintDescriptor<?> constraintDescriptor,
-			ElementType elementType) {
+															   Map<String, Object> expressionVariables,
+															   String interpolatedMessage,
+															   Class<T> rootBeanClass,
+															   T rootBean,
+															   Object leafBeanInstance,
+															   Object value,
+															   Path propertyPath,
+															   ConstraintDescriptor<?> constraintDescriptor,
+															   ElementType elementType) {
 		return new ConstraintViolationImpl<T>(
 				messageTemplate,
+				expressionVariables,
+				interpolatedMessage,
+				rootBeanClass,
+				rootBean,
+				leafBeanInstance,
+				value,
+				propertyPath,
+				constraintDescriptor,
+				elementType,
+				null,
+				null
+		);
+	}
+
+	@Deprecated
+	public static <T> ConstraintViolation<T> forBeanValidation(String messageTemplate,
+															   String interpolatedMessage,
+															   Class<T> rootBeanClass,
+															   T rootBean,
+															   Object leafBeanInstance,
+															   Object value,
+															   Path propertyPath,
+															   ConstraintDescriptor<?> constraintDescriptor,
+															   ElementType elementType) {
+		return new ConstraintViolationImpl<T>(
+				messageTemplate,
+				Collections.<String, Object>emptyMap(),
 				interpolatedMessage,
 				rootBeanClass,
 				rootBean,
@@ -61,17 +92,46 @@ public class ConstraintViolationImpl<T> implements ConstraintViolation<T>, Seria
 	}
 
 	public static <T> ConstraintViolation<T> forParameterValidation(String messageTemplate,
-			String interpolatedMessage,
-			Class<T> rootBeanClass,
-			T rootBean,
-			Object leafBeanInstance,
-			Object value,
-			Path propertyPath,
-			ConstraintDescriptor<?> constraintDescriptor,
-			ElementType elementType,
-			Object[] executableParameters) {
+																	Map<String, Object> expressionVariables,
+																	String interpolatedMessage,
+																	Class<T> rootBeanClass,
+																	T rootBean,
+																	Object leafBeanInstance,
+																	Object value,
+																	Path propertyPath,
+																	ConstraintDescriptor<?> constraintDescriptor,
+																	ElementType elementType,
+																	Object[] executableParameters) {
 		return new ConstraintViolationImpl<T>(
 				messageTemplate,
+				expressionVariables,
+				interpolatedMessage,
+				rootBeanClass,
+				rootBean,
+				leafBeanInstance,
+				value,
+				propertyPath,
+				constraintDescriptor,
+				elementType,
+				executableParameters,
+				null
+		);
+	}
+
+	@Deprecated
+	public static <T> ConstraintViolation<T> forParameterValidation(String messageTemplate,
+																	String interpolatedMessage,
+																	Class<T> rootBeanClass,
+																	T rootBean,
+																	Object leafBeanInstance,
+																	Object value,
+																	Path propertyPath,
+																	ConstraintDescriptor<?> constraintDescriptor,
+																	ElementType elementType,
+																	Object[] executableParameters) {
+		return new ConstraintViolationImpl<T>(
+				messageTemplate,
+				Collections.<String, Object>emptyMap(),
 				interpolatedMessage,
 				rootBeanClass,
 				rootBean,
@@ -86,17 +146,46 @@ public class ConstraintViolationImpl<T> implements ConstraintViolation<T>, Seria
 	}
 
 	public static <T> ConstraintViolation<T> forReturnValueValidation(String messageTemplate,
-			String interpolatedMessage,
-			Class<T> rootBeanClass,
-			T rootBean,
-			Object leafBeanInstance,
-			Object value,
-			Path propertyPath,
-			ConstraintDescriptor<?> constraintDescriptor,
-			ElementType elementType,
-			Object executableReturnValue) {
+																	  Map<String, Object> expressionVariables,
+																	  String interpolatedMessage,
+																	  Class<T> rootBeanClass,
+																	  T rootBean,
+																	  Object leafBeanInstance,
+																	  Object value,
+																	  Path propertyPath,
+																	  ConstraintDescriptor<?> constraintDescriptor,
+																	  ElementType elementType,
+																	  Object executableReturnValue) {
 		return new ConstraintViolationImpl<T>(
 				messageTemplate,
+				expressionVariables,
+				interpolatedMessage,
+				rootBeanClass,
+				rootBean,
+				leafBeanInstance,
+				value,
+				propertyPath,
+				constraintDescriptor,
+				elementType,
+				null,
+				executableReturnValue
+		);
+	}
+
+	@Deprecated
+	public static <T> ConstraintViolation<T> forReturnValueValidation(String messageTemplate,
+																	  String interpolatedMessage,
+																	  Class<T> rootBeanClass,
+																	  T rootBean,
+																	  Object leafBeanInstance,
+																	  Object value,
+																	  Path propertyPath,
+																	  ConstraintDescriptor<?> constraintDescriptor,
+																	  ElementType elementType,
+																	  Object executableReturnValue) {
+		return new ConstraintViolationImpl<T>(
+				messageTemplate,
+				Collections.<String, Object>emptyMap(),
 				interpolatedMessage,
 				rootBeanClass,
 				rootBean,
@@ -111,6 +200,7 @@ public class ConstraintViolationImpl<T> implements ConstraintViolation<T>, Seria
 	}
 
 	private ConstraintViolationImpl(String messageTemplate,
+			Map<String, Object> expressionVariables,
 			String interpolatedMessage,
 			Class<T> rootBeanClass,
 			T rootBean,
@@ -122,6 +212,7 @@ public class ConstraintViolationImpl<T> implements ConstraintViolation<T>, Seria
 			Object[] executableParameters,
 			Object executableReturnValue) {
 		this.messageTemplate = messageTemplate;
+		this.expressionVariables = expressionVariables;
 		this.interpolatedMessage = interpolatedMessage;
 		this.rootBean = rootBean;
 		this.value = value;
@@ -144,6 +235,14 @@ public class ConstraintViolationImpl<T> implements ConstraintViolation<T>, Seria
 	@Override
 	public final String getMessageTemplate() {
 		return messageTemplate;
+	}
+
+	/**
+	 *
+	 * @return the expression variables added using {@link org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl#addExpressionVariable(String, Object)}
+	 */
+	public Map<String, Object> getExpressionVariables() {
+		return expressionVariables;
 	}
 
 	@Override
@@ -196,6 +295,9 @@ public class ConstraintViolationImpl<T> implements ConstraintViolation<T>, Seria
 
 	@Override
 	// IMPORTANT - some behaviour of Validator depends on the correct implementation of this equals method!
+	// Do not take expressionVariables into account here. If everything else matches, the two CV should be considered
+	// equals (and because of the scary comment above). After all, expressionVariables is just a hint about how we got
+	// to the actual CV.
 	public boolean equals(Object o) {
 		if ( this == o ) {
 			return true;
@@ -254,6 +356,7 @@ public class ConstraintViolationImpl<T> implements ConstraintViolation<T>, Seria
 		return sb.toString();
 	}
 
+	// Same as for equals, do not take expressionVariables into account here.
 	private int createHashCode() {
 		int result = interpolatedMessage != null ? interpolatedMessage.hashCode() : 0;
 		result = 31 * result + ( propertyPath != null ? propertyPath.hashCode() : 0 );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
@@ -6,28 +6,8 @@
  */
 package org.hibernate.validator.internal.engine;
 
-import java.lang.annotation.ElementType;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.lang.reflect.Type;
-import java.util.HashSet;
-import java.util.IdentityHashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import javax.validation.ConstraintValidatorFactory;
-import javax.validation.ConstraintViolation;
-import javax.validation.MessageInterpolator;
-import javax.validation.ParameterNameProvider;
-import javax.validation.Path;
-import javax.validation.TraversableResolver;
-import javax.validation.ValidationException;
-import javax.validation.metadata.ConstraintDescriptor;
-
 import com.fasterxml.classmate.ResolvedType;
 import com.fasterxml.classmate.TypeResolver;
-
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintViolationCreationContext;
@@ -40,6 +20,26 @@ import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.spi.valuehandling.ValidatedValueUnwrapper;
+
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.ConstraintViolation;
+import javax.validation.MessageInterpolator;
+import javax.validation.ParameterNameProvider;
+import javax.validation.Path;
+import javax.validation.TraversableResolver;
+import javax.validation.ValidationException;
+import javax.validation.metadata.ConstraintDescriptor;
+import java.lang.annotation.ElementType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
@@ -292,10 +292,13 @@ public class ValidationContext<T> {
 		);
 		// at this point we make a copy of the path to avoid side effects
 		Path path = PathImpl.createCopy( constraintViolationCreationContext.getPath() );
-
+		//same for expression variables
+		Map<String, Object> expressionVariables =
+				Collections.unmodifiableMap(constraintViolationCreationContext.getExpressionVariables());
 		if ( executableParameters != null ) {
 			return ConstraintViolationImpl.forParameterValidation(
 					messageTemplate,
+					expressionVariables,
 					interpolatedMessage,
 					getRootBeanClass(),
 					getRootBean(),
@@ -310,6 +313,7 @@ public class ValidationContext<T> {
 		else if ( executableReturnValue != null ) {
 			return ConstraintViolationImpl.forReturnValueValidation(
 					messageTemplate,
+					expressionVariables,
 					interpolatedMessage,
 					getRootBeanClass(),
 					getRootBean(),
@@ -324,6 +328,7 @@ public class ValidationContext<T> {
 		else {
 			return ConstraintViolationImpl.forBeanValidation(
 					messageTemplate,
+					expressionVariables,
 					interpolatedMessage,
 					getRootBeanClass(),
 					getRootBean(),

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/HibernateConstraintValidatorContextTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/HibernateConstraintValidatorContextTest.java
@@ -6,11 +6,12 @@
  */
 package org.hibernate.validator.test.internal.engine.constraintvalidation;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import java.util.Set;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
 import javax.validation.Constraint;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -18,10 +19,12 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Payload;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
-
-import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
-import org.hibernate.validator.testutil.TestForIssue;
-import org.testng.annotations.Test;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
@@ -71,6 +74,19 @@ public class HibernateConstraintValidatorContextTest {
 
 		assertNumberOfViolations( constraintViolations, 1 );
 		assertCorrectConstraintViolationMessages( constraintViolations, "the answer is: ${foo}" );
+	}
+
+	@Test
+	public void testExpressionVariablesAreExposedInConstraintViolation() throws Exception {
+		Validator validator = getValidator();
+		Set<ConstraintViolation<Foo>> constraintViolations = validator.validate( new Foo( QUESTION_1 ) );
+
+		assertNumberOfViolations( constraintViolations, 1 );
+
+		Map<String, Object> expressionVariables =
+				((ConstraintViolationImpl<Foo>)constraintViolations.iterator().next()).getExpressionVariables();
+		Assert.assertEquals(1, expressionVariables.size());
+		Assert.assertEquals(42, expressionVariables.get("answer"));
 	}
 
 	public class Foo {


### PR DESCRIPTION
This commit adds a new getExpressionVariables() getter to ConstraintViolationImpl and minor changes to the internals:
 * add an argument to ConstraintViolationImpl private constructor
 * overload ConstraintViolationImpl.forBeanValidation & co. to handle the new constructor argument, and mark previous, overloaded ones as @Deprecated
 * adjust ValidationContext.createConstraintViolation(ValueContext<?, ?>, ConstraintViolationCreationContext, ConstraintDescriptor<?>) to pass expressionVariables as un unmodifiable Map to the overloaded builders
 * unit test :p

Useful for:
 * Single page web applications, when all i18n/l10n/interpolation stuff is handled client side in JS.
 * Web services, where we want to expose constraint violations in a parsable way. WS client may present the error to users, depending on their prefered locale, and do the interpolation itself.