### PR TITLE
Code Quality Improvement - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/proxy/ProxyTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/proxy/ProxyTest.java
@@ -58,11 +58,11 @@ public class ProxyTest {
 		}
 
 		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-			if ( method.getName().equals( "getInteger" ) ) {
+			if ( "getInteger".equals( method.getName() ) ) {
 				method.setAccessible( true );
 				return 0;
 			}
-			if ( method.getName().equals( "getString" ) ) {
+			if ( "getString".equals( method.getName() ) ) {
 				return "a";
 			}
 			return method.invoke( o, args );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
@@ -962,16 +962,16 @@ public class TypeHelperTest {
 
 		@Override
 		public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-			if ( method.getName().equals( "getBounds" ) ) {
-				return getBounds();
+			if ( "getBounds".equals( method.getName() ) ) {
+			 	return getBounds();
 			}
-			else if ( method.getName().equals( "getGenericDeclaration" ) ) {
+			else if ( "getGenericDeclaration".equals( method.getName() ) ) {
 				return getGenericDeclaration();
 			}
-			else if ( method.getName().equals( "getName" ) ) {
+			else if ( "getName".equals( method.getName() ) ) {
 				return getName();
 			}
-			else if ( method.getName().equals( "toString" ) ) {
+			else if ( "toString".equals( method.getName() ) ) {
 				return toString();
 			}
 			else {

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/ValidationXmlTestHelper.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/ValidationXmlTestHelper.java
@@ -42,7 +42,7 @@ public class ValidationXmlTestHelper {
 					new ClassLoader( previousContextCl ) {
 						@Override
 						public InputStream getResourceAsStream(String name) {
-							if ( name.equals( "META-INF/validation.xml" ) ) {
+							if ( "META-INF/validation.xml".equals( name ) ) {
 								return clazz.getResourceAsStream( validationXmlName );
 							}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Christian Ivan