### PR TITLE
HV-847: Allowing to use @SupportedValidationTarget to resolve target ambiguity of purely composed constraint

### DIFF
--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -350,8 +350,53 @@ public static class MyConstraintMappingContributor implements ConstraintMappingC
 You then need to specify the fully-qualified class name of the contributor implementation in _META-INF/validation.xml_,
 using the property key +hibernate.validator.constraint_mapping_contributor+.
 
+[[section-advanced-constraint-composition]]
+=== Advanced constraint composition features
+
+==== Validation target specification for purely composed constraints
+
+In case you specify a purely composed constraint - i.e. a constraint which has no validator itself but is solely made
+up from other, composing constraints - on a method declaration, the validation engine cannot determine whether that
+constraint is to be applied as a return value constraint or as a cross-parameter constraint.
+
+Hibernate Validator allows to resolve such ambiguities by specifying the +@SupportedValidationTarget+ annotation on the
+declaration of the composed constraint type as shown in <<example-purely-composed-constraint-validation-target>>.
+The +@ValidInvoiceAmount+ is does not declare any validator, but it is solely composed by the +@Min+ and +@NotNull+
+constraints. The +@SupportedValidationTarget+ ensures that the constraint is applied to the method return value when
+given on a method declaration.
+
+[[example-purely-composed-constraint-validation-target]]
+.Specifying the validation target of a purely composed constraint
+====
+[source, JAVA]
+----
+package org.hibernate.validator.referenceguide.chapter11.purelycomposed;
+
+@Min(value = 0)
+@NotNull
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = {})
+@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
+@ReportAsSingleViolation
+public @interface ValidInvoiceAmount {
+
+	String message() default "{org.hibernate.validator.referenceguide.chapter11.purelycomposed."
+			+ "ValidInvoiceAmount.message}";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+	@OverridesAttribute(constraint = Min.class, name = "value")
+	long value();
+}
+----
+====
+
 [[section-boolean-constraint-composition]]
-=== Boolean composition of constraints
+==== Boolean composition of constraints
 
 Bean Validation specifies that the constraints of a composed constraint (see
 <<section-constraint-composition>>) are all combined via a logical _AND_. This means all of the

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/purelycomposed/ValidInvoiceAmount.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/purelycomposed/ValidInvoiceAmount.java
@@ -1,0 +1,42 @@
+package org.hibernate.validator.referenceguide.chapter11.purelycomposed;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.OverridesAttribute;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Min(value = 0)
+@NotNull
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = {})
+@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
+@ReportAsSingleViolation
+public @interface ValidInvoiceAmount {
+
+	String message() default "{org.hibernate.validator.referenceguide.chapter11.purelycomposed."
+			+ "ValidInvoiceAmount.message}";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+	@OverridesAttribute(constraint = Min.class, name = "value")
+	long value();
+}

--- a/engine/src/main/java/org/hibernate/validator/constraints/ParameterScriptAssert.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/ParameterScriptAssert.java
@@ -37,7 +37,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * comes with the JDK:
  * </p>
  * <pre>
- * {@code @ParametersScriptAssert(script = "arg0.before(arg1)", lang = "javascript")
+ * {@code @ParameterScriptAssert(script = "arg0.before(arg1)", lang = "javascript")
  * public void createEvent(Date start, Date end) { ... }
  * }
  * </pre>

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/composition/validationtarget/AlwaysFailingConstraint.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/composition/validationtarget/AlwaysFailingConstraint.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.constraints.composition.validationtarget;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintTarget;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+import org.hibernate.validator.test.constraints.composition.validationtarget.AlwaysFailingConstraint.AlwaysFailingConstraintValidator;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author Gunnar Morling
+ */
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = AlwaysFailingConstraintValidator.class)
+@ReportAsSingleViolation
+public @interface AlwaysFailingConstraint {
+
+	String message() default "{org.hibernate.validator.test.constraints.composition.validationtarget.CustomComposingConstraint.message}";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+
+	ConstraintTarget validationAppliesTo() default ConstraintTarget.IMPLICIT;
+
+	@SupportedValidationTarget({ ValidationTarget.ANNOTATED_ELEMENT, ValidationTarget.PARAMETERS })
+	public static class AlwaysFailingConstraintValidator implements ConstraintValidator<AlwaysFailingConstraint, Object> {
+
+		@Override
+		public void initialize(AlwaysFailingConstraint constraintAnnotation) {
+		}
+
+		@Override
+		public boolean isValid(Object value, ConstraintValidatorContext context) {
+			return false;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/composition/validationtarget/InvoiceService.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/composition/validationtarget/InvoiceService.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.constraints.composition.validationtarget;
+
+/**
+ * @author Gunnar Morling
+ */
+public class InvoiceService {
+
+	@ValidInvoiceAmount
+	public long getInvoiceAmount(String orderId) {
+		return 0;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/composition/validationtarget/ValidInvoiceAmount.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/composition/validationtarget/ValidInvoiceAmount.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.constraints.composition.validationtarget;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * @author Gunnar Morling
+ */
+@AlwaysFailingConstraint
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = {})
+@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
+@ReportAsSingleViolation
+public @interface ValidInvoiceAmount {
+
+	String message() default "{org.hibernate.validator.test.constraints.composition.validationtarget.ValidInvoiceAmount.message}";
+
+	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
+}

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/composition/validationtarget/ValidationTargetOfComposedConstraintTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/composition/validationtarget/ValidationTargetOfComposedConstraintTest.java
@@ -1,0 +1,44 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.constraints.composition.validationtarget;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.executable.ExecutableValidator;
+
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutil.ValidatorUtil;
+import org.testng.annotations.Test;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+
+/**
+ *
+ * @author Gunnar Morling
+ *
+ */
+public class ValidationTargetOfComposedConstraintTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HV-847")
+	public void canUseValidationTargetToResolveAmbiguityOfPurelyComposedConstraint() throws Exception {
+		ExecutableValidator validator = ValidatorUtil.getValidator().forExecutables();
+		InvoiceService invoiceService = new InvoiceService();
+		Method method = InvoiceService.class.getMethod( "getInvoiceAmount", String.class );
+		Object returnValue = 0L;
+
+		Set<ConstraintViolation<InvoiceService>> constraintViolations = validator.validateReturnValue(
+				invoiceService,
+				method,
+				returnValue
+		);
+
+		assertCorrectConstraintTypes( constraintViolations, ValidInvoiceAmount.class );
+	}
+}


### PR DESCRIPTION
For now I just added support for resolving the ambiguity by meta-annotating the constraint definition with `@SupportedValidationTarget`.

Trying to deduct the target from composing constraints led to some chicken/egg issue: to do so, I need to parse the composing constraints first, but for that I need the constraint type of the composed constraint. I guess it could be sorted out somehow, but it didn't seem worth the effort: It's an border case, and explicit resolution is needed anyways as a fallback in case deduction from the composing constraints fails. I'd say we can add that should the subject be defined in the spec.