### PR TITLE
HV-1082 Upgrade maven-jdocbook-plugin and pressgang

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -525,18 +525,18 @@
                 <plugin>
                     <groupId>org.jboss.maven.plugins</groupId>
                     <artifactId>maven-jdocbook-plugin</artifactId>
-                    <version>2.3.9</version>
+                    <version>2.3.10</version>
                     <extensions>true</extensions>
                     <dependencies>
                         <dependency>
                             <groupId>org.jboss.pressgang</groupId>
                             <artifactId>pressgang-xslt-ns</artifactId>
-                            <version>3.1.3</version>
+                            <version>3.1.4</version>
                         </dependency>
                         <dependency>
                             <groupId>org.hibernate</groupId>
                             <artifactId>hibernate-jdocbook-style</artifactId>
-                            <version>3.0.0</version>
+                            <version>3.0.2</version>
                             <type>jdocbook-style</type>
                         </dependency>
                     </dependencies>


### PR DESCRIPTION
It allows to generate valid HTML5 output and fixes a bug where the user
was not brought to the right place when clicking on an anchor.