### PR TITLE
HV-1066 Don't use IDN.toASCII on the local part of the email

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/EmailValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/EmailValidator.java
@@ -6,15 +6,16 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.hv;
 
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+
 import java.net.IDN;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
 import org.hibernate.validator.constraints.Email;
-
-import static java.util.regex.Pattern.CASE_INSENSITIVE;
 
 /**
  * Checks that a given character sequence (e.g. string) is a well-formed email address.
@@ -29,25 +30,31 @@ import static java.util.regex.Pattern.CASE_INSENSITIVE;
  *
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
+ * @author Guillaume Smet
  */
 public class EmailValidator implements ConstraintValidator<Email, CharSequence> {
-	private static final String ATOM = "[a-z0-9!#$%&'*+/=?^_`{|}~-]";
-	private static final String DOMAIN = ATOM + "+(\\." + ATOM + "+)*";
+	private static final String LOCAL_PART_ATOM = "[a-z0-9!#$%&'*+/=?^_`{|}~\u0080-\uFFFF-]";
+	private static final String DOMAIN_LABEL = "[a-z0-9!#$%&'*+/=?^_`{|}~-]";
+	private static final String DOMAIN = DOMAIN_LABEL + "+(\\." + DOMAIN_LABEL + "+)*";
 	private static final String IP_DOMAIN = "\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\]";
 	private static final int MAX_LOCAL_PART_LENGTH = 64;
+	/**
+	 * This is the maximum length of a domain name. But be aware that each label (parts separated by a dot) of the
+	 * domain name must be at most 63 characters long. This is verified by {@link IDN#toASCII(String)}.
+	 */
 	private static final int MAX_DOMAIN_PART_LENGTH = 255;
 
 	/**
 	 * Regular expression for the local part of an email address (everything before '@')
 	 */
-	private final Pattern localPattern = java.util.regex.Pattern.compile(
-			ATOM + "+(\\." + ATOM + "+)*", CASE_INSENSITIVE
+	private static final Pattern LOCAL_PART_PATTERN = Pattern.compile(
+			LOCAL_PART_ATOM + "+(\\." + LOCAL_PART_ATOM + "+)*", CASE_INSENSITIVE
 	);
 
 	/**
 	 * Regular expression for the domain part of an email address (everything after '@')
 	 */
-	private final Pattern domainPattern = java.util.regex.Pattern.compile(
+	private static final Pattern DOMAIN_PATTERN = Pattern.compile(
 			DOMAIN + "|" + IP_DOMAIN, CASE_INSENSITIVE
 	);
 
@@ -70,51 +77,42 @@ public class EmailValidator implements ConstraintValidator<Email, CharSequence> 
 			return false;
 		}
 
-		// if we have a trailing dot in local or domain part we have an invalid email address.
-		// the regular expression match would take care of this, but IDN.toASCII drops the trailing '.'
-		// (imo a bug in the implementation)
-		if ( emailParts[0].endsWith( "." ) || emailParts[1].endsWith( "." ) ) {
+		if ( !matchLocalPart( emailParts[0] ) ) {
 			return false;
 		}
 
-		if ( !matchPart( emailParts[0], localPattern, MAX_LOCAL_PART_LENGTH ) ) {
-			return false;
-		}
-
-		return matchPart( emailParts[1], domainPattern, MAX_DOMAIN_PART_LENGTH );
+		return matchDomain( emailParts[1] );
 	}
 
-	private boolean matchPart(String part, Pattern pattern, int maxLength) {
+	private boolean matchLocalPart(String localPart) {
+		if ( localPart.length() > MAX_LOCAL_PART_LENGTH ) {
+			return false;
+		}
+		Matcher matcher = LOCAL_PART_PATTERN.matcher( localPart );
+		return matcher.matches();
+	}
+
+	private boolean matchDomain(String domain) {
+		// if we have a trailing dot the domain part we have an invalid email address.
+		// the regular expression match would take care of this, but IDN.toASCII drops the trailing '.'
+		if ( domain.endsWith( "." ) ) {
+			return false;
+		}
+
 		String asciiString;
 		try {
-			asciiString = toAscii( part );
+			asciiString = IDN.toASCII( domain );
 		}
 		catch (IllegalArgumentException e) {
 			return false;
 		}
 
-		if ( asciiString.length() > maxLength ) {
+		if ( asciiString.length() > MAX_DOMAIN_PART_LENGTH ) {
 			return false;
 		}
 
-		Matcher matcher = pattern.matcher( asciiString );
+		Matcher matcher = DOMAIN_PATTERN.matcher( asciiString );
 		return matcher.matches();
 	}
 
-	private String toAscii(String unicodeString) throws IllegalArgumentException {
-		String asciiString = "";
-		int start = 0;
-		int end = unicodeString.length() <= 63 ? unicodeString.length() : 63;
-		while ( true ) {
-			// IDN.toASCII only supports a max "label" length of 63 characters. Need to chunk the input in these sizes
-			asciiString += IDN.toASCII( unicodeString.substring( start, end ) );
-			if ( end == unicodeString.length() ) {
-				break;
-			}
-			start = end;
-			end = start + 63 > unicodeString.length() ? unicodeString.length() : start + 63;
-		}
-
-		return asciiString;
-	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/EmailValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/EmailValidatorTest.java
@@ -6,12 +6,18 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.hv;
 
+import static java.lang.annotation.ElementType.METHOD;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.AssertJUnit.assertEquals;
+
 import java.util.Set;
+
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
-
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
@@ -22,17 +28,12 @@ import org.hibernate.validator.internal.constraintvalidators.hv.EmailValidator;
 import org.hibernate.validator.testutil.MyCustomStringImpl;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.ValidatorUtil;
-
-import static java.lang.annotation.ElementType.METHOD;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.AssertJUnit.assertEquals;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
+ * @author Guillaume Smet
  */
 public class EmailValidatorTest {
 	// http://stackoverflow.com/questions/406230/regular-expression-to-match-string-not-containing-a-word
@@ -74,6 +75,7 @@ public class EmailValidatorTest {
 		isInvalidEmail( "emmanuel@" );
 		isInvalidEmail( "emma\nnuel@hibernate.org" );
 		isInvalidEmail( "emma@nuel@hibernate.org" );
+		isInvalidEmail( "emma@nuel@.hibernate.org" );
 		isInvalidEmail( "Just a string" );
 		isInvalidEmail( "string" );
 		isInvalidEmail( "me@" );
@@ -154,10 +156,12 @@ public class EmailValidatorTest {
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HV-1005")
-	public void testEmailWith64CharacterLocalPartIsValid() {
+	@TestForIssue(jiraKey = { "HV-1005", "HV-1066" })
+	public void testEmailWithUpTo64CharacterLocalPartIsValid() {
 		// Local part should allow up to 64 octets: https://tools.ietf.org/html/rfc5321#section-4.5.3.1.1
-		isValidEmail( stringOfLength( 64 ) + "@foo.com" );
+		for ( int length = 1; length <= 64; length++ ) {
+			isValidEmail( stringOfLength( length ) + "@foo.com" );
+		}
 	}
 
 	@Test
@@ -167,17 +171,25 @@ public class EmailValidatorTest {
 	}
 
 	@Test
-	@TestForIssue(jiraKey = "HV-1005")
-	public void testEmailWith255CharacterDomainPartIsValid() {
+	@TestForIssue(jiraKey = { "HV-1005", "HV-1066" })
+	public void testEmailWithUpTo255CharacterDomainPartIsValid() {
 		// Domain part should allow up to 255
-		isValidEmail( "foo@" + stringOfLength( 251 ) + ".com" );
+		for ( int length = 1; length <= 251; length++ ) {
+			isValidEmail( "foo@" + domainOfLength( length ) + ".com" );
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = { "HV-1005", "HV-1066" })
+	public void testEmailWith63CharactersDomainPartIsValid() {
+		isValidEmail( "foo@" + stringOfLength( 63 ) + "." + stringOfLength( 63 ) + ".com" );
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HV-1005")
 	public void testEmailWith256CharacterDomainPartIsInvalid() {
 		// Domain part should allow up to 255
-		isInvalidEmail( "foo@" + stringOfLength( 252 ) + ".com" );
+		isInvalidEmail( "foo@" + domainOfLength( 252 ) + ".com" );
 	}
 
 	private String stringOfLength(int length) {
@@ -190,25 +202,41 @@ public class EmailValidatorTest {
 		return s;
 	}
 
+	private String domainOfLength(int length) {
+		StringBuilder builder = new StringBuilder();
+		for ( int i = 0; i < length; i++ ) {
+			// we insert a dot from time to time to be sure each label of the domain name is at most 63 characters long
+			if ( i % 32 == 0 && i > 0 && i < length - 1 ) {
+				builder.append( "." );
+			}
+			else {
+				builder.append( 'a' );
+			}
+		}
+		String s = builder.toString();
+		assertEquals( length, s.getBytes().length );
+		return s;
+	}
+
 	private void assertOrgAddressesAreNotValid(Set<ConstraintViolation<EmailContainer>> violations) {
 		assertNumberOfViolations( violations, 1 );
 		assertCorrectConstraintViolationMessages( violations, "ORG addresses are not valid" );
 	}
 
 	private void isValidEmail(CharSequence email, String message) {
-		assertTrue( validator.isValid( email, null ), message );
+		assertTrue( validator.isValid( email, null ), String.format( message, email ) );
 	}
 
 	private void isValidEmail(CharSequence email) {
-		isValidEmail( email, "Expected a valid email." );
+		isValidEmail( email, "Expected %1$s to be a valid email." );
 	}
 
 	private void isInvalidEmail(CharSequence email, String message) {
-		assertFalse( validator.isValid( email, null ), message );
+		assertFalse( validator.isValid( email, null ), String.format( message, email ) );
 	}
 
 	private void isInvalidEmail(CharSequence email) {
-		isInvalidEmail( email, "Expected a invalid email." );
+		isInvalidEmail( email, "Expected %1$s to be an invalid email." );
 	}
 
 	@SuppressWarnings("unused")


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1066

Using IDN.toASCII on the local part of the email was a bad idea to begin
with, forcing us to introduce a splitting logic on top of IDN.toASCII.

Executing IDN.toASCII on each chunk of a split string is not equivalent
to executing it on the whole string, potentially opening the way for
other bugs.

Thus, we ended up doing the following:
- allow the \u0080-\uFFFF character range in the local part of the email
  thus allowing local parts containing UTF-8 characters;
- only use IDN.toASCII on the domain name as it should be.

This simplifies the logic a lot and should limit the number of bugs in
this area.

In passing:
- improve the feedback in email validation tests;
- be more cautious about how we generate the domain names in tests: each
  label of a domain name must be at most 63 characters long.