### PR TITLE
HV-953 Changing message interpolation algorithm to allow constraint defi...

### DIFF
--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -694,16 +694,24 @@ mechanism to register additional constraint definitions. All you have to do is t
 _javax.validation.ConstraintValidator_ to _META-INF/services_. In this service file you list the
 fully qualified classnames of your constraint validator classes (one per line). Hibernate Validator
 will automatically infer the constraint types they apply to.
-See <<example-using-service-file-for-constraint-definitions>> for an example.
+See <<example-using-service-file-for-constraint-definitions,Constraint definition via service file>>
+for an example.
 
 [[example-using-service-file-for-constraint-definitions]]
-.Using _META-INF/services/javax.validation.ConstraintValidator_ for constraint definitions
+._META-INF/services/javax.validation.ConstraintValidator_
+
 ====
 [source]
 ----
+# Assuming a custom constraint annotation @org.mycompany.CheckCase
 org.mycompany.CheckCaseValidator
 ----
 ====
+
+To contribute default messages for your custom constraints, place a ContributorValidationMessages.properties_
+and/or its locale-specific specializations into the same package as your custom constraint annotations.
+In the example above, this would mean _org.mycompany_. If you your constraint annotation are spread
+over multiple packages, you need to specify one properties file per package.
 
 [[section-constraint-definition-contributor]]
 ==== Constraint definitions via +ConstraintDefinitionContributor+

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
@@ -9,8 +9,6 @@ package org.hibernate.validator.messageinterpolation;
 import java.util.Locale;
 
 import org.hibernate.validator.internal.engine.messageinterpolation.InterpolationTerm;
-import org.hibernate.validator.internal.util.logging.Log;
-import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
 
 /**
@@ -23,10 +21,8 @@ import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
  * @author Adam Stawicki
  */
 public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolator {
-	private static final Log log = LoggerFactory.make();
-	
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator defaultResourceBundleLocator) {
-		this(defaultResourceBundleLocator, true);
+		this( defaultResourceBundleLocator, true );
 	}
 
 	public ResourceBundleMessageInterpolator() {
@@ -34,7 +30,7 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator testResourceBundleLocator, boolean cachingEnabled) {
-		super(testResourceBundleLocator, cachingEnabled);
+		super( testResourceBundleLocator, cachingEnabled );
 	}
 
 	@Override
@@ -42,6 +38,4 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 		InterpolationTerm expression = new InterpolationTerm( term, locale );
 		return expression.interpolate( context );
 	}
-	
-	
 }

