### PR TITLE
HV-980 Exposing value on property nodes of constraint violation paths

### DIFF
--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -1,3 +1,5 @@
+:sourcedir: ../../test/java
+
 [[validator-specifics]]
 == Hibernate Validator Specifics
 
@@ -60,6 +62,8 @@ part of the public this is not necessarily true for its sub-packages.
             and its default implementation.
 |org.hibernate.validator.parameternameprovider|A ParameterNameProvider based on the
             ParaNamer library, see <<section-paranamer-parameternameprovider>>.
+|+org.hibernate.validator.propertypath+|Extensions to the +javax.validation.Path+ API,
+            see <<section-extensions-path-api>>.
 |org.hibernate.validator.spi.constraintdefinition|An SPI for registering additional constraint validators programmatically,
             see <<section-constraint-definition-contribution>>.
 |org.hibernate.validator.valuehandling,
@@ -440,6 +444,24 @@ public @interface PatternOrSize {
 Using _$$ALL_FALSE$$_ as composition type implicitly enforces that only a single violation will get
 reported in case validation of the constraint composition fails.
 ====
+
+[[section-extensions-path-api]]
+=== Extensions of the Path API
+
+Hibernate Validator provides an extension to the +javax.validation.Path+ API.
+For nodes of +ElementKind.PROPERTY+ it allows to obtain the value of the represented property.
+To do so, narrow down a given node to the type +org.hibernate.validator.path.PropertyNode+ using +Node#as()+, as shown in the following example:
+
+[[example-property-node-get-value]]
+.Getting the value from property nodes
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/propertypath/PropertyPathTest.java[tags=include]
+----
+====
+
+This is specifically useful to obtain the element of +Set+ properties on the property path (e.g. +apartments+ in the example) which otherwise could not be identified (unlike for +Map+ and +List+, there is no key nor index in this case).
 
 [[non-el-message-interpolator]]
 === ParameterMessageInterpolator

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/propertypath/Apartment.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/propertypath/Apartment.java
@@ -1,0 +1,13 @@
+package org.hibernate.validator.referenceguide.chapter11.propertypath;
+
+import javax.validation.Valid;
+
+public class Apartment {
+
+	@Valid
+	Person resident;
+
+	Apartment(Person resident) {
+		this.resident = resident;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/propertypath/Building.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/propertypath/Building.java
@@ -1,0 +1,20 @@
+package org.hibernate.validator.referenceguide.chapter11.propertypath;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.validation.Valid;
+
+public class Building {
+
+	@Valid
+	private Set<Apartment> apartments = new HashSet<Apartment>();
+
+	public Set<Apartment> getApartments() {
+		return apartments;
+	}
+
+	public void setApartments(Set<Apartment> apartments) {
+		this.apartments = apartments;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/propertypath/Person.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/propertypath/Person.java
@@ -1,0 +1,13 @@
+package org.hibernate.validator.referenceguide.chapter11.propertypath;
+
+import javax.validation.constraints.Size;
+
+public class Person {
+
+	@Size(min = 5)
+	String name;
+
+	Person(String name) {
+		this.name = name;
+	}
+}

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/propertypath/PropertyPathTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/propertypath/PropertyPathTest.java
@@ -1,0 +1,61 @@
+package org.hibernate.validator.referenceguide.chapter11.propertypath;
+
+import java.util.Iterator;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Path;
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.path.PropertyNode;
+import org.testng.annotations.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+
+/**
+ * @author Gunnar Morling
+ *
+ */
+public class PropertyPathTest {
+
+	@Test
+	public void testPropertyNodeGetValueForSet() {
+		Validator validator = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.failFast( true )
+				.buildValidatorFactory()
+				.getValidator();
+
+//tag::include[]
+		Building building = new Building();
+
+		// Assume the name of the person violates a @Size constraint
+		Person bob = new Person( "Bob" );
+		Apartment bobsApartment = new Apartment( bob );
+		building.getApartments().add( bobsApartment );
+
+		Set<ConstraintViolation<Building>> constraintViolations = validator.validate( building );
+
+		Path path = constraintViolations.iterator().next().getPropertyPath();
+		Iterator<Path.Node> nodeIterator = path.iterator();
+
+		Path.Node node = nodeIterator.next();
+		assertEquals( node.getName(), "apartments" );
+		assertSame( node.as( PropertyNode.class ).getValue(), bobsApartment );
+
+		node = nodeIterator.next();
+		assertEquals( node.getName(), "resident" );
+		assertSame( node.as( PropertyNode.class ).getValue(), bob );
+
+		node = nodeIterator.next();
+		assertEquals( node.getName(), "name" );
+		assertEquals( node.as( PropertyNode.class ).getValue(), "Bob" );
+//end::include[]
+
+		assertFalse( nodeIterator.hasNext() );
+	}
+}

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -236,6 +236,7 @@
                             org.hibernate.validator.group;version="${project.version}",
                             org.hibernate.validator.messageinterpolation;version="${project.version}",
                             org.hibernate.validator.parameternameprovider;version="${project.version}",
+                            org.hibernate.validator.path;version="${project.version}",
                             org.hibernate.validator.resourceloading;version="${project.version}",
                             org.hibernate.validator.spi.*;version="${project.version}",
                             org.hibernate.validator.valuehandling;version="${project.version}",

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValueContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValueContext.java
@@ -8,6 +8,7 @@ package org.hibernate.validator.internal.engine;
 
 import java.lang.annotation.ElementType;
 import java.lang.reflect.Type;
+
 import javax.validation.ElementKind;
 import javax.validation.groups.Default;
 
@@ -166,6 +167,7 @@ public class ValueContext<T, V> {
 	}
 
 	public final void setCurrentValidatedValue(V currentValue) {
+		propertyPath.setLeafNodeValue( currentValue );
 		this.currentValue = currentValue;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValueContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValueContext.java
@@ -67,7 +67,7 @@ public class ValueContext<T, V> {
 	/**
 	 * An optional value unwrapper for the current value
 	 */
-	private ValidatedValueUnwrapper validatedValueHandler;
+	private ValidatedValueUnwrapper<V> validatedValueHandler;
 
 	/**
 	 * Enum specifying how to handle validated values
@@ -117,7 +117,6 @@ public class ValueContext<T, V> {
 	 *
 	 * @return the current value to be validated
 	 */
-	@SuppressWarnings( "unchecked" )
 	public final Object getCurrentValidatedValue() {
 		return validatedValueHandler != null ? validatedValueHandler.handleValidatedValue( currentValue ) : currentValue;
 	}
@@ -212,11 +211,11 @@ public class ValueContext<T, V> {
 		return sb.toString();
 	}
 
-	public void setValidatedValueHandler(ValidatedValueUnwrapper handler) {
+	public void setValidatedValueHandler(ValidatedValueUnwrapper<V> handler) {
 		this.validatedValueHandler = handler;
 	}
 
-	public ValidatedValueUnwrapper getValidatedValueHandler() {
+	public ValidatedValueUnwrapper<V> getValidatedValueHandler() {
 		return validatedValueHandler;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintViolation;
 
@@ -117,7 +118,8 @@ public class ConstraintTree<A extends Annotation> {
 			// check for a potential unwrapper
 
 			Type validatedValueType = valueContext.getDeclaredTypeOfValidatedElement();
-			ValidatedValueUnwrapper validatedValueUnwrapper = validationContext.getValidatedValueUnwrapper(
+			@SuppressWarnings("unchecked")
+			ValidatedValueUnwrapper<V> validatedValueUnwrapper = (ValidatedValueUnwrapper<V>) validationContext.getValidatedValueUnwrapper(
 					validatedValueType
 			);
 			if( !valueContext.getUnwrapMode().equals( UnwrapMode.SKIP_UNWRAP )) {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.metadata.ConstraintDescriptor;
@@ -209,7 +210,7 @@ public class ConstraintValidatorManager {
 
 		// if we also have a suitable value unwrapper we resolve for the type provided by the unwrapper as well
 		List<Type> suitableTypesForWrappedValue;
-		ValidatedValueUnwrapper validatedValueHandler = valueContext.getValidatedValueHandler();
+		ValidatedValueUnwrapper<?> validatedValueHandler = valueContext.getValidatedValueHandler();
 		if ( validatedValueHandler != null) {
 			Type unwrappedType = validatedValueHandler.getValidatedValueType( typeOfValidatedElement );
 			suitableTypesForWrappedValue = findSuitableValidatorTypes( unwrappedType, availableValidatorTypes );
@@ -347,7 +348,7 @@ public class ConstraintValidatorManager {
 		}
 	}
 
-	private ConstraintValidatorManager.TypeResolutionResult getTypeResolutionResultForValidatedValue(ValueContext valueContext,
+	private ConstraintValidatorManager.TypeResolutionResult getTypeResolutionResultForValidatedValue(ValueContext<?, ?> valueContext,
 			List<Type> constraintValidatorTypesForValidatedValue) {
 		if ( constraintValidatorTypesForValidatedValue.size() == 0 ) {
 			return ConstraintValidatorManager.TypeResolutionResult.NO_VALIDATORS;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -13,6 +13,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.validation.ElementKind;
 import javax.validation.Path;
 
@@ -186,6 +187,15 @@ public final class PathImpl implements Path, Serializable {
 
 	public NodeImpl setLeafNodeMapKey(Object key) {
 		currentLeafNode = NodeImpl.setMapKey( currentLeafNode, key );
+
+		nodeList.remove( nodeList.size() - 1 );
+		nodeList.add( currentLeafNode );
+		hashCode = -1;
+		return currentLeafNode;
+	}
+
+	public NodeImpl setLeafNodeValue(Object value) {
+		currentLeafNode = NodeImpl.setPropertyValue( currentLeafNode, value );
 
 		nodeList.remove( nodeList.size() - 1 );
 		nodeList.add( currentLeafNode );

--- a/engine/src/main/java/org/hibernate/validator/path/PropertyNode.java
+++ b/engine/src/main/java/org/hibernate/validator/path/PropertyNode.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.path;
+
+/**
+ * Node representing a property, providing Hibernate Validator specific functionality.
+ *
+ * @author Gunnar Morling
+ */
+public interface PropertyNode extends javax.validation.Path.PropertyNode {
+
+	/**
+	 * Returns the value of the bean property represented by this node.
+	 */
+	Object getValue();
+}

--- a/engine/src/main/java/org/hibernate/validator/path/package-info.java
+++ b/engine/src/main/java/org/hibernate/validator/path/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+/**
+ * <p>Hibernate Validator extensions around {@code javax.validation.Path}.</p>
+ * <p>This package is part of the public Hibernate Validator API.</p>
+ */
+package org.hibernate.validator.path;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/NodeImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/NodeImplTest.java
@@ -11,9 +11,12 @@ import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.validation.Constraint;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -23,8 +26,11 @@ import javax.validation.Path;
 import javax.validation.Payload;
 import javax.validation.Valid;
 import javax.validation.Validator;
+import javax.validation.constraints.Max;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
+import org.hibernate.validator.path.PropertyNode;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -34,6 +40,8 @@ import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertC
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.hibernate.validator.testutil.ValidatorUtil.getValidator;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
 
 /**
  * @author Hardy Ferentschik
@@ -181,6 +189,95 @@ public class NodeImplTest {
 		assertEquals( node.getKind(), ElementKind.PROPERTY, "unexpected node kind" );
 	}
 
+	@Test
+	public void testPropertyNodeGetValueForSet() {
+		Building building = new Building();
+		building.apartments.add( new Apartment( new Person( "Bob" ) ) );
+		building.apartments.add( new Apartment( new Person( "Alice" ) ) );
+
+		Set<ConstraintViolation<Building>> constraintViolations = validator.validate( building );
+
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "apartments[].resident.name" );
+
+		Path path = constraintViolations.iterator().next().getPropertyPath();
+		Iterator<Path.Node> nodeIterator = path.iterator();
+
+		Path.Node node = nodeIterator.next();
+		assertEquals( node.getKind(), ElementKind.PROPERTY, "unexpected node kind" );
+		assertEquals( node.getName(), "apartments" );
+		assertEquals( node.as( PropertyNode.class ).getValue(), new Apartment( new Person( "Bob" ) ) );
+
+		node = nodeIterator.next();
+		assertEquals( node.getKind(), ElementKind.PROPERTY, "unexpected node kind" );
+		assertEquals( node.getName(), "resident" );
+		assertEquals( node.as( PropertyNode.class ).getValue(), new Person( "Bob" ) );
+
+		node = nodeIterator.next();
+		assertEquals( node.getKind(), ElementKind.PROPERTY, "unexpected node kind" );
+		assertEquals( node.getName(), "name" );
+		assertEquals( node.as( PropertyNode.class ).getValue(), "Bob" );
+
+		assertFalse( nodeIterator.hasNext() );
+	}
+
+	@Test
+	public void testPropertyNodeGetValueForList() {
+		Building building = new Building();
+		building.floors.add( new Floor( 9 ) );
+		building.floors.add( new Floor( 10 ) );
+		building.floors.add( new Floor( 11 ) );
+
+		Set<ConstraintViolation<Building>> constraintViolations = validator.validate( building );
+
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "floors[2].number" );
+
+		Path path = constraintViolations.iterator().next().getPropertyPath();
+		Iterator<Path.Node> nodeIterator = path.iterator();
+
+		Path.Node node = nodeIterator.next();
+		assertEquals( node.getKind(), ElementKind.PROPERTY, "unexpected node kind" );
+		assertEquals( node.getName(), "floors" );
+		assertSame( node.as( PropertyNode.class ).getValue(), building.floors.get( 2 ) );
+
+		node = nodeIterator.next();
+		assertEquals( node.getKind(), ElementKind.PROPERTY, "unexpected node kind" );
+		assertEquals( node.getName(), "number" );
+		assertEquals( node.as( PropertyNode.class ).getValue(), 11 );
+		assertEquals( node.getIndex(), Integer.valueOf ( 2 ) );
+
+		assertFalse( nodeIterator.hasNext() );
+	}
+
+	@Test
+	public void testPropertyNodeGetValueForMap() {
+		Building building = new Building();
+		building.managers.put( "main", new Person( "Ron" ) );
+		building.managers.put( "stand-in", new Person( "Ronnie" ) );
+
+		Set<ConstraintViolation<Building>> constraintViolations = validator.validate( building );
+
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "managers[main].name" );
+
+		Path path = constraintViolations.iterator().next().getPropertyPath();
+		Iterator<Path.Node> nodeIterator = path.iterator();
+
+		Path.Node node = nodeIterator.next();
+		assertEquals( node.getKind(), ElementKind.PROPERTY, "unexpected node kind" );
+		assertEquals( node.getName(), "managers" );
+		assertSame( node.as( PropertyNode.class ).getValue(), building.managers.get( "main" ) );
+
+		node = nodeIterator.next();
+		assertEquals( node.getKind(), ElementKind.PROPERTY, "unexpected node kind" );
+		assertEquals( node.getName(), "name" );
+		assertEquals( node.as( PropertyNode.class ).getValue(), "Ron" );
+		assertEquals( node.getKey(), "main" );
+
+		assertFalse( nodeIterator.hasNext() );
+	}
+
 	private void assertConstraintViolationToOneValidation(Set<ConstraintViolation<AWithB>> constraintViolations) {
 		assertNumberOfViolations( constraintViolations, 1 );
 		assertCorrectPropertyPaths( constraintViolations, "b.b" );
@@ -265,6 +362,110 @@ public class NodeImplTest {
 
 		public D() {
 			c = new C();
+		}
+	}
+
+	static class Building {
+
+		@Valid
+		Set<Apartment> apartments = new HashSet<Apartment>();
+
+		@Valid
+		List<Floor> floors = new ArrayList<Floor>();
+
+		@Valid
+		Map<String, Person> managers = new HashMap<String, Person>();
+	}
+
+	static class Apartment {
+
+		@Valid
+		Person resident;
+
+		Apartment(Person resident) {
+			this.resident = resident;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( ( resident == null ) ? 0 : resident.hashCode() );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			Apartment other = (Apartment) obj;
+			if ( resident == null ) {
+				if ( other.resident != null ) {
+					return false;
+				}
+			}
+			else if ( !resident.equals( other.resident ) ) {
+				return false;
+			}
+			return true;
+		}
+	}
+
+	static class Floor {
+
+		@Max(10)
+		int number;
+
+		public Floor(int number) {
+			this.number = number;
+		}
+	}
+
+	static class Person {
+
+		@Size(min=5)
+		String name;
+
+		Person(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			Person other = (Person) obj;
+			if ( name == null ) {
+				if ( other.name != null ) {
+					return false;
+				}
+			}
+			else if ( !name.equals( other.name ) ) {
+				return false;
+			}
+			return true;
 		}
 	}
 


### PR DESCRIPTION
@hferentschik If you have a minute, can you take a look at that one? This provides a new HV-specific node interface `PropertyNode` with a method `getValue()` returning the value of the represented property. I.e. it's not only for sets but for all property nodes. If you agree with the general solution, I'll push another commit for the doc update. Thx!