### PR TITLE
HV-969 Setting scope of test utils dependencies to provided.

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -40,12 +40,6 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator-test-utils</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.testng</groupId>
-                    <artifactId>testng</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -40,14 +40,17 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.easytesting</groupId>
             <artifactId>fest-assert</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Many modules just want @TestForIssue from the test util package.
If they depend on the assertion or log4j helper they needs to define this
dependency anyways themselves. This avoids also have testng on the classpath
(through transitive dependencies) within a module using JUnit