--- a/engine/src/test/java/org/hibernate/validator/ValidationMessages.java
+++ b/engine/src/test/java/org/hibernate/validator/ValidationMessages.java
@@ -18,6 +18,9 @@ import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
 /**
+ * Allows us to proxy the Hibernate Validator built-in {@code ValidationMessages.properties}.
+ * This way parts of the message interpolation algorithm becomes testable.
+ *
  * @author Hardy Ferentschik
  */
 public class ValidationMessages extends ResourceBundle {
@@ -38,6 +41,7 @@ public class ValidationMessages extends ResourceBundle {
 	}
 
 	private void addTestPropertiesToBundle() {
+		// see ResourceBundleMessageInterpolatorTest#testRecursiveMessageInterpolation
 		messages.put( "replace.in.default.bundle1", "{replace.in.default.bundle2}" );
 		messages.put( "replace.in.default.bundle2", "foobar" );
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/constraintvalidator/ConstraintDefinitionContributorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraintvalidator/ConstraintDefinitionContributorTest.java
@@ -20,6 +20,7 @@ import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutil.ValidatorUtil;
 
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.hibernate.validator.testutil.ValidatorUtil.getValidator;
 import static org.testng.Assert.assertNotNull;
@@ -126,13 +127,36 @@ public class ConstraintDefinitionContributorTest {
 		validator.validate( new Baz() );
 	}
 
+	@Test
+	@TestForIssue( jiraKey = "HV-953")
+	public void constraints_defined_via_constraint_definition_contributor_can_have_default_message() {
+		Set<ConstraintViolation<Foo>> constraintViolations = validator.validate( new Foo() );
+		assertCorrectConstraintViolationMessages( constraintViolations, "MustMatch default message" );
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HV-953")
+	public void user_can_override_default_message_of_constraint_definition_contributor() {
+		Set<ConstraintViolation<Quz>> constraintViolations = validator.validate( new Quz() );
+		assertCorrectConstraintViolationMessages( constraintViolations, "MustNotMatch user message" );
+	}
+
 	public class Foo {
 		// constraint validator defined in service file!
 		@MustMatch("Foo")
 		String getFoo() {
-			return "Foobar";
+			return "Bar";
 		}
 	}
+
+	public class Quz {
+		// constraint validator defined in service file!
+		@MustNotMatch("Foo")
+		String getFoo() {
+			return "Foo";
+		}
+	}
+
 
 	public class Bar {
 		@AcmeConstraint

--- a/engine/src/test/java/org/hibernate/validator/test/constraintvalidator/MustNotMatch.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraintvalidator/MustNotMatch.java
@@ -23,8 +23,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Constraint(validatedBy = { })
 @Target({ METHOD, FIELD })
 @Retention(RUNTIME)
-public @interface MustMatch {
-	String message() default "{org.hibernate.validator.test.constraintvalidator.MustMatch.message}";
+public @interface MustNotMatch {
+	String message() default "{org.hibernate.validator.test.constraintvalidator.MustNotMatch.message}";
 
 	Class<?>[] groups() default { };
 

--- a/engine/src/test/java/org/hibernate/validator/test/constraintvalidator/MustNotMatchValidator.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraintvalidator/MustNotMatchValidator.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.constraintvalidator;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class MustNotMatchValidator implements ConstraintValidator<MustNotMatch, String> {
+
+	private String match;
+
+	@Override
+	public void initialize(MustNotMatch constraintAnnotation) {
+		this.match = constraintAnnotation.value();
+	}
+
+	@Override
+	public boolean isValid(String value, ConstraintValidatorContext context) {
+		if ( value == null ) {
+			return true;
+		}
+
+		return !value.equals( match );
+	}
+}
+
+

--- a/engine/src/test/resources/META-INF/services/javax.validation.ConstraintValidator
+++ b/engine/src/test/resources/META-INF/services/javax.validation.ConstraintValidator
@@ -1,1 +1,2 @@
 org.hibernate.validator.test.constraintvalidator.MustMatchValidator
+org.hibernate.validator.test.constraintvalidator.MustNotMatchValidator

--- a/engine/src/test/resources/ValidationMessages.properties
+++ b/engine/src/test/resources/ValidationMessages.properties
@@ -1,0 +1,2 @@
+# HV-953 - see ConstraintDefinitionContributorTest
+org.hibernate.validator.test.constraintvalidator.MustNotMatch.message=MustNotMatch user message

--- a/engine/src/test/resources/org/hibernate/validator/test/constraintvalidator/ContributorValidationMessages.properties
+++ b/engine/src/test/resources/org/hibernate/validator/test/constraintvalidator/ContributorValidationMessages.properties
@@ -1,0 +1,2 @@
+org.hibernate.validator.test.constraintvalidator.MustMatch.message=MustMatch default message
+org.hibernate.validator.test.constraintvalidator.MustNotMatch.message=MustNotMatch default message


### PR DESCRIPTION
...nition contributors to provide default message bundles

- Bundles must be places into the same package as the custom constraint annotation
- Adding tests for default messages to ConstraintDefinitionContributorTest
- Updating docs
- Removing unused log field in ResourceBundleMessageInterpolator
- Adding comments to org.hibernate.validator.ValidationMessages.java