### PR TITLE
HV-1055, HV-1057 Fixes around redeclared default group sequences

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/groups/GroupWithInheritance.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/groups/GroupWithInheritance.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.groups;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * Represents a validation group and all the groups it extends ("group inheritance").
+ *
+ * @author Gunnar Morling
+ */
+public class GroupWithInheritance implements Iterable<Group> {
+
+	private final Set<Group> groups;
+
+	public GroupWithInheritance(Set<Group> groups) {
+		this.groups = Collections.unmodifiableSet( groups );
+	}
+
+	@Override
+	public Iterator<Group> iterator() {
+		return groups.iterator();
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/groups/Sequence.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/groups/Sequence.java
@@ -7,12 +7,14 @@
 package org.hibernate.validator.internal.engine.groups;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
 import javax.validation.GroupSequence;
+import javax.validation.groups.Default;
 
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -23,11 +25,25 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
  * @author Hardy Ferentschik
  */
 public class Sequence implements Iterable<GroupWithInheritance> {
+
+	/**
+	 * An "anonymous" sequence with just a single contained element, {@code Default.class}.
+	 */
+	public static Sequence DEFAULT = new Sequence();
+
 	private static final Log log = LoggerFactory.make();
 
 	private final Class<?> sequence;
 	private List<Group> groups;
 	private List<GroupWithInheritance> expandedGroups;
+
+	private Sequence() {
+		this.sequence = Default.class;
+		this.groups = Collections.singletonList( Group.DEFAULT_GROUP );
+		this.expandedGroups = Collections.singletonList(
+				new GroupWithInheritance( Collections.singleton( Group.DEFAULT_GROUP ) )
+		);
+	}
 
 	public Sequence(Class<?> sequence, List<Group> groups) {
 		this.groups = groups;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/groups/Sequence.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/groups/Sequence.java
@@ -6,25 +6,28 @@
  */
 package org.hibernate.validator.internal.engine.groups;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+
 import javax.validation.GroupSequence;
 
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 
 /**
  * Models a group sequence.
  *
  * @author Hardy Ferentschik
  */
-public class Sequence {
+public class Sequence implements Iterable<GroupWithInheritance> {
 	private static final Log log = LoggerFactory.make();
 
 	private final Class<?> sequence;
 	private List<Group> groups;
-	private boolean inheritedGroupsExpanded = false;
+	private List<GroupWithInheritance> expandedGroups;
 
 	public Sequence(Class<?> sequence, List<Group> groups) {
 		this.groups = groups;
@@ -40,17 +43,29 @@ public class Sequence {
 	}
 
 	public void expandInheritedGroups() {
-		if ( inheritedGroupsExpanded ) {
+		if ( expandedGroups != null ) {
 			return;
 		}
 
-		List<Group> expandedGroups = newArrayList();
+		expandedGroups = new ArrayList<GroupWithInheritance>();
+		ArrayList<Group> tmpGroups = new ArrayList<Group>();
+
 		for ( Group group : groups ) {
-			expandedGroups.add( group );
-			addInheritedGroups( group, expandedGroups );
+			HashSet<Group> groupsOfGroup = new HashSet<Group>();
+
+			groupsOfGroup.add( group );
+			addInheritedGroups( group, groupsOfGroup );
+
+			expandedGroups.add( new GroupWithInheritance( groupsOfGroup ) );
+			tmpGroups.addAll( groupsOfGroup );
 		}
-		groups = expandedGroups;
-		inheritedGroupsExpanded = true;
+
+		groups = tmpGroups;
+	}
+
+	@Override
+	public Iterator<GroupWithInheritance> iterator() {
+		return expandedGroups.iterator();
 	}
 
 	@Override
@@ -97,7 +112,7 @@ public class Sequence {
 	 * @param group the group for which the inherited groups need to be added to {@code expandedGroups}
 	 * @param expandedGroups The list into which to add all groups
 	 */
-	private void addInheritedGroups(Group group, List<Group> expandedGroups) {
+	private void addInheritedGroups(Group group, Set<Group> expandedGroups) {
 		for ( Class<?> inheritedGroup : group.getDefiningClass().getInterfaces() ) {
 			if ( isGroupSequence( inheritedGroup ) ) {
 				throw log.getSequenceDefinitionsNotAllowedException();
@@ -112,5 +127,3 @@ public class Sequence {
 		return clazz.getAnnotation( GroupSequence.class ) != null;
 	}
 }
-
-

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/groups/ValidationOrder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/groups/ValidationOrder.java
@@ -6,8 +6,10 @@
  */
 package org.hibernate.validator.internal.engine.groups;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+
 import javax.validation.GroupDefinitionException;
 
 /**
@@ -32,4 +34,34 @@ public interface ValidationOrder {
 	 */
 	void assertDefaultGroupSequenceIsExpandable(List<Class<?>> defaultGroupSequence)
 			throws GroupDefinitionException;
+
+	/**
+	 * A {@link org.hibernate.validator.internal.engine.groups.ValidationOrder} which contains a single sequence which
+	 * in turn contains a single group, {@code Default}.
+	 */
+	ValidationOrder DEFAULT_SEQUENCE = new DefaultValidationOrder();
+
+	static class DefaultValidationOrder implements ValidationOrder {
+
+		private final List<Sequence> defaultSequences;
+
+		private DefaultValidationOrder() {
+			defaultSequences = Collections.singletonList( Sequence.DEFAULT );
+		}
+
+		@Override
+		public Iterator<Group> getGroupIterator() {
+			// Not using emptyIterator() to stay on 1.6 language level
+			return Collections.<Group>emptyList().iterator();
+		}
+
+		@Override
+		public Iterator<Sequence> getSequenceIterator() {
+			return defaultSequences.iterator();
+		}
+
+		@Override
+		public void assertDefaultGroupSequenceIsExpandable(List<Class<?>> defaultGroupSequence) throws GroupDefinitionException {
+		}
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/groups/ValidationOrderGenerator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/groups/ValidationOrderGenerator.java
@@ -89,7 +89,7 @@ public class ValidationOrderGenerator {
 				validationOrder.insertGroup( Group.DEFAULT_GROUP );
 			}
 			else if ( isGroupSequence( clazz ) ) {
-				insertSequence( clazz, validationOrder );
+				insertSequence( clazz, clazz.getAnnotation( GroupSequence.class ).value(), true, validationOrder );
 			}
 			else {
 				Group group = new Group( clazz );
@@ -98,6 +98,12 @@ public class ValidationOrderGenerator {
 			}
 		}
 
+		return validationOrder;
+	}
+
+	public ValidationOrder getDefaultValidationOrder(Class<?> clazz, List<Class<?>> defaultGroupSequence) {
+		DefaultValidationOrder validationOrder = new DefaultValidationOrder();
+		insertSequence( clazz, defaultGroupSequence.toArray( new Class<?>[0] ), false, validationOrder );
 		return validationOrder;
 	}
 
@@ -119,23 +125,25 @@ public class ValidationOrderGenerator {
 		}
 	}
 
-	private void insertSequence(Class<?> sequenceClass, DefaultValidationOrder validationOrder) {
-		Sequence sequence = resolvedSequences.get( sequenceClass );
+	private void insertSequence(Class<?> sequenceClass, Class<?>[] sequenceElements, boolean cache, DefaultValidationOrder validationOrder) {
+		Sequence sequence = cache ? resolvedSequences.get( sequenceClass ) : null;
 		if ( sequence == null ) {
-			sequence = resolveSequence( sequenceClass, new ArrayList<Class<?>>() );
+			sequence = resolveSequence( sequenceClass, sequenceElements, new ArrayList<Class<?>>() );
 			// we expand the inherited groups only after we determined whether the sequence is expandable
 			sequence.expandInheritedGroups();
 
 			// cache already resolved sequences
-			final Sequence cachedResolvedSequence = resolvedSequences.putIfAbsent( sequenceClass, sequence );
-			if ( cachedResolvedSequence != null ) {
-				sequence = cachedResolvedSequence;
+			if ( cache ) {
+				final Sequence cachedResolvedSequence = resolvedSequences.putIfAbsent( sequenceClass, sequence );
+				if ( cachedResolvedSequence != null ) {
+					sequence = cachedResolvedSequence;
+				}
 			}
 		}
 		validationOrder.insertSequence( sequence );
 	}
 
-	private Sequence resolveSequence(Class<?> sequenceClass, List<Class<?>> processedSequences) {
+	private Sequence resolveSequence(Class<?> sequenceClass, Class<?>[] sequenceElements, List<Class<?>> processedSequences) {
 		if ( processedSequences.contains( sequenceClass ) ) {
 			throw log.getCyclicDependencyInGroupsDefinitionException();
 		}
@@ -143,11 +151,9 @@ public class ValidationOrderGenerator {
 			processedSequences.add( sequenceClass );
 		}
 		List<Group> resolvedSequenceGroups = new ArrayList<Group>();
-		GroupSequence sequenceAnnotation = sequenceClass.getAnnotation( GroupSequence.class );
-		Class<?>[] sequenceArray = sequenceAnnotation.value();
-		for ( Class<?> clazz : sequenceArray ) {
+		for ( Class<?> clazz : sequenceElements ) {
 			if ( isGroupSequence( clazz ) ) {
-				Sequence tmpSequence = resolveSequence( clazz, processedSequences );
+				Sequence tmpSequence = resolveSequence( clazz, clazz.getAnnotation( GroupSequence.class ).value(), processedSequences );
 				addGroups( resolvedSequenceGroups, tmpSequence.getComposingGroups() );
 			}
 			else {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/groups/ValidationOrderGenerator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/groups/ValidationOrderGenerator.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
 import javax.validation.GroupSequence;
 import javax.validation.groups.Default;
 
@@ -34,7 +35,7 @@ public class ValidationOrderGenerator {
 
 	public ValidationOrderGenerator() {
 		validationOrderForDefaultGroup = new DefaultValidationOrder();
-		validationOrderForDefaultGroup.insertGroup( new Group( Default.class ) );
+		validationOrderForDefaultGroup.insertGroup( Group.DEFAULT_GROUP );
 	}
 
 	/**
@@ -85,8 +86,7 @@ public class ValidationOrderGenerator {
 		DefaultValidationOrder validationOrder = new DefaultValidationOrder();
 		for ( Class<?> clazz : groups ) {
 			if ( Default.class.equals( clazz ) ) { // HV-621
-				Group group = new Group( clazz );
-				validationOrder.insertGroup( group );
+				validationOrder.insertGroup( Group.DEFAULT_GROUP );
 			}
 			else if ( isGroupSequence( clazz ) ) {
 				insertSequence( clazz, validationOrder );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
@@ -9,10 +9,12 @@ package org.hibernate.validator.internal.metadata;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+
 import javax.validation.ParameterNameProvider;
 
-import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
+import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaDataImpl;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaDataImpl.BeanMetaDataBuilder;
@@ -89,13 +91,15 @@ public class BeanMetaDataManager {
 	 */
 	private final ExecutableHelper executableHelper;
 
+	private final ValidationOrderGenerator validationOrderGenerator = new ValidationOrderGenerator();
+
 	/**
 	 * the three properties in this field affect the invocation of rules associated to section 4.5.5
 	 * of the V1.1 specification.  By default they are all false, if true they allow
 	 * for relaxation of the Liskov Substitution Principal.
 	 */
 	private final MethodValidationConfiguration methodValidationConfiguration;
-	
+
 	/**
 	 * Creates a new {@code BeanMetaDataManager}. {@link DefaultParameterNameProvider} is used as parameter name
 	 * provider, no meta data providers besides the annotation-based providers are used.
@@ -125,7 +129,7 @@ public class BeanMetaDataManager {
 				new MethodValidationConfiguration()
 		);
 	}
-	
+
 	public BeanMetaDataManager(ConstraintHelper constraintHelper,
 			ExecutableHelper executableHelper,
 			ParameterNameProvider parameterNameProvider,
@@ -137,7 +141,7 @@ public class BeanMetaDataManager {
 		this.executableHelper = executableHelper;
 
 		this.methodValidationConfiguration = methodValidationConfiguration;
-		
+
 		this.beanMetaDataCache = new ConcurrentReferenceHashMap<Class<?>, BeanMetaData<?>>(
 				DEFAULT_INITIAL_CAPACITY,
 				DEFAULT_LOAD_FACTOR,
@@ -192,8 +196,8 @@ public class BeanMetaDataManager {
 	 * @return A bean meta data object for the given type.
 	 */
 	private <T> BeanMetaDataImpl<T> createBeanMetaData(Class<T> clazz) {
-		BeanMetaDataBuilder<T> builder = BeanMetaDataBuilder.getInstance( 
-				constraintHelper, executableHelper, clazz, methodValidationConfiguration);
+		BeanMetaDataBuilder<T> builder = BeanMetaDataBuilder.getInstance(
+				constraintHelper, executableHelper, validationOrderGenerator, clazz, methodValidationConfiguration);
 
 		for ( MetaDataProvider provider : metaDataProviders ) {
 			for ( BeanConfiguration<? super T> beanConfiguration : provider.getBeanConfigurationForHierarchy( clazz ) ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaData.java
@@ -6,11 +6,14 @@
  */
 package org.hibernate.validator.internal.metadata.aggregated;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
 import javax.validation.ConstraintDeclarationException;
 import javax.validation.metadata.BeanDescriptor;
 
+import org.hibernate.validator.internal.engine.groups.Sequence;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.facets.Validatable;
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
@@ -62,6 +65,17 @@ public interface BeanMetaData<T> extends Validatable {
 	 * @return a list of classes representing the default group sequence.
 	 */
 	List<Class<?>> getDefaultGroupSequence(T beanState);
+
+	/**
+	 * Returns a {@link org.hibernate.validator.internal.engine.groups.ValidationOrder} representing the default
+	 * validation group sequence as configured through {@code @GroupSequence}/{@code @DefaultGroupSequenceProvider}. If
+	 * this bean type does not re-declare the default validation group sequence {@link org.hibernate.validator.internal.engine.groups.ValidationOrder#DEFAULT_SEQUENCE}
+	 * will be returned.
+	 */
+	// TODO: Ideally, a plain Sequence object should be returned here; I am using ValidationOrder for now to keep
+	// backporting to 4.3 manageable. The expansion of sequences/groups should be moved from ValidationOrder into
+	// Sequence and Group, respectively.
+	Iterator<Sequence> getDefaultValidationSequence(T beanState);
 
 	/**
 	 * @return {@code true} if the entity redefines the default group sequence, {@code false} otherwise.

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -10,12 +10,12 @@ import java.lang.annotation.ElementType;
 import java.lang.reflect.Member;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
 import javax.validation.ElementKind;
 import javax.validation.groups.Default;
 import javax.validation.metadata.BeanDescriptor;
@@ -63,6 +63,11 @@ import static org.hibernate.validator.internal.util.CollectionHelper.partition;
 public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 
 	private static final Log log = LoggerFactory.make();
+
+	/**
+	 * Represents the "sequence" of just Default.class.
+	 */
+	private static final List<Class<?>> DEFAULT_GROUP_SEQUENCE = Collections.<Class<?>>singletonList( Default.class );
 
 	/**
 	 * The root bean class for this meta data.
@@ -341,7 +346,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 			setDefaultGroupSequence( defaultGroupSequence );
 		}
 		else {
-			setDefaultGroupSequence( Arrays.<Class<?>>asList( beanClass ) );
+			this.defaultGroupSequence = DEFAULT_GROUP_SEQUENCE;
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/UnconstrainedEntityMetaDataSingleton.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/UnconstrainedEntityMetaDataSingleton.java
@@ -6,11 +6,14 @@
  */
 package org.hibernate.validator.internal.metadata.aggregated;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+
 import javax.validation.ConstraintDeclarationException;
 import javax.validation.metadata.BeanDescriptor;
 
+import org.hibernate.validator.internal.engine.groups.Sequence;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.facets.Cascadable;
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
@@ -59,6 +62,11 @@ public final class UnconstrainedEntityMetaDataSingleton<T> implements BeanMetaDa
 	@Override
 	public boolean defaultGroupSequenceIsRedefined() {
 		return false;
+	}
+
+	@Override
+	public Iterator<Sequence> getDefaultValidationSequence(T beanState) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/A.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/A.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.groups.defaultgroupwithinheritance;
+
+import javax.validation.GroupSequence;
+import javax.validation.constraints.NotNull;
+
+/**
+ * @author Gunnar Morling
+ */
+@GroupSequence({ Max.class, A.class })
+public class A {
+
+	@NotNull(groups = Max.class)
+	public String foo;
+
+	@NotNull(groups = Min.class)
+	public String bar;
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/B.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/B.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.groups.defaultgroupwithinheritance;
+
+import javax.validation.constraints.NotNull;
+
+/**
+ * @author Gunnar Morling
+ */
+public class B {
+
+	@NotNull(groups = Max.class)
+	public String foo;
+
+	@NotNull(groups = Min.class)
+	public String bar;
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/DefaultGroupWithInheritanceTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/DefaultGroupWithInheritanceTest.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.groups.defaultgroupwithinheritance;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutil.ValidatorUtil;
+import org.testng.annotations.Test;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+
+/**
+ * @author Gunnar Morling
+ */
+public class DefaultGroupWithInheritanceTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1055")
+	public void testGroupInheritanceWithinRedeclaredGroupSequence() {
+		Validator validator = ValidatorUtil.getValidator();
+
+		Set<ConstraintViolation<A>> violations = validator.validate( new A() );
+		assertCorrectPropertyPaths( violations, "foo", "bar" );
+	}
+
+	@Test
+	public void testGroupInheritanceWithinPassedGroupSequence() {
+		Validator validator = ValidatorUtil.getValidator();
+
+		Set<ConstraintViolation<B>> violations = validator.validate( new B(), Max.class, Min.class );
+		assertCorrectPropertyPaths( violations, "foo", "bar" );
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/Max.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/Max.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.groups.defaultgroupwithinheritance;
+
+/**
+ * @author Gunnar Morling
+ */
+public interface Max extends Min {}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/Min.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/Min.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.groups.defaultgroupwithinheritance;
+
+/**
+ * @author Gunnar Morling
+ */
+public interface Min {}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/inheritance/GroupInheritanceTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/inheritance/GroupInheritanceTest.java
@@ -7,12 +7,12 @@
 package org.hibernate.validator.test.internal.engine.groups.inheritance;
 
 import java.util.Set;
+
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
-import org.testng.annotations.Test;
-
 import org.hibernate.validator.testutil.ValidatorUtil;
+import org.testng.annotations.Test;
 
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
@@ -23,17 +23,16 @@ import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertN
 public class GroupInheritanceTest {
 
 	/**
-	 * HV-288
+	 * HV-288, HV-1057.
 	 */
 	@Test
 	public void testGroupInheritanceWithinGroupSequence() {
 		Validator validator = ValidatorUtil.getValidator();
 		Try tryMe = new Try();
-		tryMe.field2 = "foo";
 		tryMe.field3 = "bar";
 
 		Set<ConstraintViolation<Try>> violations = validator.validate( tryMe, Try.GlobalCheck.class );
-		assertCorrectConstraintViolationMessages( violations, "field1" );
+		assertCorrectConstraintViolationMessages( violations, "field1", "field2" );
 	}
 
 	/**

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/sequence/SequenceOfSequencesTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/sequence/SequenceOfSequencesTest.java
@@ -1,0 +1,140 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.groups.sequence;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.GroupSequence;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.test.internal.engine.groups.sequence.SequenceOfSequencesTest.AllConstraints.BasicConstraints;
+import org.hibernate.validator.test.internal.engine.groups.sequence.SequenceOfSequencesTest.AllConstraints.BasicConstraints.OverlyBasicConstraints;
+import org.hibernate.validator.test.internal.engine.groups.sequence.SequenceOfSequencesTest.AllConstraints.BasicConstraints.SomewhatBasicConstraints;
+import org.hibernate.validator.test.internal.engine.groups.sequence.SequenceOfSequencesTest.AllConstraints.ComplexConstraints;
+import org.hibernate.validator.test.internal.engine.groups.sequence.SequenceOfSequencesTest.AllConstraints.ComplexConstraints.ImmenselyComplexConstraints;
+import org.hibernate.validator.test.internal.engine.groups.sequence.SequenceOfSequencesTest.AllConstraints.ComplexConstraints.SomewhatComplexConstraints;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutil.ValidatorUtil;
+import org.testng.annotations.Test;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+
+/**
+ * Sequences may comprise other sequences.
+ *
+ * @author Gunnar Moring
+ */
+public class SequenceOfSequencesTest {
+
+	/**
+	 * A sequence of sequences is passed to the validate() call.
+	 */
+	@Test
+	public void groupSequenceOfGroupSequences() {
+		Validator validator = ValidatorUtil.getValidator();
+
+		PlushAlligator alligator = new PlushAlligator();
+
+		Set<ConstraintViolation<PlushAlligator>> violations = validator.validate( alligator, AllConstraints.class );
+		assertCorrectPropertyPaths( violations, "name" );
+
+		alligator.name = "Ruben";
+		violations = validator.validate( alligator, AllConstraints.class );
+		assertCorrectPropertyPaths( violations, "highestEducationalDegree" );
+
+		alligator.highestEducationalDegree = "PhD";
+		violations = validator.validate( alligator, AllConstraints.class );
+		assertCorrectPropertyPaths( violations, "length" );
+
+		alligator.length = 540;
+		violations = validator.validate( alligator, AllConstraints.class );
+		assertCorrectPropertyPaths( violations, "age" );
+	}
+
+	/**
+	 * A sequence of sequences is used as the default group sequence.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HV-1055")
+	public void defaultGroupSequenceContainsOtherGroupSequences() {
+		Validator validator = ValidatorUtil.getValidator();
+
+		PlushCrocodile crocodile = new PlushCrocodile();
+
+		Set<ConstraintViolation<PlushCrocodile>> violations = validator.validate( crocodile );
+		assertCorrectPropertyPaths( violations, "name" );
+
+		crocodile.name = "Ruben";
+		violations = validator.validate( crocodile, AllConstraints.class );
+		assertCorrectPropertyPaths( violations, "highestEducationalDegree" );
+
+		crocodile.highestEducationalDegree = "PhD";
+		violations = validator.validate( crocodile, AllConstraints.class );
+		assertCorrectPropertyPaths( violations, "length" );
+
+		crocodile.length = 540;
+		violations = validator.validate( crocodile, AllConstraints.class );
+		assertCorrectPropertyPaths( violations, "age" );
+	}
+
+	public static class PlushAlligator {
+
+		@NotNull(groups = OverlyBasicConstraints.class)
+		public String name;
+
+		@NotNull(groups = SomewhatBasicConstraints.class)
+		public String highestEducationalDegree;
+
+		@NotNull(groups = SomewhatComplexConstraints.class)
+		public Integer length;
+
+		@NotNull(groups = ImmenselyComplexConstraints.class)
+		public Integer age;
+	}
+
+	@GroupSequence({ AllConstraints.class, PlushCrocodile.class })
+	public static class PlushCrocodile {
+
+		@NotNull(groups = OverlyBasicConstraints.class)
+		public String name;
+
+		@NotNull(groups = SomewhatBasicConstraints.class)
+		public String highestEducationalDegree;
+
+		@NotNull(groups = SomewhatComplexConstraints.class)
+		public Integer length;
+
+		@NotNull(groups = ImmenselyComplexConstraints.class)
+		public Integer age;
+	}
+
+	@GroupSequence({ BasicConstraints.class, ComplexConstraints.class })
+	public interface AllConstraints {
+
+		@GroupSequence({ OverlyBasicConstraints.class, SomewhatBasicConstraints.class })
+		public interface BasicConstraints {
+
+			public interface OverlyBasicConstraints {
+			}
+
+			public interface SomewhatBasicConstraints {
+			}
+		}
+
+		@GroupSequence({ SomewhatComplexConstraints.class, ImmenselyComplexConstraints.class })
+		public interface ComplexConstraints {
+
+			public interface SomewhatComplexConstraints {
+			}
+
+			public interface ImmenselyComplexConstraints {
+			}
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/validationorder/ValidationOrderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/validationorder/ValidationOrderTest.java
@@ -8,14 +8,14 @@ package org.hibernate.validator.test.internal.engine.groups.validationorder;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.validation.GroupDefinitionException;
 import javax.validation.groups.Default;
-
-import org.testng.annotations.Test;
 
 import org.hibernate.validator.internal.engine.groups.DefaultValidationOrder;
 import org.hibernate.validator.internal.engine.groups.Group;
 import org.hibernate.validator.internal.engine.groups.Sequence;
+import org.testng.annotations.Test;
 
 import static org.testng.FileAssert.fail;
 
@@ -29,7 +29,7 @@ public class ValidationOrderTest {
 		Group a = new Group( GroupA.class );
 		Group b = new Group( GroupB.class );
 		Group c = new Group( GroupC.class );
-		Group defaultGroup = new Group( Default.class );
+		Group defaultGroup = Group.DEFAULT_GROUP;
 
 		List<Group> sequence = new ArrayList<Group>();
 		sequence.add( a );
@@ -87,7 +87,7 @@ public class ValidationOrderTest {
 		Group a = new Group( GroupA.class );
 		Group b = new Group( GroupB.class );
 		Group c = new Group( GroupC.class );
-		Group defaultGroup = new Group( Default.class );
+		Group defaultGroup = Group.DEFAULT_GROUP;
 
 		List<Group> sequence = new ArrayList<Group>();
 		sequence.add( defaultGroup );


### PR DESCRIPTION
Hey @hferentschik, could you take a look at this PR?

The handling of group sequences is quite painful, but I aimed at doing not more changes than needed to fix the issues at bay, as HV-1055 needs backporting to 4.3. In the long run I think we should do some changes, but the topic is complex and it's not quite clear yet to me how it could look eventually.

One thing I dislike specfically is the iteration in the case where the default group is not redefined. We could skip iteration there and just invoke the validation routine once for the default group. But I refrained from doing it for the sake of backportability for now.