### PR TITLE
HV-1048 Fix validator to make to work on JDK9

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/util/Version.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/Version.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.validator.internal.util;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
 /**
@@ -13,6 +16,7 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
  * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2012 SERLI
  */
 public final class Version {
+	private static final Pattern JAVA_VERSION_PATTERN = Pattern.compile( "^(?:1\\.)?(\\d+)$" );
 	static {
 		LoggerFactory.make().version( getVersionString() );
 	}
@@ -30,10 +34,18 @@ public final class Version {
 	 * @return the Java release as an integer (e.g. 8 for Java 8)
 	 */
 	public static int getJavaRelease() {
-		// Will return something like 1.8
-		String[] specificationVersion = System.getProperty( "java.specification.version" ).split( "\\." );
+		// Will return something like 1.8 or 9
+		String vmVersionStr = System.getProperty( "java.specification.version" );
 
-		return Integer.parseInt( specificationVersion[1] );
+		Matcher matcher = JAVA_VERSION_PATTERN.matcher( vmVersionStr );  //match 1.<number> or <number>
+
+		if ( matcher.find() ) {
+			return Integer.valueOf( matcher.group( 1 ) );
+		}
+		else {
+			throw new RuntimeException("Unknown version of jvm " + vmVersionStr);
+		}
+
 	}
 
 	// helper class should not have a public constructor

--- a/pom.xml
+++ b/pom.xml
@@ -599,7 +599,7 @@
                 <plugin>
                     <groupId>org.codehaus.gmaven</groupId>
                     <artifactId>gmaven-plugin</artifactId>
-                    <version>1.4</version>
+                    <version>1.5</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.servicemix.tooling</groupId>

--- a/tck-runner/src/test/resources/test.policy
+++ b/tck-runner/src/test/resources/test.policy
@@ -114,3 +114,10 @@ grant codeBase "file:${localRepository}/org/apache/maven/surefire/-" {
     permission java.security.AllPermission;
 };
 
+
+/* ============= */
+/* jdk internal  */
+/* ============= */
+grant {
+    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal";
+};


### PR DESCRIPTION
Fixes project to make it work on JDK9 with JEP 223 
see http://openjdk.java.net/jeps/223 for more about new versioning.

The change to gmaven plugin is to make build work on windows.
policy change is needed to make tck testsuite pass on java 9.

Without this change WildFly testsuite fails spectacularly as pretty much every EE deployment gets validator enabled and it fails on its init.