### PR TITLE
HV-941 Formatting for chapters 1, 2, 11

### DIFF
--- a/documentation/src/main/asciidoc/ch01.asciidoc
+++ b/documentation/src/main/asciidoc/ch01.asciidoc
@@ -158,13 +158,13 @@ public class Car {
 ----
 ====
 
-The@NotNull, @Size and @Min annotations are used to declare the constraints which should be applied
+The +@NotNull+, +@Size+ and +@Min+ annotations are used to declare the constraints which should be applied
 to the fields of a Car instance:
 
 
-*  manufacturer must never be +null+
-*  licensePlate must never be +null+ and must be between 2 and 14 characters long
-*  seatCount must be at least 2
+*  +manufacturer+ must never be +null+
+*  +licensePlate+ must never be +null+ and must be between 2 and 14 characters long
+*  +seatCount+ must be at least 2
 
 [TIP]
 ====
@@ -176,8 +176,8 @@ on GitHub.
 
 === Validating constraints
 
-To perform a validation of these constraints, you use a Validator instance. Let's have a look at a
-unit test forCar:
+To perform a validation of these constraints, you use a +Validator+ instance. Let's have a look at a
+unit test for +Car+:
 
 .Class CarTest showing validation examples
 ====
@@ -258,22 +258,22 @@ public class CarTest {
 ----
 ====
 
-In the setUp() method a Validator object is retrieved from the ValidatorFactory. A Validator
+In the +setUp()+ method a +Validator+ object is retrieved from the +ValidatorFactory+. A +Validator+
 instance is thread-safe and may be reused multiple times. It thus can safely be stored in a static
-field and be used in the test methods to validate the different Car instances.
+field and be used in the test methods to validate the different +Car+ instances.
 
-The validate() method returns a set of ConstraintViolation instances, which you can iterate over in
+The +validate()+ method returns a set of +ConstraintViolation+ instances, which you can iterate over in
 order to see which validation errors occurred. The first three test methods show some expected
 constraint violations:
 
 
-* The @NotNull constraint on manufacturer is violated in manufacturerIsNull()
-* The @Size constraint on licensePlate is violated in licensePlateTooShort()
-* The @Min constraint on seatCount is violated in seatCountTooLow()
+* The +@NotNull+ constraint on +manufacturer+ is violated in +manufacturerIsNull()+
+* The +@Size+ constraint on +licensePlate+ is violated in +licensePlateTooShort()+
+* The +@Min+ constraint on +seatCount+ is violated in +seatCountTooLow()+
 
-If the object validates successfully, validate() returns an empty set as you can see in carIsValid().
+If the object validates successfully, +validate()+ returns an empty set as you can see in +carIsValid()+.
 
-Note that only classes from the package javax.validation are used. These are provided from the Bean
+Note that only classes from the package +javax.validation+ are used. These are provided from the Bean
 Validation API. No classes from Hibernate Validator are directly referenced, resulting in portable
 code.
 
@@ -306,7 +306,7 @@ from the new API.
 
 ==== Optional type
 
-Hibernate Validator provides also support for Java 8 +Optional+ type, by unwrapping the `Optional`
+Hibernate Validator provides also support for Java 8 +Optional+ type, by unwrapping the +Optional+
 instance and validating the internal value. <<section-optional-unwrapper>> provides examples and a
 further discussion.
 

--- a/documentation/src/main/asciidoc/ch02.asciidoc
+++ b/documentation/src/main/asciidoc/ch02.asciidoc
@@ -23,7 +23,7 @@ constraints:
 [NOTE]
 ====
 Not all constraints can be placed on all of these levels. In fact, none of the default constraints
-defined by Bean Validation can be placed at class level. The java.lang.annotation.Target annotation
+defined by Bean Validation can be placed at class level. The +java.lang.annotation.Target+ annotation
 in the constraint annotation itself determines on which elements a constraint can be placed. See
 <<validator-customconstraints>> for more information.
 ====
@@ -389,10 +389,10 @@ Last but not least, a constraint can also be placed on the class level. In this 
 property is subject of the validation but the complete object. Class-level constraints are useful if
 the validation depends on a correlation between several properties of an object.
 
-The Car class in <<example-class-level>> has the two attributes seatCount and passengers and it
+The Car class in <<example-class-level>> has the two attributes +seatCount+ and +passengers+ and it
 should be ensured that the list of passengers has not more entries than seats are available. For
-that purpose the @ValidPassengerCount constraint is added on the class level. The validator of that
-constraint has access to the complete Car object, allowing to compare the numbers of seats and
+that purpose the +@ValidPassengerCount+ constraint is added on the class level. The validator of that
+constraint has access to the complete +Car+ object, allowing to compare the numbers of seats and
 passengers.
 
 Refer to <<section-class-level-constraints>> to learn in detail how to implement this custom
@@ -461,22 +461,22 @@ public class RentalCar extends Car {
 ----
 ====
 
-Here the class RentalCar is a subclass of Car and adds the property rentalStation. If an instance of
-RentalCar is validated, not only the @NotNull constraint on rentalStation is evaluated, but also the
-constraint on manufacturer from the parent class.
+Here the class +RentalCar+ is a subclass of +Car+ and adds the property +rentalStation+. If an instance of
++RentalCar+ is validated, not only the +@NotNull+ constraint on +rentalStation+ is evaluated, but also the
+constraint on +manufacturer+ from the parent class.
 
-The same would be true, if Car was not a superclass but an interface implemented by RentalCar.
+The same would be true, if +Car+ was not a superclass but an interface implemented by +RentalCar+.
 
-Constraint annotations are aggregated if methods are overridden. So if RentalCar overrode the
-getManufacturer() method from Car, any constraints annotated at the overriding method would be
-evaluated in addition to the @NotNull constraint from the superclass.
+Constraint annotations are aggregated if methods are overridden. So if +RentalCar+ overrode the
++getManufacturer()+ method from +Car+, any constraints annotated at the overriding method would be
+evaluated in addition to the +@NotNull+ constraint from the superclass.
 
 [[section-object-graph-validation]]
 ==== Object graphs
 
 The Bean Validation API does not only allow to validate single class instances but also complete
 object graphs (cascaded validation). To do so, just annotate a field or property representing a
-reference to another object with @Valid as demonstrated in <<example-cascaded-validation>>.
+reference to another object with +@Valid+ as demonstrated in <<example-cascaded-validation>>.
 
 [[example-cascaded-validation]]
 .Cascaded validation
@@ -509,12 +509,12 @@ public class Person {
 ----
 ====
 
-If an instance of Car is validated, the referenced Person object will be validated as well, as the
-driver field is annotated with @Valid. Therefore the validation of a Car will fail if the name field
-of the referenced Person instance is null.
+If an instance of +Car+ is validated, the referenced +Person+ object will be validated as well, as the
++driver+ field is annotated with +@Valid+. Therefore the validation of a +Car+ will fail if the +name+ field
+of the referenced +Person+ instance is +null+.
 
 The validation of object graphs is recursive, i.e. if a reference marked for cascaded validation
-points to an object which itself has properties annotated with @Valid, these references will be
+points to an object which itself has properties annotated with +@Valid+, these references will be
 followed up by the validation engine as well. The validation engine will ensure that no infinite
 loops occur during cascaded validation, for example if two objects hold references to each other.
 
@@ -524,10 +524,10 @@ Object graph validation also works for collection-typed fields. That means any a
 
 
 * are arrays
-* implement java.lang.Iterable (especially Collection, List and Set)
-* implement java.util.Map
+* implement +java.lang.Iterable+ (especially +Collection+, +List+ and +Set+)
+* implement +java.util.Map+
 
-can be annotated with @Valid, which will cause each contained element to be validated, when the
+can be annotated with +@Valid+, which will cause each contained element to be validated, when the
 parent object is validated.
 
 [[example-cascaded-validation-list]]
@@ -548,25 +548,25 @@ public class Car {
 ----
 ====
 
-So when validating an instance of the Car class shown in <<example-cascaded-validation-list>>, a
-ConstraintViolation will be created, if any of the Person objects contained in the passengers list
-has a null name.
+So when validating an instance of the +Car+ class shown in <<example-cascaded-validation-list>>, a
++ConstraintViolation+ will be created, if any of the +Person+ objects contained in the passengers list
+has a +null+ name.
 
 [[section-validating-bean-constraints]]
 === Validating bean constraints
 
-The Validator interface is the most important object in Bean Validation. The next section shows how
-to obtain an Validator instance. Afterwards you'll learn how to use the different methods of the
-Validator interface.
+The +Validator+ interface is the most important object in Bean Validation. The next section shows how
+to obtain an +Validator+ instance. Afterwards you'll learn how to use the different methods of the
++Validator+ interface.
 
 [[section-obtaining-validator]]
-==== Obtaining a Validator instance
+==== Obtaining a +Validator+ instance
 
-The first step towards validating an entity instance is to get hold of a Validator instance. The
-road to this instance leads via the Validation class and a ValidatorFactory. The easiest way is to
-use the static method Validation#buildDefaultValidatorFactory():
+The first step towards validating an entity instance is to get hold of a +Validator+ instance. The
+road to this instance leads via the +Validation+ class and a +ValidatorFactory+. The easiest way is to
+use the static method +Validation#buildDefaultValidatorFactory()+:
 
-.Validation#buildDefaultValidatorFactory()
+.+Validation#buildDefaultValidatorFactory()+
 ====
 [source, JAVA]
 ----
@@ -577,30 +577,30 @@ Validator validator = factory.getValidator();
 
 This bootstraps a validator in the default configuration. Refer to <<chapter-bootstrapping>> to
 learn more about the different bootstrapping methods and how to obtain a specifically configured
-Validator instance.
++Validator+ instance.
 
 ==== Validator methods
 
-The Validator interface contains three methods that can be used to either validate entire entities
+The +Validator+ interface contains three methods that can be used to either validate entire entities
 or just single properties of the entity.
 
-All three methods return a Set<ConstraintViolation>. The set is empty, if the validation succeeds.
-Otherwise a ConstraintViolation instance is added for each violated constraint.
+All three methods return a +Set<ConstraintViolation>+. The set is empty, if the validation succeeds.
+Otherwise a +ConstraintViolation+ instance is added for each violated constraint.
 
 All the validation methods have a var-args parameter which can be used to specify, which validation
 groups shall be considered when performing the validation. If the parameter is not specified the
-default validation group (javax.validation.groups.Default) is used. The topic of validation groups
+default validation group (+javax.validation.groups.Default+) is used. The topic of validation groups
 is discussed in detail in <<chapter-groups>>.
 
-===== Validator#validate()
+===== +Validator#validate()+
 
-Use the validate() method to perform validation of all constraints of a given bean.
-<<example-validator-validate>> shows the validation of an instance of the Car class from
-<<example-property-level>> which fails to satisfy the @NotNull constraint on the manufacturer
-property. The validation call therefore returns one ConstraintViolation object.
+Use the +validate()+ method to perform validation of all constraints of a given bean.
+<<example-validator-validate>> shows the validation of an instance of the +Car+ class from
+<<example-property-level>> which fails to satisfy the +@NotNull+ constraint on the +manufacturer+
+property. The validation call therefore returns one +ConstraintViolation+ object.
 
 [[example-validator-validate]]
-.Using Validator#validate()
+.Using +Validator#validate()+
 ====
 [source, JAVA]
 ----
@@ -614,12 +614,12 @@ assertEquals( "may not be null", constraintViolations.iterator().next().getMessa
 ====
 
 
-===== Validator#validateProperty()
+===== +Validator#validateProperty()+
 
-With help of the validateProperty() you can validate a single named property of a given object. The
+With help of the +validateProperty()+ you can validate a single named property of a given object. The
 property name is the JavaBeans property name.
 
-.Using Validator#validateProperty()
+.Using +Validator#validateProperty()+
 ====
 [source, JAVA]
 ----
@@ -636,12 +636,12 @@ assertEquals( "may not be null", constraintViolations.iterator().next().getMessa
 ====
 
 
-===== Validator#validateValue()
+===== +Validator#validateValue()+
 
-By using the validateValue() method you can check whether a single property of a given class can be
+By using the +validateValue()+ method you can check whether a single property of a given class can be
 validated successfully, if the property had the specified value:
 
-.Using Validator#validateValue()
+.Using +Validator#validateValue()+
 ====
 [source, JAVA]
 ----
@@ -659,40 +659,40 @@ assertEquals( "may not be null", constraintViolations.iterator().next().getMessa
 
 [NOTE]
 ====
-@Valid is not honored by validateProperty() or validateValue().
++@Valid+ is not honored by +validateProperty()+ or +validateValue()+.
 ====
 
 
-Validator#validateProperty() is for example used in the integration of Bean Validation into JSF 2
++Validator#validateProperty()+ is for example used in the integration of Bean Validation into JSF 2
 (see <<section-presentation-layer>>) to perform a validation of the values entered into a form
 before they are propagated to the model.
 
 [[section-constraint-violation-methods]]
 
-==== ConstraintViolation methods
+==== +ConstraintViolation+ methods
 
-Now it is time to have a closer look at what a ConstraintViolation is. Using the different methods
-of ConstraintViolation a lot of useful information about the cause of the validation failure can be
+Now it is time to have a closer look at what a +ConstraintViolation+ is. Using the different methods
+of +ConstraintViolation+ a lot of useful information about the cause of the validation failure can be
 determined. <<table-constraint-violation>> gives an overview of these methods. The values in the
 "Example" column refer to <<example-validator-validate>>.
 
 [[table-constraint-violation]]
-.The various ConstraintViolation methods
+.The various +ConstraintViolation+ methods
 [options="header"]
 |===============
 |Method|Usage|Example
-|getMessage()|The interpolated error message|"may not be null"
-|getMessageTemplate()|The non-interpolated error message|"{... NotNull.message}"
-|getRootBean()|The root bean being validated|car
-|getRootBeanClass()|The class of the root bean being validated|Car.class
-|getLeafBean()|If a bean constraint, the bean instance the constraint is
+|+getMessage()+|The interpolated error message|"may not be null"
+|+getMessageTemplate()+|The non-interpolated error message|"{... NotNull.message}"
+|+getRootBean()+|The root bean being validated|car
+|+getRootBeanClass()+|The class of the root bean being validated|+Car.class+
+|+getLeafBean()+|If a bean constraint, the bean instance the constraint is
               applied on; If a property constraint, the bean instance hosting
-              the property the constraint is applied on|car
-|getPropertyPath()|The property path to the validated value from root
+              the property the constraint is applied on|+car+
+|+getPropertyPath()+|The property path to the validated value from root
               bean|contains one node with kind
-              PROPERTY and name "manufacturer"
-|getInvalidValue()|The value failing to pass the constraint|+null+
-|getConstraintDescriptor()|Constraint metadata reported to fail|descriptor for @NotNull
+              +PROPERTY+ and name "manufacturer"
+|+getInvalidValue()+|The value failing to pass the constraint|+null+
+|+getConstraintDescriptor()+|Constraint metadata reported to fail|descriptor for +@NotNull+
 
 |===============
 
@@ -728,106 +728,106 @@ impact portability of your application between Bean Validation providers.
 [options="header"]
 |===============
 |Annotation|Supported data types|Use|Hibernate metadata impact
-|@AssertFalse|Boolean,
-              boolean|Checks that the annotated element is
+|+@AssertFalse+|+Boolean+,
+              +boolean+|Checks that the annotated element is
               false|None
-|@AssertTrue|Boolean,
-              boolean|Checks that the annotated element is
+|+@AssertTrue+|+Boolean+,
+              +boolean+|Checks that the annotated element is
               true|None
-|@DecimalMax(value=,inclusive=)|BigDecimal,
-              BigInteger,
-              CharSequence,
-              byte, short,
-              int, long and the
+|+@DecimalMax(value=,inclusive=)+|+BigDecimal+,
+              +BigInteger+,
+              +CharSequence+,
+              +byte+, +short+,
+              +int+, +long+ and the
               respective wrappers of the primitive types; Additionally
               supported by HV: any sub-type of
-              Number|Checks whether the annotated value is less than the
+              +Number+|Checks whether the annotated value is less than the
               specified maximum, when inclusive=false.
               Otherwise whether the value is less than or equal to the
               specified maximum. The parameter value is
               the string representation of the max value according to the
-              BigDecimal string representation.|None
-|@DecimalMin(value=,inclusive=)|BigDecimal,
-              BigInteger,
-              CharSequence,
-              byte, short,
-              int, long and the
+              +BigDecimal+ string representation.|None
+|+@DecimalMin(value=,inclusive=)+|+BigDecimal+,
+              +BigInteger+,
+              +CharSequence+,
+              +byte+, +short+,
+              +int+, +long+ and the
               respective wrappers of the primitive types; Additionally
               supported by HV: any sub-type of
-              Number|Checks whether the annotated value is larger than the
+              +Number+|Checks whether the annotated value is larger than the
               specified minimum, when inclusive=false.
               Otherwise whether the value is larger than or equal to the
               specified minimum. The parameter value is
               the string representation of the min value according to the
-              BigDecimal string representation.|None
-|@Digits(integer=,fraction=)|BigDecimal,
-              BigInteger,
-              CharSequence,
-              byte, short,
-              int, long and the
+              +BigDecimal+ string representation.|None
+|+@Digits(integer=,fraction=)+|BigDecimal,
+              +BigInteger+,
+              +CharSequence+,
+              +byte+, +short+,
+              +int+, +long+ and the
               respective wrappers of the primitive types; Additionally
               supported by HV: any sub-type of
-              Number|Checks whether the annotated value is a number having up to
+              +Number+|Checks whether the annotated value is a number having up to
               +integer+ digits and
               +fraction+ fractional digits|Defines column precision and scale
-|@Future|java.util.Date,
-              java.util.Calendar,
-              java.time.chrono.ChronoLocalDate,
-              java.time.chrono.ChronoLocalDateTime,
-              java.time.chrono.ChronoZonedDateTime,
-              java.time.Instant,
-              java.time.OffsetDateTime,
-              java.time.Year,
-              java.time.YearMonth; Additionally
+|+@Future+|+java.util.Date+,
+              +java.util.Calendar+,
+              +java.time.chrono.ChronoLocalDate+,
+              +java.time.chrono.ChronoLocalDateTime+,
+              +java.time.chrono.ChronoZonedDateTime+,
+              +java.time.Instant+,
+              +java.time.OffsetDateTime+,
+              +java.time.Year+,
+              +java.time.YearMonth+; Additionally
               supported by HV, if the link:$$http://joda-time.sourceforge.net/$$[Joda Time]
               date/time API is on the class path: any implementations of
-              ReadablePartial and
-              ReadableInstant|Checks whether the annotated date is in the
+              +ReadablePartial+ and
+              +ReadableInstant+|Checks whether the annotated date is in the
               future|None
-|@Max(value=)|BigDecimal,
-              BigInteger, byte,
-              short, int,
-              long and the respective wrappers of the
+|+@Max(value=)+|+BigDecimal+,
+              +BigInteger+, +byte+,
+              +short+, +int+,
+              +long+ and the respective wrappers of the
               primitive types; Additionally supported by HV: any sub-type of
-              CharSequence (the numeric value
+              +CharSequence+ (the numeric value
               represented by the character sequence is evaluated), any
-              sub-type of Number|Checks whether the annotated value is less than or equal
+              sub-type of +Number+|Checks whether the annotated value is less than or equal
               to the specified maximum|Adds a check constraint on the column
-|@Min(value=)|BigDecimal,
-              BigInteger, byte,
-              short, int,
-              long and the respective wrappers of the
+|+@Min(value=)+|+BigDecimal+,
+              +BigInteger+, +byte+,
+              +short+, +int+,
+              +long+ and the respective wrappers of the
               primitive types; Additionally supported by HV: any sub-type of
-              CharSequence (the numeric value
+              +CharSequence+ (the numeric value
               represented by the char sequence is evaluated), any sub-type of
-              Number|Checks whether the annotated value is higher than or
+              +Number+|Checks whether the annotated value is higher than or
               equal to the specified minimum|Adds a check constraint on the column
-|@NotNull|Any type|Checks that the annotated value is not
-              null.|Column(s) are not nullable
-|@Null|Any type|Checks that the annotated value is
-              null|None
-|@Past|java.util.Date,
-              java.util.Calendar,
-              java.time.chrono.ChronoLocalDate,
-              java.time.chrono.ChronoLocalDateTime,
-              java.time.chrono.ChronoZonedDateTime,
-              java.time.Instant,
-              java.time.OffsetDateTime,
-              java.time.Year,
-              java.time.YearMonth; Additionally
+|+@NotNull+|Any type|Checks that the annotated value is not
+              +null+.|Column(s) are not nullable
+|+@Null+|Any type|Checks that the annotated value is
+              +null+|None
+|+@Past+|+java.util.Date+,
+              +java.util.Calendar+,
+              +java.time.chrono.ChronoLocalDate+,
+              +java.time.chrono.ChronoLocalDateTime+,
+              +java.time.chrono.ChronoZonedDateTime+,
+              +java.time.Instant+,
+              +java.time.OffsetDateTime+,
+              +java.time.Year+,
+              +java.time.YearMonth+; Additionally
               supported by HV, if the link:$$http://joda-time.sourceforge.net/$$[Joda Time]
               date/time API is on the class path: any implementations of
-              ReadablePartial and
-              ReadableInstant|Checks whether the annotated date is in the past|None
-|@Pattern(regex=,flag=)|CharSequence|Checks if the annotated string matches the regular
-              expression regex considering the given
-              flag match|None
-|@Size(min=, max=)|CharSequence,
-              Collection, Map
-              and arrays|Checks if the annotated element's size is between min and
-              max (inclusive)|Column length will be set to
-              max
-|@Valid|Any non-primitive type|Performs validation recursively on the associated object.
+              +ReadablePartial+ and
+              +ReadableInstant+|Checks whether the annotated date is in the past|None
+|+@Pattern(regex=,flag=)+|+CharSequence+|Checks if the annotated string matches the regular
+              expression +regex+ considering the given
+              flag +match+|None
+|+@Size(min=, max=)+|+CharSequence+,
+              +Collection+, +Map+
+              and arrays|Checks if the annotated element's size is between +min+ and
+              +max+ (inclusive)|Column length will be set to
+              +max+
+|+@Valid+|Any non-primitive type|Performs validation recursively on the associated object.
               If the object is a collection or an array, the elements are
               validated recursively. If the object is a map, the value
               elements are validated recursively.|None
@@ -848,7 +848,7 @@ message, groups and payload. This is a requirement of the Bean Validation specif
 
 In addition to the constraints defined by the Bean Validation API Hibernate Validator provides
 several useful custom constraints which are listed in <<table-custom-constraints>>. With one
-exception also these constraints apply to the field/property level, only @ScriptAssert is a class-
+exception also these constraints apply to the field/property level, only +@ScriptAssert+ is a class-
 level constraint.
 
 [[table-custom-constraints]]
@@ -860,136 +860,136 @@ level constraint.
 |Use
 |Hibernate metadata impact
 
-|@CreditCardNumber(ignoreNonDigitCharacters=)
-|CharSequence
+|+@CreditCardNumber(ignoreNonDigitCharacters=)+
+|+CharSequence+
 |Checks that the annotated character sequence passes the
  Luhn checksum test. Note, this validation aims to check for user
  mistakes, not credit card validity! See also
- http://www.merriampark.com/anatomycc.htm[Anatomy of Credit Card Numbers]. ignoreNonDigitCharacters
+ http://www.merriampark.com/anatomycc.htm[Anatomy of Credit Card Numbers]. +ignoreNonDigitCharacters+
  allows to ignore non digit characters. The default is +false+.
 |None
 
-|@EAN
-|CharSequence
+|+@EAN+
+|+CharSequence+
 |Checks that the annotated character sequence is a valid
 link:$$http://en.wikipedia.org/wiki/International_Article_Number_%28EAN%29$$[EAN] barcode.
 type determines the type of barcode. The default is EAN-13.
 |None
 
-|@Email
-|CharSequence
+|+@Email+
+|+CharSequence+
 |Checks whether the specified character sequence is a valid email address. The optional parameters
-regexp and flags allow to specify an additional regular expression (including regular expression
++regexp+ and +flags+ allow to specify an additional regular expression (including regular expression
 flags) which the email must match.
 |None
 
-|@Length(min=, +
-         max=)
-|CharSequence
+|+@Length(min=, +
+         max=)+
+|+CharSequence+
 |Validates that the annotated character sequence is
-              between min and
-              max included
+              between +min+ and
+              +max+ included
 |Column length will be set to max
 
-|@LuhnCheck(startIndex= , +
+|+@LuhnCheck(startIndex= , +
             endIndex=, +
             checkDigitIndex=, +
-            ignoreNonDigitCharacters=)
-|CharSequence
+            ignoreNonDigitCharacters=)+
+|+CharSequence+
 |Checks that the digits within the annotated character
 sequence pass the Luhn checksum algorithm (see also
-link:$$http://en.wikipedia.org/wiki/Luhn_algorithm$$[Luhn algorithm]). startIndex and
-endIndex allow to only run the algorithm on
-the specified sub-string. checkDigitIndex
+link:$$http://en.wikipedia.org/wiki/Luhn_algorithm$$[Luhn algorithm]). +startIndex+ and
++endIndex+ allow to only run the algorithm on
+the specified sub-string. +checkDigitIndex+
 allows to use an arbitrary digit within the character sequence
 as the check digit. If not specified it is assumed that the
 check digit is part of the specified range. Last but not least,
-ignoreNonDigitCharacters allows to ignore
++ignoreNonDigitCharacters+ allows to ignore
 non digit characters.
 |None
 
-|@Mod10Check(multiplier=, +
+|+@Mod10Check(multiplier=, +
              weight=, +
              startIndex=, +
              endIndex=, +
              checkDigitIndex=, +
-             ignoreNonDigitCharacters=)
-|CharSequence
+             ignoreNonDigitCharacters=)+
+|+CharSequence+
 |Checks that the digits within the annotated character
 sequence pass the generic mod 10 checksum algorithm.
-multiplier determines the multiplier for
-odd numbers (defaults to 3), weight the
++multiplier+ determines the multiplier for
+odd numbers (defaults to 3), +weight+ the
 weight for even numbers (defaults to 1).
-startIndex and
-endIndex allow to only run the algorithm on
-the specified sub-string. checkDigitIndex
++startIndex+ and
++endIndex+ allow to only run the algorithm on
+the specified sub-string. +checkDigitIndex+
 allows to use an arbitrary digit within the character sequence
 as the check digit. If not specified it is assumed that the
 check digit is part of the specified range. Last but not least,
-ignoreNonDigitCharacters allows to ignore
++ignoreNonDigitCharacters+ allows to ignore
 non digit characters.
 |None
 
-|@Mod11Check(threshold=, +
+|+@Mod11Check(threshold=, +
              startIndex=, +
              endIndex=, +
              checkDigitIndex=, +
              ignoreNonDigitCharacters=, +
              treatCheck10As=, +
-             treatCheck11As=)
-|CharSequence
+             treatCheck11As=)+
+|+CharSequence+
 |Checks that the digits within the annotated character
 sequence pass the mod 11 checksum algorithm.
-threshold specifies the threshold for the
++threshold+ specifies the threshold for the
 mod11 multiplier growth; if no value is specified the multiplier
-will grow indefinitely. treatCheck10As
-and treatCheck11As specify the check
+will grow indefinitely. +treatCheck10As+
+and +treatCheck11As+ specify the check
 digits to be used when the mod 11 checksum equals 10 or 11,
 respectively. Default to X and 0, respectively.
-startIndex, endIndex
-acheckDigitIndex and
-ignoreNonDigitCharacters carry the same
-semantics as in @Mod10Check.
++startIndex+, +endIndex+
++checkDigitIndex+ and
++ignoreNonDigitCharacters+ carry the same
+semantics as in +@Mod10Check+.
 |None
 
-|@NotBlank
-|CharSequence
+|+@NotBlank+
+|+CharSequence+
 |Checks that the annotated character sequence is not null
 and the trimmed length is greater than 0. The difference to
-@NotEmpty is that this constraint can
++@NotEmpty+ is that this constraint can
 only be applied on strings and that trailing white-spaces are
 ignored.
 |None
 
-|@NotEmpty
-|CharSequence, Collection, Map and arrays
+|+@NotEmpty+
+|+CharSequence+, +Collection+, +Map+ and arrays
 |Checks whether the annotated element is not null nor empty
 |None
 
-|@Range(min=, +
-        max=)
-|BigDecimal, BigInteger, CharSequence, byte, short, int, long and the respective wrappers of the
+|+@Range(min=, +
+        max=)+
+|+BigDecimal+, +BigInteger+, +CharSequence+, +byte+, +short+, +int+, +long+ and the respective wrappers of the
 primitive types
 |Checks whether the annotated value lies between (inclusive) the specified minimum and maximum
 |None
 
-|@SafeHtml(whitelistType= , +
+|+@SafeHtml(whitelistType= , +
            additionalTags=, +
-           additionalTagsWithAttributes=)
-|CharSequence
+           additionalTagsWithAttributes=)+
+|+CharSequence+
 |Checks whether the annotated value
-contains potentially malicious fragments such as <script/>. In order to use this
+contains potentially malicious fragments such as +<script/>+. In order to use this
 constraint, the
 link:$$http://jsoup.org/$$[jsoup] library must be part of the class path.
-With the whitelistType attribute a predefined whitelist type can be chosen which can
-be refined via additionalTags or additionalTagsWithAttributes. The former allows to
+With the +whitelistType+ attribute a predefined whitelist type can be chosen which can
+be refined via +additionalTags+ or +additionalTagsWithAttributes+. The former allows to
 add tags without any attributes, whereas the latter allows to specify tags and
-optionally allowed attributes using the annotation @SafeHtml.Tag.
+optionally allowed attributes using the annotation +@SafeHtml.Tag+.
 |None
 
-|@ScriptAssert(lang=, +
+|+@ScriptAssert(lang=, +
               script=, +
-              alias=)
+              alias=)+
 |Any type
 |Checks whether the given script can successfully be
 evaluated against the annotated element. In order to use this
@@ -1001,19 +1001,19 @@ any scripting or expression language, for which a JSR 223
 compatible engine can be found in the class path.
 |None
 
-|@URL(protocol=, +
+|+@URL(protocol=, +
       host=, +
       port=, +
       regexp=, +
-      flags=)
-|CharSequence
+      flags=)+
+|+CharSequence+
 |Checks if the annotated character sequence is a valid URL
 according to RFC2396. If any of the optional parameters
-protocol, host or
-port are specified, the corresponding URL
++protocol+, +host+ or
++port+ are specified, the corresponding URL
 fragments must match the specified values. The optional
-parameters regexp and
-flags allow to specify an additional
+parameters +regexp+ and
++flags+ allow to specify an additional
 regular expression (including regular expression flags) which
 the URL must match. Per default this constraint used the +java.net.URL+ constructor to
 verify whether a given string represents a valid URL. A regular expression based version is also
@@ -1044,13 +1044,13 @@ Hibernate Validator!
 [options="header"]
 |===============
 |Annotation|Supported data types|Use|Country|Hibernate metadata impact
-|@CNPJ|CharSequence|Checks that the annotated character sequence represents
+|+@CNPJ+|+CharSequence+|Checks that the annotated character sequence represents
                 a Brazilian corporate tax payer registry number (Cadastro de
                 Pessoa Juríeddica)|Brazil|None
-|@CPF|CharSequence|Checks that the annotated character sequence represents
+|+@CPF+|+CharSequence+|Checks that the annotated character sequence represents
                 a Brazilian individual taxpayer registry number (Cadastro de
                 Pessoa Fídsica)|Brazil|None
-|@TituloEleitoral|CharSequence|Checks that the annotated character sequence represents
+|+@TituloEleitoral+|+CharSequence+|Checks that the annotated character sequence represents
                 a Brazilian voter ID card number (link:$$http://ghiorzi.org/cgcancpf.htm$$[Título Eleitoral])|Brazil|None
 
 |===============

--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -23,47 +23,47 @@ part of the public this is not necessarily true for its sub-packages.
 [options="header"]
 |===============
 |Packages|Description
-|org.hibernate.validator|Classes used by the Bean Validation bootstrap mechanism
+|+org.hibernate.validator+|Classes used by the Bean Validation bootstrap mechanism
             (eg. validation provider, configuration class); For more details
             see <<chapter-bootstrapping>>.
-|org.hibernate.validator.cfg,
-            org.hibernate.validator.cfg.context,
-            org.hibernate.validator.cfg.defs,
-            org.hibernate.validator.spi.cfg|Hibernate Validator's fluent API for constraint
-            declaration; In org.hibernate.validator.cfg you
-            will find the ConstraintMapping interface,
-            in org.hibernate.validator.cfg.defs all
-            constraint definitions and in org.hibernate.validator.spi.cfg a
+|+org.hibernate.validator.cfg+,
+            +org.hibernate.validator.cfg.context+,
+            +org.hibernate.validator.cfg.defs+,
+            +org.hibernate.validator.spi.cfg+|Hibernate Validator's fluent API for constraint
+            declaration; In +org.hibernate.validator.cfg+ you
+            will find the +ConstraintMapping+ interface,
+            in +org.hibernate.validator.cfg.defs+ all
+            constraint definitions and in +org.hibernate.validator.spi.cfg+ a
             callback for using the API for configuring the default validator factory.
             Refer to <<section-programmatic-api>> for the details.
-|org.hibernate.validator.constraints,
-            org.hibernate.validator.constraints.br|Some useful custom constraints provided by Hibernate
+|+org.hibernate.validator.constraints+,
+            +org.hibernate.validator.constraints.br+|Some useful custom constraints provided by Hibernate
             Validator in addition to the built-in constraints defined by the
             Bean Validation specification; The constraints are described in
             detail in <<validator-defineconstraints-hv-constraints>>.
-|org.hibernate.validator.constraintvalidation|Extended constraint validator context which allows to set
+|+org.hibernate.validator.constraintvalidation+|Extended constraint validator context which allows to set
             custom attributes for message interpolation. <<section-hibernateconstraintvalidatorcontext>> describes
             how to make use of that feature.
-|org.hibernate.validator.group,
-            org.hibernate.validator.spi.group|The group sequence provider feature which allows you to
+|+org.hibernate.validator.group+,
+            +org.hibernate.validator.spi.group+|The group sequence provider feature which allows you to
             define dynamic default group sequences in function of the
             validated object state; The specifics can be found in <<section-default-group-class>>.
-|org.hibernate.validator.messageinterpolation,
-            org.hibernate.validator.resourceloading,
-            org.hibernate.validator.spi.resourceloading|Classes related to constraint message interpolation; The
+|+org.hibernate.validator.messageinterpolation+,
+            +org.hibernate.validator.resourceloading+,
+            +org.hibernate.validator.spi.resourceloading+|Classes related to constraint message interpolation; The
             first package contains Hibernate Validator's default message
             interpolator,
-            ResourceBundleMessageInterpolator. The
+            +ResourceBundleMessageInterpolator+. The
             latter two packages provide the
-            ResourceBundleLocator SPI for the loading of resource
+            +ResourceBundleLocator+ SPI for the loading of resource
             bundles (see <<section-resource-bundle-locator>>)
             and its default implementation.
-|org.hibernate.validator.parameternameprovider|A ParameterNameProvider based on the
+|+org.hibernate.validator.parameternameprovider+|A +ParameterNameProvider+ based on the
             ParaNamer library, see <<section-paranamer-parameternameprovider>>.
-|org.hibernate.validator.spi.constraintdefinition|An SPI for registering additional constraint validators programmatically,
+|+org.hibernate.validator.spi.constraintdefinition+|An SPI for registering additional constraint validators programmatically,
             see <<section-constraint-definition-contribution>>.
-|org.hibernate.validator.valuehandling,
-            org.hibernate.validator.spi.valuehandling|Classes related to the processing of values prior to their
+|+org.hibernate.validator.valuehandling+,
+            +org.hibernate.validator.spi.valuehandling+|Classes related to the processing of values prior to their
             validation, see <<section-value-handling>>.
 
 |===============
@@ -73,7 +73,7 @@ part of the public this is not necessarily true for its sub-packages.
 The public packages of Hibernate Validator fall into two categories: while the actual API parts are
 intended to be _invoked_ or _used_ by clients (e.g. the API for programmatic constraint declaration
 or the custom constraints), the SPI (service provider interface) packages contain interfaces which
-are intended to be _implemented_ by clients (e.g. ResourceBundleLocator).
+are intended to be _implemented_ by clients (e.g. +ResourceBundleLocator+).
 ====
 
 Any packages not listed in that table are internal packages of Hibernate Validator and are not
@@ -130,14 +130,14 @@ assertEquals( 1, constraintViolations.size() );
 ----
 ====
 
-Here the validated object actually fails to satisfy both the constraints declared on the Car class,
-yet the validation call yields only one ConstraintViolation since the fail fast mode is enabled.
+Here the validated object actually fails to satisfy both the constraints declared on the +Car+ class,
+yet the validation call yields only one +ConstraintViolation+ since the fail fast mode is enabled.
 
 
 [NOTE]
 ====
 There is no guarantee in which order the constraints are evaluated, i.e. it is not deterministic
-whether the returned violation originates from the @NotNull or the @AssertTrue constraint. If
+whether the returned violation originates from the +@NotNull+ or the +@AssertTrue+ constraint. If
 required, a deterministic evaluation order can be enforced using group sequences as described in
 <<section-defining-group-sequences>>.
 ====
@@ -160,8 +160,8 @@ By default, constraints added via the fluent API are additive to constraints con
 standard configuration capabilities. But it is also possible to ignore annotation and XML configured
 constraints where required.
 
-The API is centered around the ConstraintMapping interface. You obtain a new mapping via
-HibernateValidatorConfiguration#createConstraintMapping() which you then can configure in a fluent
+The API is centered around the +ConstraintMapping+ interface. You obtain a new mapping via
++HibernateValidatorConfiguration#createConstraintMapping()+ which you then can configure in a fluent
 manner as shown in <<example-constraint-mapping>>.
 
 [[example-constraint-mapping]]
@@ -194,16 +194,16 @@ Validator validator = configuration.addMapping( constraintMapping )
 ====
 
 Constraints can be configured on multiple classes and properties using method chaining. The
-constraint definition classes NotNullDef and SizeDef are helper classes which allow to configure
+constraint definition classes +NotNullDef+ and SizeDef are helper classes which allow to configure
 constraint parameters in a type-safe fashion. Definition classes exist for all built-in constraints
-in the org.hibernate.validator.cfg.defs package. By calling ignoreAnnotations() any constraints
+in the +org.hibernate.validator.cfg.defs+ package. By calling +ignoreAnnotations()+ any constraints
 configured via annotations or XML are ignored for the given element.
 
 
 [NOTE]
 ====
 Each element (type, property, method etc.) may only be configured once within all the constraint
-mappings used to set up one validator factory. Otherwise a ValidationException is raised.
+mappings used to set up one validator factory. Otherwise a +ValidationException+ is raised.
 ====
 
 [NOTE]
@@ -215,8 +215,8 @@ configuring a subtype. Instead you need to configure the supertype in this case.
 Having configured the mapping, you must add it back to the configuration object from which you then
 can obtain a validator factory.
 
-For custom constraints you can either create your own definition classes extending ConstraintDef or
-you can use GenericConstraintDef as seen in <<example-generic-constraint-mapping>>.
+For custom constraints you can either create your own definition classes extending +ConstraintDef+ or
+you can use +GenericConstraintDef+ as seen in <<example-generic-constraint-mapping>>.
 
 [[example-generic-constraint-mapping]]
 .Programmatic declaration of a custom constraint
@@ -234,9 +234,9 @@ constraintMapping
 ----
 ====
 
-By invoking valid() you can mark a member for cascaded validation which is equivalent to annotating
-it with @Valid. Configure any group conversions to be applied during cascaded validation using the
-convertGroup() method (equivalent to @ConvertGroup). An example can be seen in
+By invoking +valid()+ you can mark a member for cascaded validation which is equivalent to annotating
+it with +@Valid+. Configure any group conversions to be applied during cascaded validation using the
++convertGroup()+ method (equivalent to +@ConvertGroup+). An example can be seen in
 <<example-cascading-constraints>>.
 
 [[example-cascading-constraints]]
@@ -406,7 +406,7 @@ Hibernate Validator offers an extension to this and allows you to compose constr
 _OR_ or _NOT_. To do so you have to use the ConstraintComposition annotation and the enum
 CompositionType with its values _AND_, _OR_ and _$$ALL_FALSE$$_.
 
-<<example-boolean-constraint-composition>> shows how to build a composed constraint @PatternOrSize
+<<example-boolean-constraint-composition>> shows how to build a composed constraint +@PatternOrSize+
 where only one of the composing constraints needs to be valid in order to pass the validation.
 Either the validated string is all lower-cased or it is between two and three characters long.
 
@@ -473,23 +473,23 @@ interpolation algorithm as defined by the specification. Refer to
 The Bean Validation specification offers at several points in its API the possibility to unwrap a
 given interface to a implementor specific subtype. In the case of constraint violation creation in
 +ConstraintValidator+ implementations as well as message interpolation in +MessageInterpolator+
-instances, there exist unwrap() methods for the provided context instances -
-ConstraintValidatorContext respectively MessageInterpolatorContext. Hibernate Validator provides
+instances, there exist +unwrap()+ methods for the provided context instances -
++ConstraintValidatorContext+ respectively +MessageInterpolatorContext+. Hibernate Validator provides
 custom extensions for both of these interfaces.
 
 [[section-hibernateconstraintvalidatorcontext]]
 ==== HibernateConstraintValidatorContext
 
 [[section-custom-constraint-validator-context]]
-HibernateConstraintValidatorContext is a subtype of ConstraintValidatorContext which allows you to
++HibernateConstraintValidatorContext+ is a subtype of +ConstraintValidatorContext+ which allows you to
 set arbitrary parameters for interpolation via the Expression Language message interpolation
 facility (see <<section-interpolation-with-message-expressions>>). For example the default error
-message for the @Future constraint is "must be in the future". What if you would like to include the
+message for the +@Future+ constraint is "must be in the future". What if you would like to include the
 current date to make the message more explicit? <<example-custom-message-parameter>> shows how this
 could be achieved.
 
 [[example-custom-message-parameter]]
-.Custom @Future validator with message parameters
+.Custom +@Future+ validator with message parameters
 ====
 [source, JAVA]
 ----
@@ -521,11 +521,11 @@ public class MyFutureValidator implements ConstraintValidator<Future, Date> {
 
 [NOTE]
 ====
-Note that the parameters specified via addExpressionVariable(String, Object) are global and apply
-for all constraint violations created by this isValid() invocation. This includes the default
-constraint violation, but also all violations created by the ConstraintViolationBuilder. You can,
+Note that the parameters specified via +addExpressionVariable(String, Object)+ are global and apply
+for all constraint violations created by this +isValid()+ invocation. This includes the default
+constraint violation, but also all violations created by the +ConstraintViolationBuilder+. You can,
 however, update the parameters between invocations of
-ConstraintViolationBuilder#addConstraintViolation().
++ConstraintViolationBuilder#addConstraintViolation()+.
 ====
 
 [WARNING]
@@ -535,8 +535,8 @@ This functionality is currently experimental and might change in future versions
 
 ==== HibernateMessageInterpolatorContext
 
-Hibernate Validator also offers a custom extension of MessageInterpolatorContext, namely
-HibernateMessageInterpolatorContext (see <<example-custom-message-interpolator-context>>). This
+Hibernate Validator also offers a custom extension of +MessageInterpolatorContext+, namely
++HibernateMessageInterpolatorContext+ (see <<example-custom-message-interpolator-context>>). This
 subtype was introduced to allow a better integration of Hibernate Validator into the Glassfish. The
 root bean type was in this case needed to determine the right classloader for the message resource
 bundle. If you have any other usecases, let us know.
@@ -561,17 +561,17 @@ public interface HibernateMessageInterpolatorContext extends MessageInterpolator
 [[section-paranamer-parameternameprovider]]
 === ParaNamer based ParameterNameProvider
 
-Hibernate Validator comes with a ParameterNameProvider implementation which leverages the
+Hibernate Validator comes with a +ParameterNameProvider+ implementation which leverages the
 link:http://paranamer.codehaus.org/[ParaNamer] library.
 
 This library provides several ways for obtaining parameter names at runtime, e.g. based on debug
 symbols created by the Java compiler, constants with the parameter names woven into the bytecode in
-a post-compile step or annotations such as the @Named annotation from JSR 330.
+a post-compile step or annotations such as the +@Named+ annotation from JSR 330.
 
-In order to use ParanamerParameterNameProvider, either pass an instance when bootstrapping a
+In order to use +ParanamerParameterNameProvider+, either pass an instance when bootstrapping a
 validator as shown in <<example-using-custom-parameter-name-provider>> or specify
-org.hibernate.validator.parameternameprovider.ParanamerParameterNameProvider as value for the
-&lt;parameter-name-provider&gt; element in the _META-INF/validation.xml_ file.
++org.hibernate.validator.parameternameprovider.ParanamerParameterNameProvider+ as value for the
++&lt;parameter-name-provider&gt;+ element in the _META-INF/validation.xml_ file.
 
 
 [TIP]
@@ -581,10 +581,10 @@ is available in the Maven Central repository with the group id +com.thoughtworks
 artifact id +paranamer+.
 ====
 
-By default ParanamerParameterNameProvider retrieves parameter names from constants added to the byte
-code at build time (via DefaultParanamer) and debug symbols (via BytecodeReadingParanamer).
-Alternatively you can specify a Paranamer implementation of your choice when creating a
-ParanamerParameterNameProvider instance.
+By default +ParanamerParameterNameProvider+ retrieves parameter names from constants added to the byte
+code at build time (via +DefaultParanamer+) and debug symbols (via +BytecodeReadingParanamer+).
+Alternatively you can specify a +Paranamer+ implementation of your choice when creating a
++ParanamerParameterNameProvider+ instance.
 
 [[section-value-handling]]
 === Unwrapping values
@@ -885,9 +885,9 @@ configuration.addConstraintDefinitionContributor(
 
 There are several cases in which Hibernate Validator needs to load resources or classes given by name:
 
-* XML descriptors (+META-INF/validation.xml+ as well as XML constraint mappings)
+* XML descriptors (_META-INF/validation.xml_ as well as XML constraint mappings)
 * classes specified by name in XML descriptors (e.g. custom message interpolators etc.)
-* the +ValidationMessages+ resource bundle
+* the _ValidationMessages_ resource bundle
 
 By default Hibernate Validator tries to load these resources via the current thread context classloader.
 If that's not successful, Hibernate Validator's own classloader will be tried as a fallback.

--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -1,3 +1,5 @@
+:sourcedir: ../../test/java
+
 [[validator-specifics]]
 == Hibernate Validator Specifics
 
@@ -93,40 +95,14 @@ all.
 [[example-using-fail-fast]]
 .Using the fail fast validation mode
 ====
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-package org.hibernate.validator.referenceguide.chapter11.failfast;
-
-public class Car {
-
-	@NotNull
-	private String manufacturer;
-
-	@AssertTrue
-	private boolean isRegistered;
-
-	public Car(String manufacturer, boolean isRegistered) {
-		this.manufacturer = manufacturer;
-		this.isRegistered = isRegistered;
-	}
-
-	//getters and setters...
-}
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/failfast/Car.java[tags=include]
 ----
 
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-Validator validator = Validation.byProvider( HibernateValidator.class )
-		.configure()
-		.failFast( true )
-		.buildValidatorFactory()
-		.getValidator();
-
-Car car = new Car( null, false );
-
-Set<ConstraintViolation<Car>> constraintViolations = validator.validate( car );
-
-assertEquals( 1, constraintViolations.size() );
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/failfast/FailFastTest.java[tags=include]
 ----
 ====
 
@@ -167,29 +143,9 @@ manner as shown in <<example-constraint-mapping>>.
 [[example-constraint-mapping]]
 .Programmatic constraint declaration
 ====
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-HibernateValidatorConfiguration configuration = Validation
-		.byProvider( HibernateValidator.class )
-		.configure();
-
-ConstraintMapping constraintMapping = configuration.createConstraintMapping();
-
-constraintMapping
-	.type( Car.class )
-		.property( "manufacturer", FIELD )
-			.constraint( new NotNullDef() )
-		.property( "licensePlate", FIELD )
-			.ignoreAnnotations()
-			.constraint( new NotNullDef() )
-			.constraint( new SizeDef().min( 2 ).max( 14 ) )
-	.type( RentalCar.class )
-		.property( "rentalStation", METHOD )
-			.constraint( new NotNullDef() );
-
-Validator validator = configuration.addMapping( constraintMapping )
-		.buildValidatorFactory()
-		.getValidator()
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/constraintapi/ConstraintApiTest.java[tags=constraintMapping]
 ----
 ====
 
@@ -221,16 +177,9 @@ you can use +GenericConstraintDef+ as seen in <<example-generic-constraint-mappi
 [[example-generic-constraint-mapping]]
 .Programmatic declaration of a custom constraint
 ====
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-ConstraintMapping constraintMapping = configuration.createConstraintMapping();
-
-constraintMapping
-	.type( Car.class )
-		.property( "licensePlate", FIELD )
-			.constraint( new GenericConstraintDef<CheckCase>( CheckCase.class )
-				.param( "value", CaseMode.UPPER )
-			);
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/constraintapi/ConstraintApiTest.java[tags=genericConstraintDef]
 ----
 ====
 
@@ -242,19 +191,9 @@ it with +@Valid+. Configure any group conversions to be applied during cascaded 
 [[example-cascading-constraints]]
 .Marking a property for cascaded validation
 ====
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-ConstraintMapping constraintMapping = configuration.createConstraintMapping();
-
-constraintMapping
-	.type( Car.class )
-		.property( "driver", FIELD )
-			.constraint( new NotNullDef() )
-			.valid()
-			.convertGroup( Default.class ).to( PersonDefault.class )
-	.type( Person.class )
-		.property( "name", FIELD )
-			.constraint( new NotNullDef().groups( PersonDefault.class ) );
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/constraintapi/ConstraintApiTest.java[tags=cascaded]
 ----
 ====
 
@@ -267,31 +206,9 @@ constraints as well as cross-parameter constraints.
 [[example-method-constraint-mapping]]
 .Programmatic declaration of method and constructor constraints
 ====
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-ConstraintMapping constraintMapping = configuration.createConstraintMapping();
-
-constraintMapping
-	.type( Car.class )
-		.constructor( String.class )
-			.parameter( 0 )
-				.constraint( new SizeDef().min( 3 ).max( 50 ) )
-			.returnValue()
-				.valid()
-		.method( "drive", int.class )
-			.parameter( 0 )
-				.constraint( new MaxDef().value ( 75 ) )
-		.method( "load", List.class, List.class )
-			.crossParameter()
-				.constraint( new GenericConstraintDef<LuggageCountMatchesPassengerCount>(
-						LuggageCountMatchesPassengerCount.class ).param(
-							"piecesOfLuggagePerPassenger", 2
-						)
-				)
-		.method( "getDriver" )
-			.returnValue()
-				.constraint( new NotNullDef() )
-				.valid();
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/constraintapi/ConstraintApiTest.java[tags=executableConfiguration]
 ----
 ====
 
@@ -301,15 +218,9 @@ provider of a type as shown in the following example.
 [[example-sequences]]
 .Configuration of default group sequence and default group sequence provider
 ====
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-ConstraintMapping constraintMapping = configuration.createConstraintMapping();
-
-constraintMapping
-	.type( Car.class )
-		.defaultGroupSequence( Car.class, CarChecks.class )
-	.type( RentalCar.class )
-		.defaultGroupSequenceProviderClass( RentalCarGroupSequenceProvider.class );
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/constraintapi/ConstraintApiTest.java[tags=defaultGroupSequence]
 ----
 ====
 
@@ -325,25 +236,9 @@ To do so, implement the +ConstraintMappingContributor+ contract:
 [[example-constraint-mapping-contributor]]
 .Custom +ConstraintMappingContributor+ implementation
 ====
-[source, JAVA]
+[source, JAVA, indent=0]
 ----
-public static class MyConstraintMappingContributor implements ConstraintMappingContributor {
-
-	@Override
-	public void createConstraintMappings(ConstraintMappingBuilder builder) {
-		builder.addConstraintMapping()
-			.type( Marathon.class )
-				.property( "name", METHOD )
-					.constraint( new NotNullDef() )
-				.property( "numberOfHelpers", FIELD )
-					.constraint( new MinDef().value( 1 ) );
-
-		builder.addConstraintMapping()
-			.type( Runner.class )
-				.property( "paidEntryFee", FIELD )
-					.constraint( new AssertTrueDef() );
-	}
-}
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/constraintapi/MyConstraintMappingContributor.java[tags=include]
 ----
 ====
 
@@ -370,28 +265,7 @@ given on a method declaration.
 ====
 [source, JAVA]
 ----
-package org.hibernate.validator.referenceguide.chapter11.purelycomposed;
-
-@Min(value = 0)
-@NotNull
-@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
-@Retention(RUNTIME)
-@Documented
-@Constraint(validatedBy = {})
-@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
-@ReportAsSingleViolation
-public @interface ValidInvoiceAmount {
-
-	String message() default "{org.hibernate.validator.referenceguide.chapter11.purelycomposed."
-			+ "ValidInvoiceAmount.message}";
-
-	Class<?>[] groups() default {};
-
-	Class<? extends Payload>[] payload() default {};
-
-	@OverridesAttribute(constraint = Min.class, name = "value")
-	long value();
-}
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/purelycomposed/ValidInvoiceAmount.java[tags=include]
 ----
 ====
 

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/constraintapi/ConstraintApiTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/constraintapi/ConstraintApiTest.java
@@ -6,8 +6,6 @@ import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.groups.Default;
 
-import org.junit.Test;
-
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.cfg.ConstraintMapping;
@@ -15,6 +13,7 @@ import org.hibernate.validator.cfg.GenericConstraintDef;
 import org.hibernate.validator.cfg.defs.MaxDef;
 import org.hibernate.validator.cfg.defs.NotNullDef;
 import org.hibernate.validator.cfg.defs.SizeDef;
+import org.junit.Test;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
@@ -23,6 +22,7 @@ public class ConstraintApiTest {
 
 	@Test
 	public void constraintMapping() {
+		//tag::constraintMapping[]
 		HibernateValidatorConfiguration configuration = Validation
 				.byProvider( HibernateValidator.class )
 				.configure();
@@ -44,6 +44,7 @@ public class ConstraintApiTest {
 		Validator validator = configuration.addMapping( constraintMapping )
 				.buildValidatorFactory()
 				.getValidator();
+		//end::constraintMapping[]
 	}
 
 	@Test
@@ -52,6 +53,7 @@ public class ConstraintApiTest {
 				.byProvider( HibernateValidator.class )
 				.configure();
 
+		//tag::genericConstraintDef[]
 		ConstraintMapping constraintMapping = configuration.createConstraintMapping();
 
 		constraintMapping
@@ -60,6 +62,7 @@ public class ConstraintApiTest {
 					.constraint( new GenericConstraintDef<CheckCase>( CheckCase.class )
 						.param( "value", CaseMode.UPPER )
 					);
+		//end::genericConstraintDef[]
 	}
 
 	@Test
@@ -68,6 +71,7 @@ public class ConstraintApiTest {
 				.byProvider( HibernateValidator.class )
 				.configure();
 
+		//tag::cascaded[]
 		ConstraintMapping constraintMapping = configuration.createConstraintMapping();
 
 		constraintMapping
@@ -79,6 +83,7 @@ public class ConstraintApiTest {
 			.type( Person.class )
 				.property( "name", FIELD )
 					.constraint( new NotNullDef().groups( PersonDefault.class ) );
+		//end::cascaded[]
 	}
 
 	@Test
@@ -87,6 +92,7 @@ public class ConstraintApiTest {
 				.byProvider( HibernateValidator.class )
 				.configure();
 
+		//tag::executableConfiguration[]
 		ConstraintMapping constraintMapping = configuration.createConstraintMapping();
 
 		constraintMapping
@@ -110,6 +116,7 @@ public class ConstraintApiTest {
 					.returnValue()
 						.constraint( new NotNullDef() )
 						.valid();
+		//end::executableConfiguration[]
 	}
 
 	@Test
@@ -118,6 +125,7 @@ public class ConstraintApiTest {
 				.byProvider( HibernateValidator.class )
 				.configure();
 
+		//tag::defaultGroupSequence[]
 		ConstraintMapping constraintMapping = configuration.createConstraintMapping();
 
 		constraintMapping
@@ -125,6 +133,7 @@ public class ConstraintApiTest {
 				.defaultGroupSequence( Car.class, CarChecks.class )
 			.type( RentalCar.class )
 				.defaultGroupSequenceProviderClass( RentalCarGroupSequenceProvider.class );
+		//end::defaultGroupSequence[]
 	}
 
 	public interface PersonDefault {

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/constraintapi/MyConstraintMappingContributor.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/constraintapi/MyConstraintMappingContributor.java
@@ -1,0 +1,33 @@
+//tag::include[]
+package org.hibernate.validator.referenceguide.chapter11.constraintapi;
+
+//end::include[]
+import org.hibernate.validator.cfg.defs.AssertTrueDef;
+import org.hibernate.validator.cfg.defs.MinDef;
+import org.hibernate.validator.cfg.defs.NotNullDef;
+import org.hibernate.validator.spi.cfg.ConstraintMappingContributor;
+import org.hibernate.validator.test.cfg.Marathon;
+import org.hibernate.validator.test.cfg.Runner;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+
+//tag::include[]
+public class MyConstraintMappingContributor implements ConstraintMappingContributor {
+
+	@Override
+	public void createConstraintMappings(ConstraintMappingBuilder builder) {
+		builder.addConstraintMapping()
+			.type( Marathon.class )
+				.property( "name", METHOD )
+					.constraint( new NotNullDef() )
+				.property( "numberOfHelpers", FIELD )
+					.constraint( new MinDef().value( 1 ) );
+
+		builder.addConstraintMapping()
+			.type( Runner.class )
+				.property( "paidEntryFee", FIELD )
+					.constraint( new AssertTrueDef() );
+	}
+}
+//end::include[]

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/failfast/Car.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/failfast/Car.java
@@ -1,8 +1,11 @@
+// tag::include[]
 package org.hibernate.validator.referenceguide.chapter11.failfast;
 
+//end::include[]
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
 
+//tag::include[]
 public class Car {
 
 	@NotNull
@@ -18,3 +21,4 @@ public class Car {
 
 	//getters and setters...
 }
+//end::include[]

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/failfast/FailFastTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/failfast/FailFastTest.java
@@ -1,13 +1,13 @@
 package org.hibernate.validator.referenceguide.chapter11.failfast;
 
 import java.util.Set;
+
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 
-import org.junit.Test;
-
 import org.hibernate.validator.HibernateValidator;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
@@ -15,6 +15,7 @@ public class FailFastTest {
 
 	@Test
 	public void failFast() {
+		//tag::include[]
 		Validator validator = Validation.byProvider( HibernateValidator.class )
 				.configure()
 				.failFast( true )
@@ -26,5 +27,6 @@ public class FailFastTest {
 		Set<ConstraintViolation<Car>> constraintViolations = validator.validate( car );
 
 		assertEquals( 1, constraintViolations.size() );
+		//end::include[]
 	}
 }

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/purelycomposed/ValidInvoiceAmount.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/purelycomposed/ValidInvoiceAmount.java
@@ -1,5 +1,7 @@
+// tag::include[]
 package org.hibernate.validator.referenceguide.chapter11.purelycomposed;
 
+//end::include[]
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -20,6 +22,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+//tag::include[]
 @Min(value = 0)
 @NotNull
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
@@ -40,3 +43,4 @@ public @interface ValidInvoiceAmount {
 	@OverridesAttribute(constraint = Min.class, name = "value")
 	long value();
 }
+//end::include[]


### PR DESCRIPTION
This applies the literal formatting for chapter 11.

The second commit is an experiment for including examples directly from sources rather than copying them. I think it's the better approach in general, but converting it now takes quite some time, so I'm not sure whether it's worth the effort atm. Maybe let's better do it when adding/updating given example listings anyways?

Any thoughts?