### PR TITLE
HV-1065 Add hibernate.validator.constraint_mapping_contributors option

### DIFF
--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -292,7 +292,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/constraint
 If you are not bootstrapping a validator factory manually
 but work with the default factory as configured via _META-INF/validation.xml_
 (see <<chapter-xml-configuration>>),
-you can add one or more constraint mappings by creating a constraint mapping contributor.
+you can add one or more constraint mappings by creating one or several constraint mapping contributors.
 To do so, implement the `ConstraintMappingContributor` contract:
 
 [[example-constraint-mapping-contributor]]
@@ -305,7 +305,8 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/constraint
 ====
 
 You then need to specify the fully-qualified class name of the contributor implementation in _META-INF/validation.xml_,
-using the property key `hibernate.validator.constraint_mapping_contributor`.
+using the property key `hibernate.validator.constraint_mapping_contributors`. You can specify several
+contributors by separating them with a comma.
 
 [[section-advanced-constraint-composition]]
 === Advanced constraint composition features

--- a/engine/src/main/java/org/hibernate/validator/HibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/HibernateValidatorConfiguration.java
@@ -62,11 +62,22 @@ public interface HibernateValidatorConfiguration extends Configuration<Hibernate
 	 * the default validator factory. Accepts a String with the fully-qualified class name of a
 	 * {@link org.hibernate.validator.spi.cfg.ConstraintMappingContributor} implementation.
 	 *
+	 * @deprecated use hibernate.validator.constraint_mapping_contributors instead
 	 * @since 5.2
 	 */
+	@Deprecated
 	String CONSTRAINT_MAPPING_CONTRIBUTOR = "hibernate.validator.constraint_mapping_contributor";
 
-	/*
+	/**
+	 * Property for configuring a constraint mapping contributor, allowing to set up one or more constraint mappings for
+	 * the default validator factory. Accepts a String with the comma separated fully-qualified class names of one or more
+	 * {@link org.hibernate.validator.spi.cfg.ConstraintMappingContributor} implementations.
+	 *
+	 * @since 5.3
+	 */
+	String CONSTRAINT_MAPPING_CONTRIBUTORS = "hibernate.validator.constraint_mapping_contributors";
+
+	/**
 	 * Property corresponding to the {@link #timeProvider(TimeProvider)} method. Accepts a String with the
 	 * fully-qualified class name of a {@link TimeProvider} implementation.
 	 *

--- a/engine/src/main/java/org/hibernate/validator/internal/util/StringHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/StringHelper.java
@@ -85,9 +85,20 @@ public class StringHelper {
 		}
 	}
 
+	/**
+	 * Indicates if the string is null or is empty ie only contains whitespaces.
+	 *
+	 * @param value the string considered
+	 * @return true if the string is null or only contains whitespaces
+	 */
+	public static boolean isNullOrEmptyString(String value) {
+		return value == null || value.trim().isEmpty();
+	}
+
 	private static boolean startsWithSeveralUpperCaseLetters(String string) {
 		return string.length() > 1 &&
 				Character.isUpperCase( string.charAt( 0 ) ) &&
 				Character.isUpperCase( string.charAt( 1 ) );
 	}
+
 }

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ConstraintMappingContributorConfiguredInValidationXmlTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ConstraintMappingContributorConfiguredInValidationXmlTest.java
@@ -48,6 +48,9 @@ public class ConstraintMappingContributorConfiguredInValidationXmlTest {
 
 				violations = validator.validate( new Runner() );
 				assertCorrectConstraintTypes( violations, AssertTrue.class );
+
+				violations = validator.validate( new Judge() );
+				assertCorrectConstraintTypes( violations, Min.class );
 			}
 		} );
 
@@ -58,7 +61,7 @@ public class ConstraintMappingContributorConfiguredInValidationXmlTest {
 			runWithCustomValidationXml( validationXmlName, runnable );
 	}
 
-	public static class MyConstraintMappingContributor implements ConstraintMappingContributor {
+	public static class MyConstraintMappingContributor1 implements ConstraintMappingContributor {
 
 		@Override
 		public void createConstraintMappings(ConstraintMappingBuilder builder) {
@@ -68,11 +71,28 @@ public class ConstraintMappingContributorConfiguredInValidationXmlTest {
 						.constraint( new NotNullDef() )
 					.property( "numberOfHelpers", FIELD )
 						.constraint( new MinDef().value( 1 ) );
+		}
+	}
 
+	public static class MyConstraintMappingContributor2 implements ConstraintMappingContributor {
+
+		@Override
+		public void createConstraintMappings(ConstraintMappingBuilder builder) {
 			builder.addConstraintMapping()
 				.type( Runner.class )
 					.property( "paidEntryFee", FIELD )
 						.constraint( new AssertTrueDef() );
+		}
+	}
+
+	public static class MyConstraintMappingContributor3 implements ConstraintMappingContributor {
+
+		@Override
+		public void createConstraintMappings(ConstraintMappingBuilder builder) {
+			builder.addConstraintMapping()
+				.type( Judge.class )
+					.property( "age", FIELD )
+						.constraint( new MinDef().value( 18 ) );
 		}
 	}
 }

--- a/engine/src/test/resources/org/hibernate/validator/test/cfg/constraint-mapping-contributor-validation.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/cfg/constraint-mapping-contributor-validation.xml
@@ -11,5 +11,6 @@
     xsi:schemaLocation="http://jboss.org/xml/ns/javax/validation/configuration validation-configuration-1.1.xsd"
     version="1.1">
 
-    <property name="hibernate.validator.constraint_mapping_contributor">org.hibernate.validator.test.cfg.ConstraintMappingContributorConfiguredInValidationXmlTest$MyConstraintMappingContributor</property>
+    <property name="hibernate.validator.constraint_mapping_contributors">org.hibernate.validator.test.cfg.ConstraintMappingContributorConfiguredInValidationXmlTest$MyConstraintMappingContributor1,org.hibernate.validator.test.cfg.ConstraintMappingContributorConfiguredInValidationXmlTest$MyConstraintMappingContributor2</property>
+    <property name="hibernate.validator.constraint_mapping_contributor">org.hibernate.validator.test.cfg.ConstraintMappingContributorConfiguredInValidationXmlTest$MyConstraintMappingContributor3</property>
 </validation-config>

--- a/integration/src/test/resources/constraint-mapping-contributor-validation.xml
+++ b/integration/src/test/resources/constraint-mapping-contributor-validation.xml
@@ -11,5 +11,5 @@
     xsi:schemaLocation="http://jboss.org/xml/ns/javax/validation/configuration validation-configuration-1.1.xsd"
     version="1.1">
 
-    <property name="hibernate.validator.constraint_mapping_contributor">org.hibernate.validator.integration.wildfly.MyConstraintMappingContributor</property>
+    <property name="hibernate.validator.constraint_mapping_contributors">org.hibernate.validator.integration.wildfly.MyConstraintMappingContributor</property>
 </validation-config>


### PR DESCRIPTION
* https://hibernate.atlassian.net/browse/HV-1065

The current hibernate.validator.constraint_mapping_contributor option
does not accept a comma separated list of contributors which is not in
line with the other options.

Deprecate hibernate.validator.constraint_mapping_contributor. Will be
removed in 6.