### PR TITLE
HV-933 Changing @CPF and @CNPJ to validate w/ or w/o separator character...

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/constraints/br/CNPJ.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/br/CNPJ.java
@@ -14,9 +14,6 @@ import javax.validation.Payload;
 import javax.validation.ReportAsSingleViolation;
 import javax.validation.constraints.Pattern;
 
-import org.hibernate.validator.constraints.Mod11Check;
-import org.hibernate.validator.constraints.Mod11Check.List;
-
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
@@ -30,16 +27,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @author George Gastaldi
  */
 @Pattern(regexp = "([0-9]{2}[.]?[0-9]{3}[.]?[0-9]{3}[/]?[0-9]{4}[-]?[0-9]{2})")
-@List({
-		@Mod11Check(threshold = 9,
-				endIndex = 14,
-				checkDigitIndex = 16,
-				ignoreNonDigitCharacters = true),
-		@Mod11Check(threshold = 9,
-				endIndex = 16,
-				checkDigitIndex = 17,
-				ignoreNonDigitCharacters = true)
-})
 @ReportAsSingleViolation
 @Documented
 @Constraint(validatedBy = { })

--- a/engine/src/main/java/org/hibernate/validator/constraints/br/CPF.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/br/CPF.java
@@ -14,8 +14,6 @@ import javax.validation.Payload;
 import javax.validation.ReportAsSingleViolation;
 import javax.validation.constraints.Pattern;
 
-import org.hibernate.validator.constraints.Mod11Check;
-
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
@@ -42,16 +40,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 		@Pattern(regexp = "^(?:(?!777\\.?777\\.?777-?77).)*$"),
 		@Pattern(regexp = "^(?:(?!888\\.?888\\.?888-?88).)*$"),
 		@Pattern(regexp = "^(?:(?!999\\.?999\\.?999-?99).)*$")
