### PR TITLE
HV-994 Validation of parameter on stateless bean

### DIFF
--- a/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidationExtension.java
+++ b/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidationExtension.java
@@ -30,12 +30,9 @@ import javax.enterprise.inject.spi.BeforeBeanDiscovery;
 import javax.enterprise.inject.spi.Extension;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.enterprise.inject.spi.ProcessBean;
-import javax.enterprise.inject.spi.WithAnnotations;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.validation.BootstrapConfiguration;
 import javax.validation.Configuration;
-import javax.validation.Constraint;
-import javax.validation.Valid;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
@@ -212,11 +209,7 @@ public class ValidationExtension implements Extension {
 	 * @param processAnnotatedTypeEvent event fired for each annotated type
 	 * @param <T> the annotated type
 	 */
-	public <T> void processAnnotatedType(@Observes @WithAnnotations({
-			Constraint.class,
-			Valid.class,
-			ValidateOnExecution.class
-	}) ProcessAnnotatedType<T> processAnnotatedTypeEvent) {
+	public <T> void processAnnotatedType(@Observes ProcessAnnotatedType<T> processAnnotatedTypeEvent) {
 		Contracts.assertNotNull( processAnnotatedTypeEvent, "The ProcessAnnotatedType event cannot be null" );
 
 		// validation globally disabled

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -91,6 +91,18 @@
             <artifactId>wildfly-arquillian-container-managed</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.faces</groupId>
+            <artifactId>javax.faces-api</artifactId>
+            <version>2.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ejb</groupId>
+            <artifactId>ejb-api</artifactId>
+            <version>3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/integration/src/test/java/org/hibernate/validator/integration/util/MyValidator.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/util/MyValidator.java
@@ -6,11 +6,18 @@
  */
 package org.hibernate.validator.integration.util;
 
+import java.util.Collections;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.executable.ExecutableValidator;
 import javax.validation.metadata.BeanDescriptor;
+import javax.validation.metadata.ConstraintDescriptor;
+import javax.validation.metadata.ConstructorDescriptor;
+import javax.validation.metadata.MethodDescriptor;
+import javax.validation.metadata.MethodType;
+import javax.validation.metadata.PropertyDescriptor;
+import javax.validation.metadata.ElementDescriptor.ConstraintFinder;
 
 /**
  * @author Hardy Ferentschik
@@ -19,22 +26,78 @@ public class MyValidator implements Validator {
 
 	@Override
 	public <T> Set<ConstraintViolation<T>> validate(T object, Class<?>... groups) {
-		throw new UnsupportedOperationException();
+		return Collections.emptySet();
 	}
 
 	@Override
 	public <T> Set<ConstraintViolation<T>> validateProperty(T object, String propertyName, Class<?>... groups) {
-		throw new UnsupportedOperationException();
+		return Collections.emptySet();
 	}
 
 	@Override
 	public <T> Set<ConstraintViolation<T>> validateValue(Class<T> beanType, String propertyName, Object value, Class<?>... groups) {
-		throw new UnsupportedOperationException();
+		return Collections.emptySet();
 	}
 
 	@Override
 	public BeanDescriptor getConstraintsForClass(Class<?> clazz) {
-		throw new UnsupportedOperationException();
+		return new BeanDescriptor() {
+
+			@Override
+			public boolean hasConstraints() {
+				return false;
+			}
+
+			@Override
+			public Class<?> getElementClass() {
+				return null;
+			}
+
+			@Override
+			public Set<ConstraintDescriptor<?>> getConstraintDescriptors() {
+				return null;
+			}
+
+			@Override
+			public ConstraintFinder findConstraints() {
+				return null;
+			}
+
+			@Override
+			public boolean isBeanConstrained() {
+				return false;
+			}
+
+			@Override
+			public PropertyDescriptor getConstraintsForProperty(String propertyName) {
+				return null;
+			}
+
+			@Override
+			public MethodDescriptor getConstraintsForMethod(String methodName, Class<?>... parameterTypes) {
+				return null;
+			}
+
+			@Override
+			public ConstructorDescriptor getConstraintsForConstructor(Class<?>... parameterTypes) {
+				return null;
+			}
+
+			@Override
+			public Set<PropertyDescriptor> getConstrainedProperties() {
+				return null;
+			}
+
+			@Override
+			public Set<MethodDescriptor> getConstrainedMethods(MethodType methodType, MethodType... methodTypes) {
+				return null;
+			}
+
+			@Override
+			public Set<ConstructorDescriptor> getConstrainedConstructors() {
+				return null;
+			}
+		};
 	}
 
 	@Override

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/StatelessBeanInterfaceValidationIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/StatelessBeanInterfaceValidationIT.java
@@ -1,0 +1,92 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.integration.wildfly;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+
+import org.hibernate.validator.integration.wildfly.statelessbean.Greeter;
+import org.hibernate.validator.integration.wildfly.statelessbean.StatelessBean;
+import org.hibernate.validator.integration.wildfly.statelessbean.StatelessBeanInterface;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.webapp30.WebAppDescriptor;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Davide D'Alto
+ */
+@TestForIssue(jiraKey = "HV-994")
+@RunWith(Arquillian.class)
+public class StatelessBeanInterfaceValidationIT {
+
+	private static final String CONTEXT_ROOT = "HV994";
+	private static final String WAR_FILE_NAME = StatelessBeanInterfaceValidationIT.class.getSimpleName() + ".war";
+
+	@Deployment
+	public static Archive<?> createTestArchive() {
+		return ShrinkWrap.create( WebArchive.class, WAR_FILE_NAME )
+				.addClasses( StatelessBean.class, StatelessBeanInterface.class, Greeter.class )
+				.addAsWebInfResource( webXml(), "web.xml" )
+				.addAsWebInfResource( jbossWebXml(), "jboss-web.xml" )
+				.addAsWebResource( "StatelessBeanInterfaceValidationIT-index.xhtml", "/index.xhtml" );
+	}
+
+	private static Asset webXml() {
+		String webXml = Descriptors.create( WebAppDescriptor.class )
+				.displayName( "HV-994 Test" )
+				.createWelcomeFileList()
+					.welcomeFile( "index.xhtml" ).up()
+				.createServlet()
+					.servletName( "Faces Servlet" )
+					.servletClass( "javax.faces.webapp.FacesServlet" ).up()
+				.createServletMapping()
+					.servletName( "Faces Servlet" )
+					.urlPattern( "*.xhtml" ).up()
+				.exportAsString();
+		return new StringAsset( webXml );
+	}
+
+	private static Asset jbossWebXml() {
+		String webXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><jboss-web><context-root>/" + CONTEXT_ROOT + "</context-root></jboss-web>";
+		return new StringAsset( webXml );
+	}
+
+	@Inject
+	private Greeter bean;
+
+	@Test
+	public void shouldBeAbleToValidateStatelessBeanFromInterface() {
+		try {
+			bean.getMessage();
+			fail( "Expected a @NotNull validation error, see " + StatelessBeanInterface.class.getSimpleName() + "#lookup(String)" );
+		}
+		catch (Exception e) {
+			assertEquals( ConstraintViolationException.class, e.getCause().getClass() );
+
+			ConstraintViolationException violationException = (ConstraintViolationException) e.getCause();
+			int size = violationException.getConstraintViolations().size();
+			assertEquals( 1, size );
+
+			ConstraintViolation<?> constraintViolation = violationException.getConstraintViolations().iterator().next();
+			assertEquals( "{javax.validation.constraints.NotNull.message}", constraintViolation.getConstraintDescriptor().getMessageTemplate() );
+			assertEquals( "lookup.arg0", constraintViolation.getPropertyPath().toString() );
+		}
+	}
+}

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/statelessbean/Greeter.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/statelessbean/Greeter.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.integration.wildfly.statelessbean;
+
+import javax.inject.Inject;
+
+@javax.faces.bean.ManagedBean(name = "greeter", eager = true)
+public class Greeter {
+
+	@Inject
+	private StatelessBeanInterface bean;
+
+	public String getMessage() {
+		return bean.lookup( null );
+	}
+}

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/statelessbean/StatelessBean.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/statelessbean/StatelessBean.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.integration.wildfly.statelessbean;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class StatelessBean implements StatelessBeanInterface {
+
+	public static final String NULL_MESSAGE = "ERROR （；¬＿¬)";
+
+	@Override
+	public String lookup(String text) {
+		if ( text == null ) {
+			return NULL_MESSAGE;
+		}
+		else {
+			return "Found me!";
+		}
+	}
+}

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/statelessbean/StatelessBeanInterface.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/statelessbean/StatelessBeanInterface.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.integration.wildfly.statelessbean;
+
+import javax.validation.constraints.NotNull;
+
+public interface StatelessBeanInterface {
+
+	String lookup(@NotNull String text);
+}

--- a/integration/src/test/resources/StatelessBeanInterfaceValidationIT-index.xhtml
+++ b/integration/src/test/resources/StatelessBeanInterfaceValidationIT-index.xhtml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:h="http://java.sun.com/jsf/html"
+	xmlns:f="http://java.sun.com/jsf/core">
+<h:body>
+	<f:validateBean validationGroups="javax.validation.groups.Default">
+		<h:outputText value="#{helloWorld.message}" />
+		<h:messages style="color:red" />
+	</f:validateBean>
+</h:body>
+</html>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-994

It seems the `@WithAnnotation` used with `ValidationExtension#processAnnotatedType` does not check constraint defined on interfaces. If remove it, everything works as expected.