### PR TITLE
HV-1012 Updated jsoup version from 1.8.1 to 1.8.3 in order to eliminate an unsafe XSS vector

### DIFF
--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/SafeHtmlValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/SafeHtmlValidatorTest.java
@@ -55,6 +55,13 @@ public class SafeHtmlValidatorTest {
 	}
 
 	@Test
+	public void testInvalidIncompleteImgTagWithScriptIncluded() {
+		descriptor.setValue( "whitelistType", WhiteListType.BASIC );
+
+		assertFalse( getSafeHtmlValidator().isValid( "<img src=asdf onerror=\"alert(1)\" x=", null ) );
+	}
+
+	@Test
 	public void testValid() throws Exception {
 		descriptor.setValue( "whitelistType", WhiteListType.BASIC );
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <classmate.version>1.1.0</classmate.version>
         <paranamer.version>2.5.5</paranamer.version>
         <joda-time.version>2.1</joda-time.version>
-        <jsoup.version>1.8.1</jsoup.version>
+        <jsoup.version>1.8.3</jsoup.version>
         <wildfly.version>8.2.0.Final</wildfly.version>
         <arquillian.version>1.0.2.Final</arquillian.version>
         <slf4j.version>1.7.2</slf4j.version>


### PR DESCRIPTION
Through a security review we have discovered a problem related to Jsoup used by the SafeHtml validator. A fix has been submitted to Jsoup and the fix has now been released with version 1.8.3.

I have added a test for SafeHtmlValidator that exposes the problem and updated Jsoup to the currently latest version.

Please see the Jsoup pull request for details: https://github.com/jhy/jsoup/pull/582