### PR TITLE
HV-1019 PathImpl copy constructor fix

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -302,6 +302,7 @@ public final class PathImpl implements Path, Serializable {
 
 	private PathImpl(List<Node> nodeList) {
 		this.nodeList = new ArrayList<Node>( nodeList );
+		this.hashCode = -1;
 	}
 
 	private static PathImpl parseProperty(String propertyName) {


### PR DESCRIPTION
The org.hibernate.validator.internal.engine.path.PathImpl copy constructor sets the hashCode to -1, in order the hashCode to be computed on first attempt to use it.