### PR TITLE
HV-915 Update compiler option for documentation module

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -63,6 +63,15 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <!-- We can keep it 1.8 since we don't have sources in this module
+                         Keeping it at 1.8 will avoid errors when importing the project in eclipse -->
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-915

For the document module we could actually set the JDK to 1.8, I don't think there is any drawback.
This would avoid some errors when importing the project in eclipse.

I'm going to update the contribution guide on the website to explain how to solve the other errors.