### PR TITLE
HV-913 Providing new profile for the "tck-runner" module for executing t...

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You will also need a JDK 8 and Maven 3 (>= 3.0.3). With these prerequisites in p
 
     mvn clean install -s settings-example.xml
 
-There are more build options available as well. For more information refer to [Contributing to Hibernate Validator](http://community.jboss.org/wiki/ContributingtoHibernateValidator).
+There are more build options available as well. For more information refer to [Contributing to Hibernate Validator](http://hibernate.org/validator/contribute/).
 
 ## Hibernate Validator URLs
 

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -165,7 +165,8 @@
                 </property>
             </activation>
             <properties>
-                <arquillian.protocol>Local</arquillian.protocol>
+                <!-- The properties "arquillian.protocol" and "surefire.argLine" are set based on this setting via GMaven-->
+                <with-security-manager>true</with-security-manager>
             </properties>
             <dependencies>
                 <dependency>
@@ -176,6 +177,26 @@
             </dependencies>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>gmaven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>configure-properties</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <source><![CDATA[
+                                        project.properties['arquillian.protocol'] = Boolean.valueOf(pom.properties['with-security-manager']) ? 'LocalSecurityManagerTesting' : 'Local';
+                                        project.properties['surefire.argLine'] = Boolean.valueOf(pom.properties['with-security-manager']) ? '-Djava.security.manager -Djava.security.policy=${project.build.directory}/test-classes/test.policy -Djava.security.debug=access' : '';
+                                        ]]>
+                                    </source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
@@ -190,6 +211,7 @@
                                     <value>true</value>
                                 </property>
                             </systemProperties>
+                            <argLine>${surefire.argLine}</argLine>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -315,48 +337,6 @@
                             <systemPropertyVariables>
                                 <arquillian.launch>incontainer</arquillian.launch>
                             </systemPropertyVariables>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>security-manager</id>
-            <activation>
-                <property>
-                    <name>with-security-manager</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <properties>
-                <arquillian.protocol>LocalSecurityManagerTesting</arquillian.protocol>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.hibernate.beanvalidation.tck</groupId>
-                    <artifactId>beanvalidation-standalone-container-adapter</artifactId>
-                    <version>${tck.version}</version>
-                </dependency>
-            </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <systemProperties>
-                                <property>
-                                    <name>validation.provider</name>
-                                    <value>${validation.provider}</value>
-                                </property>
-                                <property>
-                                    <name>excludeIntegrationTests</name>
-                                    <value>true</value>
-                                </property>
-                            </systemProperties>
-                            <argLine>-Djava.security.manager -Djava.security.policy=${project.build.directory}/test-classes/test.policy -Djava.security.debug=access</argLine>
-                            <!-- For debugging -->
-                            <!-- <argLine>-Djava.security.manager -Djava.security.policy=${project.build.directory}/test-classes/test.policy -Djava.security.debug=access -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=n</argLine> -->
                         </configuration>
                     </plugin>
                 </plugins>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -22,7 +22,6 @@
     <properties>
         <tck.version>1.1.2.Final</tck.version>
         <tck.suite.file>${project.build.directory}/dependency/beanvalidation-tck-tests-suite.xml</tck.suite.file>
-        <arquillian.version>1.0.0.Final</arquillian.version>
         <wildflyTargetDir>${project.build.directory}/wildfly-${wildfly.version}</wildflyTargetDir>
         <validation.provider>org.hibernate.validator.HibernateValidator</validation.provider>
         <remote.debug />
@@ -66,13 +65,11 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>${arquillian.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
             <artifactId>arquillian-protocol-servlet</artifactId>
-            <version>${arquillian.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -318,6 +315,48 @@
                             <systemPropertyVariables>
                                 <arquillian.launch>incontainer</arquillian.launch>
                             </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>security-manager</id>
+            <activation>
+                <property>
+                    <name>with-security-manager</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <arquillian.protocol>LocalSecurityManagerTesting</arquillian.protocol>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.hibernate.beanvalidation.tck</groupId>
+                    <artifactId>beanvalidation-standalone-container-adapter</artifactId>
+                    <version>${tck.version}</version>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <property>
+                                    <name>validation.provider</name>
+                                    <value>${validation.provider}</value>
+                                </property>
+                                <property>
+                                    <name>excludeIntegrationTests</name>
+                                    <value>true</value>
+                                </property>
+                            </systemProperties>
+                            <argLine>-Djava.security.manager -Djava.security.policy=${project.build.directory}/test-classes/test.policy -Djava.security.debug=access</argLine>
+                            <!-- For debugging -->
+                            <!-- <argLine>-Djava.security.manager -Djava.security.policy=${project.build.directory}/test-classes/test.policy -Djava.security.debug=access -Xdebug -Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=n</argLine> -->
                         </configuration>
                     </plugin>
                 </plugins>

--- a/tck-runner/readme.md
+++ b/tck-runner/readme.md
@@ -10,6 +10,16 @@ used when running
 
     $ mvn clean test
 
+By default this will run the tests with a security manager enabled in order to make sure Hibernate Validator invokes
+security-relevant APIs using privileged actions. You can run the tests without the security manager e.g. for analysis
+purposes like this:
+
+    $ mvn clean test -Dwith-security-manager=false
+
+The policy file is located at src/test/resources/test.policy. You may need to adapt the URL of the Hibernate Validator
+engine entry depending on your specific set-up, e.g. when obtaining these classes from engine/target/classes while
+running the tests from within an IDE.
+
 ## In container
 
 You can also run the TCK test against Wildfly. In this case the tests are bundled as war files and executed

--- a/tck-runner/src/main/java/org/hibernate/validator/tckrunner/securitymanager/DelegatingExecutor.java
+++ b/tck-runner/src/main/java/org/hibernate/validator/tckrunner/securitymanager/DelegatingExecutor.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.tckrunner.securitymanager;
+
+/**
+ * Executes a given operation.
+ * <p>
+ * The whole purpose of this class is to establish a frame on the stack which is as close as possible to the running
+ * tests and whose protection domain has no permissions at all. It is separated from the other Arquillian-related
+ * classes which need special permissions on their own.
+ * <p>
+ * This will reveal any invocation of security-relevant methods in the HV code base which don't make use of a
+ * do-privileged block.
+ *
+ * @author Gunnar Morling
+ *
+ */
+public class DelegatingExecutor implements Executor {
+
+	private final Executor delegate;
+
+	public DelegatingExecutor(Executor delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public void invoke(Object... parameters) throws Throwable {
+		delegate.invoke( parameters );
+	}
+}

--- a/tck-runner/src/main/java/org/hibernate/validator/tckrunner/securitymanager/Executor.java
+++ b/tck-runner/src/main/java/org/hibernate/validator/tckrunner/securitymanager/Executor.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.tckrunner.securitymanager;
+
+/**
+ * Executes a given operation.
+ *
+ * @author Gunnar Morling
+ *
+ */
+public interface Executor {
+
+	void invoke(Object... parameters) throws Throwable;
+}

--- a/tck-runner/src/test/java/org/hibernate/validator/tckrunner/securitymanager/TckRunner.java
+++ b/tck-runner/src/test/java/org/hibernate/validator/tckrunner/securitymanager/TckRunner.java
@@ -1,0 +1,73 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.tckrunner.securitymanager;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.beanvalidation.tck.util.IntegrationTestsMethodSelector;
+import org.testng.ITestResult;
+import org.testng.TestListenerAdapter;
+import org.testng.TestNG;
+import org.testng.xml.XmlMethodSelector;
+import org.testng.xml.XmlPackage;
+import org.testng.xml.XmlSuite;
+import org.testng.xml.XmlTest;
+
+/**
+ * Main class for running the test suite programmatically, for debugging purposes.
+ * <p>
+ * Specify the following arguments when running this test:
+ * <pre>
+ * -Dvalidation.provider=org.hibernate.validator.HibernateValidator
+ * -Djava.security.manager=default
+ * -Djava.security.policy=target/test-classes/test.policy
+ * -Djava.security.debug=access
+ * -DexcludeIntegrationTests=true
+ * -Darquillian.protocol=LocalSecurityManagerTesting
+ * -Dorg.jboss.testharness.spi.StandaloneContainers=org.hibernate.jsr303.tck.util.StandaloneContainersImpl
+ * </pre>
+ *
+ * @author Gunnar Morling
+ */
+public class TckRunner {
+
+	public static void main(String[] args) {
+		XmlSuite suite = new XmlSuite();
+		suite.setName( "JSR-349-TCK" );
+
+		XmlTest test = new XmlTest(suite);
+		test.setName("JSR-349-TCK");
+
+		List<XmlPackage> packages = Collections.singletonList( new XmlPackage( "org.hibernate.beanvalidation.tck.tests" ) );
+		test.setXmlPackages( packages );
+
+		// Alternatively e.g. use this for running single tests
+		// List<XmlClass> classes = Collections.singletonList( new XmlClass( ValidateTest.class ) );
+		// test.setXmlClasses( classes );
+
+		XmlMethodSelector selector = new XmlMethodSelector();
+		selector.setClassName( IntegrationTestsMethodSelector.class.getName() );
+		test.setMethodSelectors( Collections.singletonList( selector  ) );
+
+		TestListenerAdapter tla = new TestListenerAdapter();
+		TestNG testng = new TestNG();
+		testng.setXmlSuites( Collections.singletonList( suite ) );
+		testng.addListener(tla);
+		testng.run();
+
+		for ( ITestResult failure: tla.getConfigurationFailures() ) {
+			System.out.println( "Failure: " + failure.getName() );
+			failure.getThrowable().printStackTrace();
+		}
+
+		for ( ITestResult result : tla.getFailedTests() ) {
+			System.out.println( "Failed:" + result.getName() );
+			result.getThrowable().printStackTrace();
+		}
+	}
+}

--- a/tck-runner/src/test/java/org/hibernate/validator/tckrunner/securitymanager/arquillian/LocalSecurityManagerTestingContainerMethodExecutor.java
+++ b/tck-runner/src/test/java/org/hibernate/validator/tckrunner/securitymanager/arquillian/LocalSecurityManagerTestingContainerMethodExecutor.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.tckrunner.securitymanager.arquillian;
+
+import org.jboss.arquillian.container.test.spi.ContainerMethodExecutor;
+import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+
+/**
+ * A custom {@link ContainerMethodExecutor} based on {@link LocalSecurityManagerTestingExecutionEvent}.
+ *
+ * @author Gunnar Morling
+ */
+public class LocalSecurityManagerTestingContainerMethodExecutor implements ContainerMethodExecutor {
+
+	@Inject
+	private Event<LocalSecurityManagerTestingExecutionEvent> event;
+
+	@Inject
+	private Instance<TestResult> testResult;
+
+	@Override
+	public TestResult invoke(TestMethodExecutor testMethodExecutor) {
+		event.fire( new LocalSecurityManagerTestingExecutionEvent( testMethodExecutor ) );
+		return testResult.get();
+	}
+}

--- a/tck-runner/src/test/java/org/hibernate/validator/tckrunner/securitymanager/arquillian/LocalSecurityManagerTestingExecutionEvent.java
+++ b/tck-runner/src/test/java/org/hibernate/validator/tckrunner/securitymanager/arquillian/LocalSecurityManagerTestingExecutionEvent.java
@@ -1,0 +1,80 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.tckrunner.securitymanager.arquillian;
+
+import java.lang.reflect.Method;
+
+import org.hibernate.validator.tckrunner.securitymanager.DelegatingExecutor;
+import org.hibernate.validator.tckrunner.securitymanager.Executor;
+import org.jboss.arquillian.container.test.impl.execution.event.LocalExecutionEvent;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+
+/**
+ * A custom {@link LocalExecutionEvent} which channels execution through a specific protection domain.
+ *
+ * @author Gunnar Morling
+ */
+public class LocalSecurityManagerTestingExecutionEvent extends LocalExecutionEvent {
+
+	public LocalSecurityManagerTestingExecutionEvent(TestMethodExecutor executor) {
+		super( new DelegatingTestMethodExecutor( executor ) );
+	}
+
+	/**
+	 * Invokes the given test method via {@link DelegatingExecutor} which lives in its own protection domain.
+	 *
+	 * @author Gunnar Morling
+	 *
+	 */
+	private static class DelegatingTestMethodExecutor implements TestMethodExecutor {
+
+		private final Executor delegate;
+		private final Method method;
+		private final Object instance;
+
+		public DelegatingTestMethodExecutor(TestMethodExecutor delegate) {
+			this.method = delegate.getMethod();
+			this.instance = delegate.getInstance();
+			this.delegate = new DelegatingExecutor( new ArquillianExecutor( delegate ) );
+		}
+
+		@Override
+		public Method getMethod() {
+			return method;
+		}
+
+		@Override
+		public Object getInstance() {
+			return instance;
+		}
+
+		@Override
+		public void invoke(Object... parameters) throws Throwable {
+			delegate.invoke( parameters );
+		}
+	}
+
+	/**
+	 * Executes a given test via a given Arquillian test executor.
+	 *
+	 * @author Gunnar Morling
+	 *
+	 */
+	private static class ArquillianExecutor implements Executor {
+
+		private final TestMethodExecutor delegate;
+
+		public ArquillianExecutor(TestMethodExecutor delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void invoke(Object... parameters) throws Throwable {
+			delegate.invoke( parameters );
+		}
+	}
+}

--- a/tck-runner/src/test/java/org/hibernate/validator/tckrunner/securitymanager/arquillian/LocalSecurityManagerTestingExtension.java
+++ b/tck-runner/src/test/java/org/hibernate/validator/tckrunner/securitymanager/arquillian/LocalSecurityManagerTestingExtension.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.tckrunner.securitymanager.arquillian;
+
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * An Arquillian extension which contributes a special protocol, {@link LocalSecurityManagerTestingProtocol}.
+ * <p>
+ * This protocol is essentially the same as
+ * {@link org.jboss.arquillian.container.test.impl.client.protocol.local.LocalProtocol}, only that the execution of
+ * tests is channeled through a specific protection domain (basically, "target/classes" of this module, or the
+ * equivalent JAR). Specifying only minimal permissions to this protection domain allows for the identification of code
+ * in the HV JAR which doesn't use privileged actions as required.
+ *
+ * @author Gunnar Morling
+ */
+public class LocalSecurityManagerTestingExtension implements LoadableExtension {
+
+	@Override
+	public void register(ExtensionBuilder builder) {
+		builder.service( Protocol.class, LocalSecurityManagerTestingProtocol.class );
+	}
+}

--- a/tck-runner/src/test/java/org/hibernate/validator/tckrunner/securitymanager/arquillian/LocalSecurityManagerTestingProtocol.java
+++ b/tck-runner/src/test/java/org/hibernate/validator/tckrunner/securitymanager/arquillian/LocalSecurityManagerTestingProtocol.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.tckrunner.securitymanager.arquillian;
+
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.test.impl.client.protocol.local.LocalProtocol;
+import org.jboss.arquillian.container.test.impl.client.protocol.local.LocalProtocolConfiguration;
+import org.jboss.arquillian.container.test.spi.ContainerMethodExecutor;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+
+/**
+ * Extension of {@link LocalProtocol} which uses a special executor,
+ * {@link LocalSecurityManagerTestingContainerMethodExecutor}.
+ *
+ * @author Gunnar Morling
+ */
+public class LocalSecurityManagerTestingProtocol extends LocalProtocol {
+
+	public static final String NAME = "LocalSecurityManagerTesting";
+
+	@Inject
+	private Instance<Injector> injector;
+
+	@Override
+	public ProtocolDescription getDescription() {
+		return new ProtocolDescription( NAME );
+	}
+
+	@Override
+	public ContainerMethodExecutor getExecutor(LocalProtocolConfiguration protocolConfiguration, ProtocolMetaData metaData, CommandCallback callback) {
+		return injector.get().inject( new LocalSecurityManagerTestingContainerMethodExecutor() );
+	}
+}

--- a/tck-runner/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/tck-runner/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,7 @@
+#
+# Hibernate Validator, declare and validate application constraints
+#
+# License: Apache License, Version 2.0
+# See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+#
+org.hibernate.validator.tckrunner.securitymanager.arquillian.LocalSecurityManagerTestingExtension

--- a/tck-runner/src/test/resources/test.policy
+++ b/tck-runner/src/test/resources/test.policy
@@ -5,11 +5,11 @@
  * actions so it can be used within an SM enabled, only giving the required permissions to Hibernate Validator but not
  * other code which uses it.
  *
- * For that purpose this test set up puts one frame onto the call stack (via {@ code DelegatingExecutor}) whose
+ * For that purpose this test set up puts one frame onto the call stack (via {@code DelegatingExecutor}) whose
  * protection domain (target/classes) has no permissions assigned at all. That way any missing privileged actions in
  * Hibernate Validator would lead to an access control exception. All the other domains involved in tests (e.g.
- * Arquillian or TestNG) are assigned with "all permissions" to keep this set up manageable. As the privilege-less
- * DelegatingExecutor frame sits is located in the stack very close to the actual code under test, it is ensured that
+ * Arquillian or TestNG) are assigned with "all permissions" to keep this set-up manageable. As the privilege-less
+ * DelegatingExecutor frame is located in the stack very close to the actual code under test, it is ensured that
  * any possible privileged blocks within these domains will not conceal any missing privileged blocks in Hibernate
  * Validator (only one Arquillian class and the BV TCK domain are located in between and both don't use any privileged
  * actions).
@@ -19,9 +19,23 @@
 /* Hibernate Validator engine and its dependencies */
 /* =============================================== */
 
+// Used during builds which obtain "engine" from the local repo, e.g. mvn clean install -pl tck-runner
+
 // replace with this when debugging in the IDE with workspace resolution
 // grant codeBase "file:/<project-dir>/engine/target/classes/" {
 grant codeBase "file:${localRepository}/org/hibernate/hibernate-validator/${project.version}/hibernate-validator-${project.version}.jar" {
+    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
+
+    // JAXB
+    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.*";
+    permission java.util.PropertyPermission "com.sun.xml.internal.bind.*", "read";
+    permission java.util.PropertyPermission "mapAnyUriToUri", "read";
+};
+
+// Used during aggregator builds also building "engine", e.g. mvn clean install -pl tck-runner -am
+
+grant codeBase "file:${basedir}/../engine/target/hibernate-validator-${project.version}.jar" {
     permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
     permission java.lang.RuntimePermission "accessDeclaredMembers";
 

--- a/tck-runner/src/test/resources/test.policy
+++ b/tck-runner/src/test/resources/test.policy
@@ -1,0 +1,165 @@
+/**
+ * Policy file for running the Bean Validation TCK within a security manager.
+ *
+ * The goal if this is to make sure that all SM-relevant APIs are invoked by Hibernate Validator using privileged
+ * actions so it can be used within an SM enabled, only giving the required permissions to Hibernate Validator but not
+ * other code which uses it.
+ *
+ * For that purpose this test set up puts one frame onto the call stack (via {@ code DelegatingExecutor}) whose
+ * protection domain (target/classes) has no permissions assigned at all. That way any missing privileged actions in
+ * Hibernate Validator would lead to an access control exception. All the other domains involved in tests (e.g.
+ * Arquillian or TestNG) are assigned with "all permissions" to keep this set up manageable. As the privilege-less
+ * DelegatingExecutor frame sits is located in the stack very close to the actual code under test, it is ensured that
+ * any possible privileged blocks within these domains will not conceal any missing privileged blocks in Hibernate
+ * Validator (only one Arquillian class and the BV TCK domain are located in between and both don't use any privileged
+ * actions).
+ */
+
+/* =============================================== */
+/* Hibernate Validator engine and its dependencies */
+/* =============================================== */
+
+// replace with this when debugging in the IDE with workspace resolution
+// grant codeBase "file:/<project-dir>/engine/target/classes/" {
+grant codeBase "file:${localRepository}/org/hibernate/hibernate-validator/${project.version}/hibernate-validator-${project.version}.jar" {
+    permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
+
+    // JAXB
+    permission java.lang.RuntimePermission "accessClassInPackage.com.sun.xml.internal.bind.*";
+    permission java.util.PropertyPermission "com.sun.xml.internal.bind.*", "read";
+    permission java.util.PropertyPermission "mapAnyUriToUri", "read";
+};
+
+grant codeBase "file:${localRepository}/com/fasterxml/classmate/${classmate.version}/classmate-${classmate.version}.jar" {
+    permission java.lang.RuntimePermission "accessDeclaredMembers";
+};
+
+grant codeBase "file:${localRepository}/org/jboss/logging/jboss-logging/3.1.3.GA/jboss-logging-3.1.3.GA.jar" {
+    permission java.util.PropertyPermission "org.jboss.logging.provider", "read";
+};
+
+/* =================== */
+/* Bean Validation API */
+/* =================== */
+
+grant codeBase "file:${localRepository}/javax/validation/validation-api/${bv.api.version}/validation-api-${bv.api.version}.jar" {
+    permission java.io.FilePermission "<<ALL FILES>>", "read";
+};
+
+/* =================== */
+/* Bean Validation TCK */
+/* =================== */
+
+grant codeBase "file:${localRepository}/org/hibernate/beanvalidation/tck/beanvalidation-tck-tests/${tck.version}/beanvalidation-tck-tests-${tck.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/hibernate/beanvalidation/tck/beanvalidation-standalone-container-adapter/${tck.version}/beanvalidation-standalone-container-adapter-${tck.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+/* ========== */
+/* TCK Runner */
+/* ========== */
+
+// Ideally, this domain should have no permissions at all; Only specifically enabling some API calls done by the BV TCK
+// tests (which do not use privileged actions for these)
+grant codeBase "file:${project.build.directory}/classes" {
+    permission java.util.PropertyPermission "validation.provider", "read";
+    permission java.io.FilePermission "${localRepository}/org/hibernate/beanvalidation/tck/beanvalidation-tck-tests/${tck.version}/beanvalidation-tck-tests-${tck.version}.jar", "read";
+    permission java.util.PropertyPermission "user.language", "write";
+};
+
+grant codeBase "file:${project.build.directory}/test-classes" {
+    permission java.security.AllPermission;
+};
+
+/* ===================== */
+/* Arquillian/ShrinkWrap */
+/* ===================== */
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/test/arquillian-test-spi/${arquillian.version}/arquillian-test-spi-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/testng/arquillian-testng-core/${arquillian.version}/arquillian-testng-core-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/core/arquillian-core-spi/${arquillian.version}/arquillian-core-spi-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/test/arquillian-test-impl-base/${arquillian.version}/arquillian-test-impl-base-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/core/arquillian-core-impl-base/${arquillian.version}/arquillian-core-impl-base-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/config/arquillian-config-impl-base/${arquillian.version}/arquillian-config-impl-base-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/config/arquillian-config-impl-base/${arquillian.version}/arquillian-config-impl-base-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/container/arquillian-container-test-impl-base/${arquillian.version}/arquillian-container-test-impl-base-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/container/arquillian-container-impl-base/${arquillian.version}/arquillian-container-impl-base-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/testng/arquillian-testng-container/${arquillian.version}/arquillian-testng-container-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/arquillian/container/arquillian-container-test-spi/${arquillian.version}/arquillian-container-test-spi-${arquillian.version}.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/shrinkwrap/descriptors/shrinkwrap-descriptors-api-base/2.0.0-alpha-3/shrinkwrap-descriptors-api-base-2.0.0-alpha-3.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/shrinkwrap/shrinkwrap-api/1.0.1/shrinkwrap-api-1.0.1.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/jboss/shrinkwrap/shrinkwrap-impl-base/1.0.1/shrinkwrap-impl-base-1.0.1.jar" {
+    permission java.security.AllPermission;
+};
+
+/* ======= */
+/* TestNG  */
+/* ======= */
+
+grant codeBase "file:${localRepository}/org/testng/testng/6.8/testng-6.8.jar" {
+    permission java.security.AllPermission;
+};
+
+// Dependency of TestNG
+grant codeBase "file:${localRepository}/org/beanshell/bsh/2.0b4/bsh-2.0b4.jar" {
+    permission java.security.AllPermission;
+};
+
+/* ========= */
+/* Surefire  */
+/* ========= */
+
+grant codeBase "file:${localRepository}/org/apache/maven/surefire/surefire-booter/2.15/surefire-booter-2.15.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/apache/maven/surefire/surefire-testng/2.15/surefire-testng-2.15.jar" {
+    permission java.security.AllPermission;
+};
+
+grant codeBase "file:${localRepository}/org/apache/maven/surefire/surefire-api/2.15/surefire-api-2.15.jar" {
+    permission java.security.AllPermission;
+};


### PR DESCRIPTION
...he TCK with a security manager enabled

The TCK can be executed with a security manager enabled like this:

    mvn clean install -pl tck-runner/ -Dwith-security-manager

If we agree on the overall approach I'll send a PR to update the docs on the web site  as well.