### PR TITLE
adds tests to CPF and CNPJ without mask

### DIFF
--- a/engine/src/test/java/org/hibernate/validator/test/constraints/br/CNPJValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/br/CNPJValidatorTest.java
@@ -25,6 +25,11 @@ public class CNPJValidatorTest {
 				new Company( "91.509.901/0001-69" )
 		);
 		assertNumberOfViolations( violations, 0 );
+
+		violations = ValidatorUtil.getValidator().validate(
+				new Company( "91509901000169" )
+		);
+		assertNumberOfViolations( violations, 0 );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/br/CPFValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/br/CPFValidatorTest.java
@@ -25,6 +25,11 @@ public class CPFValidatorTest {
 				new Person( "134.241.313-00" )
 		);
 		assertNumberOfViolations( violations, 0 );
+
+		violations =  ValidatorUtil.getValidator().validate(
+				new Person( "13424131300" )
+		);
+		assertNumberOfViolations(violations, 0 );
 	}
 
 	@Test
@@ -39,6 +44,17 @@ public class CPFValidatorTest {
 				new Person( "999.999.999-99" )
 		);
 		assertNumberOfViolations( violations, 1 );
+
+		violations = ValidatorUtil.getValidator().validate(
+				new Person( "00000000000" )
+		);
+		assertNumberOfViolations( violations, 1 );
+
+		violations = ValidatorUtil.getValidator().validate(
+				new Person( "99999999999" )
+		);
+		assertNumberOfViolations( violations, 1 );
+
 	}
 
 	@Test


### PR DESCRIPTION
In Brazilian documents, CPF and CNPJ, we may use these information without the mask.
So this test, should work.
So the CPF 134.241.313-00 is valid as 13424131300 is to.
The same thing happend with the CNPJ: 91.509.901/0001-69 and 91509.901000169
I thought in create the other annotations with represents CPF and CNPJ without mask
