### PR TITLE
HV-980. Store java.util.Set element as Node.key in Path

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -602,6 +602,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 							validationContext,
 							valueIter,
 							false,
+							false,
 							valueContext,
 							validationOrder
 					);
@@ -613,11 +614,13 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 					Type type = value.getClass();
 					Iterator<?> elementsIter = createIteratorForCascadedValue( type, value, valueContext );
 					boolean isIndexable = isIndexable( type );
+					boolean isSetIterator = ReflectionHelper.isSet( type );
 
 					validateCascadedConstraint(
 							validationContext,
 							elementsIter,
 							isIndexable,
+							isSetIterator,
 							valueContext,
 							validationOrder
 					);
@@ -684,7 +687,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		return isIndexable;
 	}
 
-	private void validateCascadedConstraint(ValidationContext<?> context, Iterator<?> iter, boolean isIndexable, ValueContext<?, ?> valueContext, ValidationOrder validationOrder) {
+	private void validateCascadedConstraint(ValidationContext<?> context, Iterator<?> iter, boolean isIndexable, boolean isSetIterator, ValueContext<?, ?> valueContext, ValidationOrder validationOrder) {
 		Object value;
 		Object mapKey;
 		int i = 0;
@@ -694,6 +697,9 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 				mapKey = ( (Map.Entry<?, ?>) value ).getKey();
 				valueContext.setKey( mapKey );
 				value = ( (Map.Entry<?, ?>) value ).getValue();
+			}
+			else if ( isSetIterator ) {
+				valueContext.setKey( value );
 			}
 			else if ( isIndexable ) {
 				valueContext.setIndex( i );

--- a/engine/src/main/java/org/hibernate/validator/internal/util/ReflectionHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/ReflectionHelper.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -339,6 +340,25 @@ public final class ReflectionHelper {
 		if ( type instanceof WildcardType ) {
 			Type[] upperBounds = ( (WildcardType) type ).getUpperBounds();
 			return upperBounds.length != 0 && isList( upperBounds[0] );
+		}
+		return false;
+	}
+
+	/**
+	* @param type the type to check
+	* 
+	* @return Returns <code>true</code> if <code>type</code> is implementing <code>Set</code>, <code>false</code> otherwise.
+	*/
+	public static boolean isSet(Type type) {
+		if ( type instanceof Class && Set.class.isAssignableFrom( (Class<?>) type ) ) {
+			return true;
+		}
+		if ( type instanceof ParameterizedType ) {
+			return isSet( ( (ParameterizedType) type ).getRawType() );
+		}
+		if ( type instanceof WildcardType ) {
+			Type[] upperBounds = ( (WildcardType) type ).getUpperBounds();
+			return upperBounds.length != 0 && isSet( upperBounds[0] );
 		}
 		return false;
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/ClassValidatorWithTypeVariableTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/ClassValidatorWithTypeVariableTest.java
@@ -64,7 +64,7 @@ public class ClassValidatorWithTypeVariableTest {
 
 		Set<ConstraintViolation<Batch>> violations = validator.validate( batch );
 		assertNumberOfViolations( violations, 1 );
-		assertCorrectPropertyPaths( violations, "offers[].item" );
+		assertCorrectPropertyPaths( violations, "offers[" + offer.toString() + "].item" );
 		assertCorrectConstraintTypes( violations, NotNull.class );
 	}
 
@@ -78,7 +78,7 @@ public class ClassValidatorWithTypeVariableTest {
 
 		Set<ConstraintViolation<Batch>> violations = validator.validate( batch );
 		assertNumberOfViolations( violations, 1 );
-		assertCorrectPropertyPaths( violations, "offers[].item.date" );
+		assertCorrectPropertyPaths( violations, "offers[" + offer.toString() + "].item.date" );
 		assertCorrectConstraintTypes( violations, NotNull.class );
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextTest.java
@@ -138,12 +138,13 @@ public class ConstraintValidatorContextTest {
 	@Test
 	@TestForIssue(jiraKey = "HV-709")
 	public void testAddingNodesInClassLevelConstraintKeepsInIterableKeyAndIndex() {
-		Set<ConstraintViolation<FooContainer>> constraintViolations = validator.validate( new FooContainer() );
+		FooContainer fooContainer = new FooContainer();
+		Set<ConstraintViolation<FooContainer>> constraintViolations = validator.validate( fooContainer );
 
 		assertThat( constraintViolations ).containsPaths(
 				pathWith().property( "fooList" ).property( "myNode1", true, null, 1 ),
 				pathWith().property( "fooArray" ).property( "myNode1", true, null, 1 ),
-				pathWith().property( "fooSet" ).property( "myNode1", true, null, null ),
+				pathWith().property( "fooSet" ).property( "myNode1", true, fooContainer.fooSetElement, null ),
 				pathWith().property( "fooMap" ).property( "myNode1", true, "MapKey", null )
 		);
 	}
@@ -218,6 +219,8 @@ public class ConstraintValidatorContextTest {
 	}
 
 	private static class FooContainer {
+		private final Foo fooSetElement = new Foo();
+
 		@Valid
 		private final List<Foo> fooList = Arrays.asList( null, new Foo() );
 
@@ -225,7 +228,7 @@ public class ConstraintValidatorContextTest {
 		private final Foo[] fooArray = new Foo[] { null, new Foo() };
 
 		@Valid
-		private final Set<Foo> fooSet = asSet( null, new Foo() );
+		private final Set<Foo> fooSet = asSet( null, fooSetElement );
 
 		@Valid
 		private final Map<String, Foo> fooMap;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/conversion/AbstractGroupConversionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/conversion/AbstractGroupConversionTest.java
@@ -19,6 +19,7 @@ package org.hibernate.validator.test.internal.engine.groups.conversion;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+
 import javax.validation.ConstraintDeclarationException;
 import javax.validation.ConstraintViolation;
 import javax.validation.GroupSequence;
@@ -49,13 +50,13 @@ public abstract class AbstractGroupConversionTest {
 	@Test
 	public void groupConversionOnField() {
 		Set<ConstraintViolation<User1>> violations = validator.validate( new User1() );
-		assertCorrectPropertyPaths( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPaths( violations, "addresses[" + new Address() + "].street1", "addresses[" + new Address() + "].zipCode" );
 	}
 
 	@Test
 	public void groupConversionOnGetter() {
 		Set<ConstraintViolation<User2>> violations = validator.validate( new User2() );
-		assertCorrectPropertyPaths( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPaths( violations, "addresses[" + new Address() + "].street1", "addresses[" + new Address() + "].zipCode" );
 	}
 
 	@Test
@@ -87,28 +88,28 @@ public abstract class AbstractGroupConversionTest {
 	@Test
 	public void multipleGroupConversionsOnField() {
 		Set<ConstraintViolation<User3>> violations = validator.validate( new User3() );
-		assertCorrectPropertyPaths( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPaths( violations, "addresses[" + new Address() + "].street1", "addresses[" + new Address() + "].zipCode" );
 
 		violations = validator.validate( new User3(), Complete.class );
 		for ( ConstraintViolation<User3> constraintViolation : violations ) {
 			System.out.println( constraintViolation.getPropertyPath() );
 		}
-		assertCorrectPropertyPaths( violations, "addresses[].doorCode", "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPaths( violations, "addresses[" + new Address() + "].doorCode", "addresses[" + new Address() + "].street1", "addresses[" + new Address() + "].zipCode" );
 	}
 
 	@Test
 	public void multipleGroupConversionsOnGetter() {
 		Set<ConstraintViolation<User4>> violations = validator.validate( new User4() );
-		assertCorrectPropertyPaths( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPaths( violations, "addresses[" + new Address() + "].street1", "addresses[" + new Address() + "].zipCode" );
 
 		violations = validator.validate( new User4(), Complete.class );
-		assertCorrectPropertyPaths( violations, "addresses[].doorCode", "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPaths( violations, "addresses[" + new Address() + "].doorCode", "addresses[" + new Address() + "].street1", "addresses[" + new Address() + "].zipCode" );
 	}
 
 	@Test
 	public void conversionIsEvaluatedPerProperty() {
 		Set<ConstraintViolation<User5>> violations = validator.validate( new User5() );
-		assertCorrectPropertyPaths( violations, "addresses[].street1", "addresses[].zipCode", "phoneNumber.number" );
+		assertCorrectPropertyPaths( violations, "addresses[" + new Address() + "].street1", "addresses[" + new Address() + "].zipCode", "phoneNumber.number" );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class,
@@ -145,6 +146,12 @@ public abstract class AbstractGroupConversionTest {
 
 		@Size(groups = FullPostal.class, max = 2)
 		String doorCode = "ABC";
+
+		@Override
+		public String toString() {
+			return "{Address: street1=" + street1 + ", street2=" + street2 + ", zipCode=" + zipCode + "doorCode=" + doorCode + "}";
+		}
+
 	}
 
 	private static class PhoneNumber {


### PR DESCRIPTION
When a bean property of type java.util.Set is violated, the Path of the ConstraintViolation does contain no information which element of the Set is violated. As a fix for this problem, the violated element is stored as Node.key in the Path.

See https://hibernate.atlassian.net/browse/HV-980 for more details