### PR TITLE
Code Quality Improvement - Constructors should only call non-overridable methods

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
@@ -252,7 +252,7 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 	}
 
 	@Override
-	public HibernateValidatorConfiguration addConstraintDefinitionContributor(ConstraintDefinitionContributor contributor) {
+	public final HibernateValidatorConfiguration addConstraintDefinitionContributor(ConstraintDefinitionContributor contributor) {
 		Contracts.assertNotNull( contributor, MESSAGES.parameterMustNotBeNull( "contributor" ) );
 		constraintDefinitionContributors.add( contributor );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/parser/TokenCollector.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/parser/TokenCollector.java
@@ -102,7 +102,7 @@ public class TokenCollector {
 		terminateToken();
 	}
 
-	public void parse() throws MessageDescriptorFormatException {
+	public final void parse() throws MessageDescriptorFormatException {
 		currentParserState.start( this );
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
@@ -319,7 +319,7 @@ public class NodeImpl
 		return builder.toString();
 	}
 
-	public int buildHashCode() {
+	public final int buildHashCode() {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + ( ( index == null ) ? 0 : index.hashCode() );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/AbstractConstraintMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/AbstractConstraintMetaData.java
@@ -75,7 +75,7 @@ public abstract class AbstractConstraintMetaData implements ConstraintMetaData {
 	}
 
 	@Override
-	public boolean isCascading() {
+	public final boolean isCascading() {
 		return isCascading;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
@@ -333,7 +333,7 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 		}
 
 		@Override
-		public void add(ConstrainedElement constrainedElement) {
+		public final void add(ConstrainedElement constrainedElement) {
 			super.add( constrainedElement );
 			ConstrainedExecutable constrainedExecutable = (ConstrainedExecutable) constrainedElement;
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/PropertyMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/PropertyMetaData.java
@@ -219,7 +219,7 @@ public class PropertyMetaData extends AbstractConstraintMetaData implements Casc
 		}
 
 		@Override
-		public void add(ConstrainedElement constrainedElement) {
+		public final void add(ConstrainedElement constrainedElement) {
 			super.add( constrainedElement );
 
 			// HV-925

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/mixedconfiguration/annotation/Competition.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/mixedconfiguration/annotation/Competition.java
@@ -29,7 +29,7 @@ public abstract class Competition implements ICompetition {
 		return name;
 	}
 
-	public void setName(String name) {
+	public final void setName(String name) {
 		this.name = name;
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/mixedconfiguration/annotation/GameDetail.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/mixedconfiguration/annotation/GameDetail.java
@@ -27,7 +27,7 @@ public class GameDetail {
 		return competition;
 	}
 
-	public void setCompetition(Competition competition) {
+	public final void setCompetition(Competition competition) {
 		this.competition = competition;
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/mixedconfiguration/xml/Competition.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/mixedconfiguration/xml/Competition.java
@@ -24,7 +24,7 @@ public abstract class Competition implements ICompetition {
 		return name;
 	}
 
-	public void setName(String name) {
+	public final void setName(String name) {
 		this.name = name;
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/mixedconfiguration/xml/GameDetail.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/mixedconfiguration/xml/GameDetail.java
@@ -22,7 +22,7 @@ public class GameDetail {
 		return competition;
 	}
 
-	public void setCompetition(Competition competition) {
+	public final void setCompetition(Competition competition) {
 		this.competition = competition;
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1699 - “Constructors should only call non-overridable methods”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1699

Please let me know if you have any questions.

Christian Ivan