### PR TITLE
HV-1066 email domains with a 63 character length fails EmailValidator

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/EmailValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/EmailValidator.java
@@ -36,7 +36,7 @@ public class EmailValidator implements ConstraintValidator<Email, CharSequence> 
 	private static final String IP_DOMAIN = "\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\]";
 	private static final int MAX_LOCAL_PART_LENGTH = 64;
 	private static final int MAX_DOMAIN_PART_LENGTH = 255;
-	private static final int ASCII_MAX_LABEL_LENGTH = 63;
+	private static final int IDN_TO_ASCII_MAX_LABEL_LENGTH = 63;
 
 	/**
 	 * Regular expression for the local part of an email address (everything before '@')
@@ -105,8 +105,7 @@ public class EmailValidator implements ConstraintValidator<Email, CharSequence> 
 	private String toAscii(String unicodeString) throws IllegalArgumentException {
 		String asciiString = "";
 		int start = 0;
-		int index = getBreakingIndex( unicodeString, ASCII_MAX_LABEL_LENGTH );
-		int end = unicodeString.length() <=  index ? unicodeString.length() : index;
+		int end = getIDNToASCIIPartEnd( unicodeString, IDN_TO_ASCII_MAX_LABEL_LENGTH);
 		while ( true ) {
 			// IDN.toASCII only supports a max "label" length of 63 characters. Need to chunk the input in these sizes
 			asciiString += IDN.toASCII( unicodeString.substring( start, end ) );
@@ -114,16 +113,15 @@ public class EmailValidator implements ConstraintValidator<Email, CharSequence> 
 				break;
 			}
 			start = end;
-			index = getBreakingIndex( unicodeString, start + ASCII_MAX_LABEL_LENGTH );
-			end = index > unicodeString.length() ? unicodeString.length() : index;
+			end = getIDNToASCIIPartEnd( unicodeString, start + IDN_TO_ASCII_MAX_LABEL_LENGTH);
 		}
 
 		return asciiString;
 	}
 
-	private int getBreakingIndex(String unicodeString, int index) {
+	private int getIDNToASCIIPartEnd(String unicodeString, int index) {
 		if (unicodeString.length() <= index) {
-			return index;
+			return unicodeString.length();
 		}
 		return unicodeString.charAt( index ) == '.' ? Math.max( 0, index - 1 ) : index;
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/EmailValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/EmailValidatorTest.java
@@ -154,10 +154,12 @@ public class EmailValidatorTest {
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HV-1005")
+	@TestForIssue(jiraKey = {"HV-1005", "HV-1066"})
 	public void testEmailWith64CharacterLocalPartIsValid() {
 		// Local part should allow up to 64 octets: https://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
-		isValidEmail( stringOfLength( 64 ) + "@foo.com" );
+		for (int num = 1; num < 64; num++) {
+			isValidEmail( stringOfLength( num ) + "@foo.com" );
+		}
 	}
 
 	@Test
@@ -167,10 +169,12 @@ public class EmailValidatorTest {
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HV-1005")
+	@TestForIssue(jiraKey = {"HV-1005", "HV-1066"})
 	public void testEmailWith255CharacterDomainPartIsValid() {
 		// Domain part should allow up to 255
-		isValidEmail( "foo@" + stringOfLength( 251 ) + ".com" );
+		for (int num = 1; num < 251; num++) {
+			isValidEmail( "foo@" + stringOfLength( num ) + ".com" );
+		}
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/EmailValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/EmailValidatorTest.java
@@ -157,7 +157,7 @@ public class EmailValidatorTest {
 	@TestForIssue(jiraKey = {"HV-1005", "HV-1066"})
 	public void testEmailWith64CharacterLocalPartIsValid() {
 		// Local part should allow up to 64 octets: https://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
-		for (int num = 1; num < 64; num++) {
+		for (int num = 1; num <= 64; num++) {
 			isValidEmail( stringOfLength( num ) + "@foo.com" );
 		}
 	}
@@ -172,7 +172,8 @@ public class EmailValidatorTest {
 	@TestForIssue(jiraKey = {"HV-1005", "HV-1066"})
 	public void testEmailWith255CharacterDomainPartIsValid() {
 		// Domain part should allow up to 255
-		for (int num = 1; num < 251; num++) {
+		isValidEmail( "foo@" + stringOfLength( 63 ) + ".com" );
+		for (int num = 1; num <= 251; num++) {
 			isValidEmail( "foo@" + stringOfLength( num ) + ".com" );
 		}
 	}


### PR DESCRIPTION
changed the way unicode string is split in  cases when it's length > 63 (the limit for IDN.toASCII). Also updated unit test cases to check for strings of different lengths