### PR TITLE
HV-1058 Some optimizations around BeanMetaDataImpl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
         <paranamer.version>2.5.5</paranamer.version>
         <joda-time.version>2.7</joda-time.version>
         <jsoup.version>1.8.3</jsoup.version>
-        <wildfly.version>10.0.0.CR5</wildfly.version>
+        <wildfly.version>10.0.0.Final</wildfly.version>
         <arquillian.version>1.1.9.Final</arquillian.version>
         <slf4j.version>1.7.2</slf4j.version>
         <jboss.logging.version>3.3.0.Final</jboss.logging.version>


### PR DESCRIPTION
Hey @hferentschik, a quick follow-up to HV-1055.

It avoids the repeated default group sequence retrieval when building the metamodel descriptors and also makes `BeanMetaDataImpl` fully immutable. WF 10 Final update as a bonus :)