-})
-@Mod11Check.List({
-		@Mod11Check(checkDigitIndex = 12,
-				endIndex = 10,
-				treatCheck10As = '0',
-				ignoreNonDigitCharacters = true),
-		@Mod11Check(checkDigitIndex = 13,
-				endIndex = 12,
-				treatCheck10As = '0',
-				ignoreNonDigitCharacters = true)
 })
 @ReportAsSingleViolation
 @Documented

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/Mod11CheckValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/Mod11CheckValidator.java
@@ -45,24 +45,44 @@ public class Mod11CheckValidator extends ModCheckBase
 	private char treatCheck11As;
 
 	/**
-	 * @return The threshold for the algorithm multiplier multiplier growth
+	 * The threshold for the algorithm multiplier multiplier growth
 	 */
 	private int threshold;
 
 	@Override
 	public void initialize(Mod11Check constraintAnnotation) {
-		super.initialize(
+		initialize(
 				constraintAnnotation.startIndex(),
 				constraintAnnotation.endIndex(),
 				constraintAnnotation.checkDigitIndex(),
-				constraintAnnotation.ignoreNonDigitCharacters()
+				constraintAnnotation.ignoreNonDigitCharacters(),
+				constraintAnnotation.threshold(),
+				constraintAnnotation.treatCheck10As(),
+				constraintAnnotation.treatCheck11As(),
+				constraintAnnotation.processingDirection()
 		);
-		this.threshold = constraintAnnotation.threshold();
+	}
 
-		this.reverseOrder = constraintAnnotation.processingDirection() == ProcessingDirection.LEFT_TO_RIGHT;
+	public void initialize(int startIndex,
+			int endIndex,
+			int checkDigitIndex,
+			boolean ignoreNonDigitCharacters,
+			int threshold,
+			char treatCheck10As,
+			char treatCheck11As,
+			ProcessingDirection direction
+	) {
+		super.initialize(
+				startIndex,
+				endIndex,
+				checkDigitIndex,
+				ignoreNonDigitCharacters
+		);
+		this.threshold = threshold;
+		this.reverseOrder = direction == ProcessingDirection.LEFT_TO_RIGHT;
 
-		this.treatCheck10As = constraintAnnotation.treatCheck10As();
-		this.treatCheck11As = constraintAnnotation.treatCheck11As();
+		this.treatCheck10As = treatCheck10As;
+		this.treatCheck11As = treatCheck11As;
 
 		if ( !Character.isLetterOrDigit( this.treatCheck10As ) ) {
 			throw log.getTreatCheckAsIsNotADigitNorALetterException( this.treatCheck10As );

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/br/CNPJValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/br/CNPJValidator.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.hv.br;
+
+import java.util.regex.Pattern;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.hibernate.validator.constraints.Mod11Check;
+import org.hibernate.validator.constraints.br.CNPJ;
+import org.hibernate.validator.internal.constraintvalidators.hv.Mod11CheckValidator;
+
+/**
+ * @author Hardy Ferentschik
+ */
+public class CNPJValidator implements ConstraintValidator<CNPJ, CharSequence> {
+	private static final Pattern DIGITS_ONLY = Pattern.compile( "\\d+" );
+
+	private final Mod11CheckValidator withSeparatorMod11Validator1 = new Mod11CheckValidator();
+	private final Mod11CheckValidator withSeparatorMod11Validator2 = new Mod11CheckValidator();
+
+	private final Mod11CheckValidator withoutSeparatorMod11Validator1 = new Mod11CheckValidator();
+	private final Mod11CheckValidator withoutSeparatorMod11Validator2 = new Mod11CheckValidator();
+
+	@Override
+	public void initialize(CNPJ constraintAnnotation) {
+		// validates CNPJ strings with separator, eg 91.509.901/0001-69
+		// there are two checksums generated. The first over the digits prior the hyphen with the first
+		// check digit being the digit directly after the hyphen. The second checksum is over all digits
+		// pre hyphen + first check digit. The check digit in this case is the second digit after the hyphen
+		withSeparatorMod11Validator1.initialize(
+				0, 14, 16, true, 9, 'X', '0', Mod11Check.ProcessingDirection.RIGHT_TO_LEFT
+		);
+		withSeparatorMod11Validator2.initialize(
+				0, 16, 17, true, 9, 'X', '0', Mod11Check.ProcessingDirection.RIGHT_TO_LEFT
+		);
+
+		// validates CNPJ strings without separator, eg 91509901000169
+		// checksums as described above, except there are no separator characters
+		withoutSeparatorMod11Validator1.initialize(
+				0, 11, 12, true, 9, 'X', '0', Mod11Check.ProcessingDirection.RIGHT_TO_LEFT
+		);
+		withoutSeparatorMod11Validator2.initialize(
+				0, 12, 13, true, 9, 'X', '0', Mod11Check.ProcessingDirection.RIGHT_TO_LEFT
+		);
+	}
+
+	@Override
+	public boolean isValid(CharSequence value, ConstraintValidatorContext context) {
+		if ( value == null ) {
+			return true;
+		}
+
+		if ( DIGITS_ONLY.matcher( value ).matches() ) {
+			return withoutSeparatorMod11Validator1.isValid( value, context )
+					&& withoutSeparatorMod11Validator2.isValid( value, context );
+		}
+		else {
+			return withSeparatorMod11Validator1.isValid( value, context )
+					&& withSeparatorMod11Validator2.isValid( value, context );
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/br/CPFValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/br/CPFValidator.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.hv.br;
+
+import java.util.regex.Pattern;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.hibernate.validator.constraints.Mod11Check;
+import org.hibernate.validator.constraints.br.CPF;
+import org.hibernate.validator.internal.constraintvalidators.hv.Mod11CheckValidator;
+
+/**
+ * @author Hardy Ferentschik
+ */
+public class CPFValidator implements ConstraintValidator<CPF, CharSequence> {
+	private static final Pattern DIGITS_ONLY = Pattern.compile( "\\d+" );
+
+	private final Mod11CheckValidator withSeparatorMod11Validator1 = new Mod11CheckValidator();
+	private final Mod11CheckValidator withSeparatorMod11Validator2 = new Mod11CheckValidator();
+
+	private final Mod11CheckValidator withoutSeparatorMod11Validator1 = new Mod11CheckValidator();
+	private final Mod11CheckValidator withoutSeparatorMod11Validator2 = new Mod11CheckValidator();
+
+	@Override
+	public void initialize(CPF constraintAnnotation) {
+		// validates CPF strings with separator, eg 134.241.313-00
+		// there are two checksums generated. The first over the digits prior the hyphen with the first
+		// check digit being the digit directly after the hyphen. The second checksum is over all digits
+		// pre hyphen + first check digit. The check digit in this case is the second digit after the hyphen
+		withSeparatorMod11Validator1.initialize(
+				0, 10, 12, true, Integer.MAX_VALUE, '0', '0', Mod11Check.ProcessingDirection.RIGHT_TO_LEFT
+		);
+		withSeparatorMod11Validator2.initialize(
+				0, 12, 13, true, Integer.MAX_VALUE, '0', '0', Mod11Check.ProcessingDirection.RIGHT_TO_LEFT
+		);
+
+		// validates CPF strings without separator, eg 13424131300
+		// checksums as described above, except there are no separator characters
+		withoutSeparatorMod11Validator1.initialize(
+				0, 8, 9, true, Integer.MAX_VALUE, '0', '0', Mod11Check.ProcessingDirection.RIGHT_TO_LEFT
+		);
+		withoutSeparatorMod11Validator2.initialize(
+				0, 9, 10, true, Integer.MAX_VALUE, '0', '0', Mod11Check.ProcessingDirection.RIGHT_TO_LEFT
+		);
+	}
+
+	@Override
+	public boolean isValid(CharSequence value, ConstraintValidatorContext context) {
+		if ( value == null ) {
+			return true;
+		}
+
+		if ( DIGITS_ONLY.matcher( value ).matches() ) {
+			return withoutSeparatorMod11Validator1.isValid( value, context )
+					&& withoutSeparatorMod11Validator2.isValid( value, context );
+		}
+		else {
+			return withSeparatorMod11Validator1.isValid( value, context )
+					&& withSeparatorMod11Validator2.isValid( value, context );
+
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
@@ -48,6 +48,8 @@ import org.hibernate.validator.constraints.ParameterScriptAssert;
 import org.hibernate.validator.constraints.SafeHtml;
 import org.hibernate.validator.constraints.ScriptAssert;
 import org.hibernate.validator.constraints.URL;
+import org.hibernate.validator.constraints.br.CNPJ;
+import org.hibernate.validator.constraints.br.CPF;
 import org.hibernate.validator.internal.constraintvalidators.bv.AssertFalseValidator;
 import org.hibernate.validator.internal.constraintvalidators.bv.AssertTrueValidator;
 import org.hibernate.validator.internal.constraintvalidators.bv.DecimalMaxValidatorForCharSequence;
@@ -108,6 +110,8 @@ import org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidat
 import org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCollection;
 import org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForMap;
 import org.hibernate.validator.internal.constraintvalidators.hv.URLValidator;
+import org.hibernate.validator.internal.constraintvalidators.hv.br.CNPJValidator;
+import org.hibernate.validator.internal.constraintvalidators.hv.br.CPFValidator;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.Version;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -148,6 +152,14 @@ public class ConstraintHelper {
 		constraintList = newArrayList();
 		constraintList.add( AssertTrueValidator.class );
 		builtinConstraints.put( AssertTrue.class, constraintList );
+
+		constraintList = newArrayList();
+		constraintList.add( CNPJValidator.class );
+		builtinConstraints.put( CNPJ.class, constraintList );
+
+		constraintList = newArrayList();
+		constraintList.add( CPFValidator.class );
+		builtinConstraints.put( CPF.class, constraintList );
 
 		constraintList = newArrayList();
 		constraintList.add( DecimalMaxValidatorForNumber.class );

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/br/CNPJValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/br/CNPJValidatorTest.java
@@ -8,31 +8,50 @@ package org.hibernate.validator.test.constraints.br;
 
 import java.util.Set;
 import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
 
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.constraints.br.CNPJ;
 import org.hibernate.validator.testutil.TestForIssue;
-import org.hibernate.validator.testutil.ValidatorUtil;
 
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutil.ValidatorUtil.getValidator;
 
 public class CNPJValidatorTest {
+	private Validator validator;
+
+	@BeforeMethod
+	public void setUp() {
+		validator = getValidator();
+	}
+
 	@Test
 	@TestForIssue(jiraKey = "HV-491")
-	public void testCorrectFormattedCNPJWithReportAsSingleViolation() {
-		Set<ConstraintViolation<Company>> violations = ValidatorUtil.getValidator().validate(
-				new Company( "91.509.901/0001-69" )
-		);
+	public void correct_cnpj_with_separator_validates() {
+		Set<ConstraintViolation<Company>> violations = validator.validate( new Company( "91.509.901/0001-69" ) );
+		assertNumberOfViolations( violations, 0 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-933")
+	public void correct_cnpj_without_separator_validates() {
+		Set<ConstraintViolation<Company>> violations = validator.validate( new Company( "91509901000169" ) );
 		assertNumberOfViolations( violations, 0 );
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HV-491")
-	public void testIncorrectFormattedCNPJWithReportAsSingleViolation() {
-		Set<ConstraintViolation<Company>> violations = ValidatorUtil.getValidator().validate(
-				new Company( "ABCDEF" )
-		);
+	public void incorrect_cnpj_with_separator_creates_constraint_violation() {
+		Set<ConstraintViolation<Company>> violations = validator.validate( new Company( "91.509.901/0001-60" ) );
+		assertNumberOfViolations( violations, 1 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-933")
+	public void incorrect_cnpj_without_separator_creates_constraint_violation() {
+		Set<ConstraintViolation<Company>> violations = validator.validate( new Company( "91509901000160" ) );
 		assertNumberOfViolations( violations, 1 );
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/br/CPFValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/br/CPFValidatorTest.java
@@ -8,100 +8,116 @@ package org.hibernate.validator.test.constraints.br;
 
 import java.util.Set;
 import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
 
+
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.constraints.br.CPF;
 import org.hibernate.validator.testutil.TestForIssue;
-import org.hibernate.validator.testutil.ValidatorUtil;
 
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutil.ValidatorUtil.getValidator;
 
 public class CPFValidatorTest {
+	private String[] invalidCPFs = {
+			"000.000.000-00", "111.111.111-11", "222.222.222-22",
+			"333.333.333-33", "444.444.444-44", "555.555.555-55",
+			"666.666.666-66", "777.777.777-77", "888.888.888-88",
+			"999.999.999-99"
+	};
+
+	private Validator validator;
+
+	@BeforeMethod
+	public void setUp() {
+		validator = getValidator();
+	}
+
 	@Test
 	@TestForIssue(jiraKey = "HV-491")
-	public void testCorrectFormattedCPFWithReportAsSingleViolation() {
-		Set<ConstraintViolation<Person>> violations = ValidatorUtil.getValidator().validate(
-				new Person( "134.241.313-00" )
-		);
+	public void correct_cpf_with_separator_validates() {
+		Set<ConstraintViolation<Person>> violations = validator.validate( new Person( "134.241.313-00" ) );
+		assertNumberOfViolations( violations, 0 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-933")
+	public void correct_cpf_without_separator_validates() {
+		Set<ConstraintViolation<Person>> violations = validator.validate( new Person( "13424131300" ) );
 		assertNumberOfViolations( violations, 0 );
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HV-491")
-	public void testCPFBoundaryConditions() {
-		Set<ConstraintViolation<Person>> violations = ValidatorUtil.getValidator().validate(
-				new Person( "000.000.000-00" )
-		);
-		assertNumberOfViolations( violations, 1 );
-
-		violations = ValidatorUtil.getValidator().validate(
-				new Person( "999.999.999-99" )
-		);
-		assertNumberOfViolations( violations, 1 );
-	}
-
-	@Test
-	@TestForIssue(jiraKey = "HV-491")
-	public void testIncorrectFormattedCPFWithReportAsSingleViolation() {
-		Set<ConstraintViolation<Person>> violations = ValidatorUtil.getValidator().validate(
-				new Person( "48255-77" )
-		);
+	public void incorrect_formatted_cpf_is_invalid() {
+		Set<ConstraintViolation<Person>> violations = validator.validate( new Person( "48255-77" ) );
 		assertNumberOfViolations( violations, 1 );
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HV-808")
-	public void testCPFBoundaryConditionsForAllSameDigitValidMod11() {
-		String[] invalidCPFs = {
-				"000.000.000-00", "111.111.111-11", "222.222.222-22",
-				"333.333.333-33", "444.444.444-44", "555.555.555-55",
-				"666.666.666-66", "777.777.777-77", "888.888.888-88",
-				"999.999.999-99"
-		};
-
-		Set<ConstraintViolation<Person>> violations = null;
-
+	public void any_same_digit_cpf_with_separator_is_invalid() {
 		for ( String cpf : invalidCPFs ) {
-			violations = ValidatorUtil.getValidator().validate(
-					new Person( cpf )
-			);
-
+			Set<ConstraintViolation<Person>> violations = validator.validate( new Person( cpf ) );
 			assertNumberOfViolations( violations, 1 );
+		}
+	}
 
-			violations = ValidatorUtil.getValidator().validate(
-					new Person( cpf.replaceAll( "[^0-9]", "" ) )
-			);
+	@Test
+	@TestForIssue(jiraKey = "HV-933")
+	public void any_same_digit_cpf_without_separator_is_invalid() {
+		for ( String cpf : invalidCPFs ) {
+			String cpfWithoutseparator = cpf.replaceAll( "[^0-9]", "" );
+			Set<ConstraintViolation<Person>> violations = validator.validate( new Person( cpfWithoutseparator ) );
 			assertNumberOfViolations( violations, 1 );
 		}
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HV-808")
-	public void testCorrectFormattedCPFWithReportAsSingleViolationForCheckDigitSelfValidation() {
-		Set<ConstraintViolation<Person>> violations = ValidatorUtil.getValidator().validate(
-				new Person( "378.796.950-01" )
-		);
+	public void valid_cpfs_with_separator_validate() {
+		Set<ConstraintViolation<Person>> violations = validator.validate( new Person( "378.796.950-01" ) );
 		assertNumberOfViolations( violations, 0 );
 
-		violations = ValidatorUtil.getValidator().validate(
-				new Person( "378.796.950-02" )
-		);
-		assertNumberOfViolations( violations, 1 );
+		violations = validator.validate( new Person( "331.814.296-43" ) );
+		assertNumberOfViolations( violations, 0 );
+	}
 
-		violations = ValidatorUtil.getValidator().validate(
-				new Person( "331.814.296-43" )
-		);
+	@Test
+	@TestForIssue(jiraKey = "HV-933")
+	public void valid_cpf_without_separator_validates() {
+		Set<ConstraintViolation<Person>> violations = validator.validate( new Person( "37879695001" ) );
 		assertNumberOfViolations( violations, 0 );
 
-		violations = ValidatorUtil.getValidator().validate(
-				new Person( "331.814.296-52" )
-		);
+		violations = validator.validate( new Person( "33181429643" ) );
+		assertNumberOfViolations( violations, 0 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-808")
+	public void invalid_cpf_with_separator_creates_constraint_violation() {
+		Set<ConstraintViolation<Person>> violations = validator.validate( new Person( "378.796.950-02" ) );
 		assertNumberOfViolations( violations, 1 );
 
-		violations = ValidatorUtil.getValidator().validate(
-				new Person( "331.814.296-51" )
-		);
+		violations = validator.validate( new Person( "331.814.296-52" ) );
+		assertNumberOfViolations( violations, 1 );
+
+		violations = validator.validate( new Person( "331.814.296-51" ) );
+		assertNumberOfViolations( violations, 1 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-933")
+	public void invalid_cpf_without_separator_creates_constraint_violation() {
+		Set<ConstraintViolation<Person>> violations = validator.validate( new Person( "37879695002" ) );
+		assertNumberOfViolations( violations, 1 );
+
+		violations = validator.validate( new Person( "33181429652" ) );
+		assertNumberOfViolations( violations, 1 );
+
+		violations = validator.validate( new Person( "33181429651" ) );
 		assertNumberOfViolations( violations, 1 );
 	}
 


### PR DESCRIPTION
...s by introducing actual constraint validator classes.

These constraint are not anymore pure composition constraints.