### PR TITLE
HV-1069 Replace fest-assert with assertj

### DIFF
--- a/engine-jdk8-tests/pom.xml
+++ b/engine-jdk8-tests/pom.xml
@@ -76,8 +76,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/JavaFXClassLoadingTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/JavaFXClassLoadingTest.java
@@ -11,7 +11,6 @@ import java.security.PrivilegedAction;
 
 import javax.validation.ValidationException;
 
-import org.fest.assertions.Assertions;
 import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
 import org.hibernate.validator.testutil.TestForIssue;
 
@@ -19,6 +18,8 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.classloader.ShrinkWrapClassLoader;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Davide D'Alto
@@ -35,14 +36,14 @@ public class JavaFXClassLoadingTest {
 	public void shouldBeAbleToFindTheClassInTCCL() throws Exception {
 		JavaArchive archive = ShrinkWrap.create( JavaArchive.class ).addClass( JavaFXClassLoadingTest.class );
 		ShrinkWrapClassLoader classLoaderWithoutExpectedClass = new ShrinkWrapClassLoader( (ClassLoader) null, archive );
-		Assertions.assertThat( isClassPresent( JAVAFX_APPLICATION_CLASS, classLoaderWithoutExpectedClass, true ) ).isTrue();
+		assertThat( isClassPresent( JAVAFX_APPLICATION_CLASS, classLoaderWithoutExpectedClass, true ) ).isTrue();
 	}
 
 	@Test
 	public void shouldNotFindTheClass() throws Exception {
 		JavaArchive archive = ShrinkWrap.create( JavaArchive.class ).addClass( JavaFXClassLoadingTest.class );
 		ShrinkWrapClassLoader classLoaderWithoutExpectedClass = new ShrinkWrapClassLoader( (ClassLoader) null, archive );
-		Assertions.assertThat( isClassPresent( JAVAFX_APPLICATION_CLASS, classLoaderWithoutExpectedClass, false ) ).isFalse();
+		assertThat( isClassPresent( JAVAFX_APPLICATION_CLASS, classLoaderWithoutExpectedClass, false ) ).isFalse();
 	}
 
 	private static boolean isClassPresent(String className, ClassLoader classLoader, boolean fallbackOnTCCL) {

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/JavaFXClassLoadingTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/JavaFXClassLoadingTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.test.internal.engine.valuehandling;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
@@ -18,8 +20,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.classloader.ShrinkWrapClassLoader;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Davide D'Alto

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnConstructorTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnConstructorTest.java
@@ -6,6 +6,20 @@
  */
 package org.hibernate.validator.test.internal.engine.valuehandling;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -30,20 +44,6 @@ import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.constraints.NotBlankTypeUse;
 import org.hibernate.validator.testutils.constraints.NotNullTypeUse;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
-
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE_USE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
 /**
  * Test combination of {@link Optional} and {@link UnwrapValidatedValue} on methods.

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnConstructorTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnConstructorTest.java
@@ -20,7 +20,6 @@ import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
-import org.fest.assertions.Assertions;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -39,6 +38,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
@@ -96,7 +96,7 @@ public class OptionalTypeAnnotationConstraintOnConstructorTest {
 		assertNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "ModelB.arg0", "ModelB.arg0" );
 
-		Assertions.assertThat( constraintViolations ).onProperty( "message" ).containsOnly( "container", "type" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
 		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNullTypeUse.class );
 	}
 
@@ -137,7 +137,7 @@ public class OptionalTypeAnnotationConstraintOnConstructorTest {
 				.forExecutables()
 				.validateConstructorParameters( constructor, values );
 
-		Assertions.assertThat( constraintViolations ).isEmpty();
+		assertThat( constraintViolations ).isEmpty();
 	}
 
 	@Test
@@ -150,7 +150,7 @@ public class OptionalTypeAnnotationConstraintOnConstructorTest {
 
 		assertNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "ModelC.arg0", "ModelC.arg0" );
-		Assertions.assertThat( constraintViolations ).onProperty( "message" ).containsOnly( "container", "type" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
 		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class, NotNull.class );
 	}
 
@@ -201,7 +201,7 @@ public class OptionalTypeAnnotationConstraintOnConstructorTest {
 				.forExecutables()
 				.validateConstructorParameters( constructor, values );
 
-		Assertions.assertThat( constraintViolations ).isEmpty();
+		assertThat( constraintViolations ).isEmpty();
 	}
 
 	@ConstraintComposition(CompositionType.OR)

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnFieldTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnFieldTest.java
@@ -6,6 +6,20 @@
  */
 package org.hibernate.validator.test.internal.engine.valuehandling;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -29,20 +43,6 @@ import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.constraints.NotBlankTypeUse;
 import org.hibernate.validator.testutils.constraints.NotNullTypeUse;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
-
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE_USE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
 /**
  * Test combination of {@link Optional} and {@link UnwrapValidatedValue} on fields.

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnFieldTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnFieldTest.java
@@ -19,7 +19,6 @@ import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
-import org.fest.assertions.Assertions;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -38,6 +37,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
@@ -89,7 +89,7 @@ public class OptionalTypeAnnotationConstraintOnFieldTest {
 		assertNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNull", "valueWithNotNull" );
 		// TODO: We don't need to validate the type since the container already failed
-		Assertions.assertThat( constraintViolations ).onProperty( "message" ).containsOnly( "container", "type" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
 		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNullTypeUse.class );
 	}
 
@@ -134,7 +134,7 @@ public class OptionalTypeAnnotationConstraintOnFieldTest {
 		Set<ConstraintViolation<ModelC>> constraintViolations = validator.validate( model );
 		assertNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNullUnwrapped", "valueWithNotNullUnwrapped" );
-		Assertions.assertThat( constraintViolations ).onProperty( "message" ).containsOnly( "container", "type" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
 		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class, NotNull.class );
 	}
 

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnGetterTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnGetterTest.java
@@ -19,7 +19,6 @@ import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
-import org.fest.assertions.Assertions;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -38,6 +37,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
@@ -89,7 +89,7 @@ public class OptionalTypeAnnotationConstraintOnGetterTest {
 		assertNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNull", "valueWithNotNull" );
 		// TODO: We don't need to validate the type since the container already failed
-		Assertions.assertThat( constraintViolations ).onProperty( "message" ).containsOnly( "container", "type" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
 		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNullTypeUse.class );
 	}
 
@@ -123,7 +123,7 @@ public class OptionalTypeAnnotationConstraintOnGetterTest {
 		model.setValueWithNullOrNotBlank( Optional.empty() );
 
 		Set<ConstraintViolation<ModelD>> constraintViolations = validator.validate( model );
-		Assertions.assertThat( constraintViolations ).isEmpty();
+		assertThat( constraintViolations ).isEmpty();
 	}
 
 	@Test
@@ -134,7 +134,7 @@ public class OptionalTypeAnnotationConstraintOnGetterTest {
 		Set<ConstraintViolation<ModelC>> constraintViolations = validator.validate( model );
 		assertNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNullUnwrapped", "valueWithNotNullUnwrapped" );
-		Assertions.assertThat( constraintViolations ).onProperty( "message" ).containsOnly( "container", "type" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
 		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class, NotNull.class );
 	}
 

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnGetterTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnGetterTest.java
@@ -6,6 +6,20 @@
  */
 package org.hibernate.validator.test.internal.engine.valuehandling;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -29,20 +43,6 @@ import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.constraints.NotBlankTypeUse;
 import org.hibernate.validator.testutils.constraints.NotNullTypeUse;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
-
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE_USE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
 /**
  * Test combination of {@link Optional} and {@link UnwrapValidatedValue} on methods.

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnMethodTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnMethodTest.java
@@ -20,7 +20,6 @@ import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
-import org.fest.assertions.Assertions;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -39,6 +38,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
@@ -95,7 +95,7 @@ public class OptionalTypeAnnotationConstraintOnMethodTest {
 
 		assertNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "method.arg0", "method.arg0" );
-		Assertions.assertThat( constraintViolations ).onProperty( "message" ).containsOnly( "container", "type" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
 		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNullTypeUse.class );
 	}
 
@@ -136,7 +136,7 @@ public class OptionalTypeAnnotationConstraintOnMethodTest {
 				.forExecutables()
 				.validateParameters( new ModelD(), method, values );
 
-		Assertions.assertThat( constraintViolations ).isEmpty();
+		assertThat( constraintViolations ).isEmpty();
 	}
 
 	@Test
@@ -149,7 +149,7 @@ public class OptionalTypeAnnotationConstraintOnMethodTest {
 
 		assertNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "method.arg0", "method.arg0" );
-		Assertions.assertThat( constraintViolations ).onProperty( "message" ).containsOnly( "container", "type" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
 		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class, NotNull.class );
 	}
 
@@ -200,7 +200,7 @@ public class OptionalTypeAnnotationConstraintOnMethodTest {
 				.forExecutables()
 				.validateParameters( new ModelE(), method, values );
 
-		Assertions.assertThat( constraintViolations ).isEmpty();
+		assertThat( constraintViolations ).isEmpty();
 	}
 
 	@Test

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnMethodTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnMethodTest.java
@@ -6,6 +6,20 @@
  */
 package org.hibernate.validator.test.internal.engine.valuehandling;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -30,20 +44,6 @@ import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.constraints.NotBlankTypeUse;
 import org.hibernate.validator.testutils.constraints.NotNullTypeUse;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
-
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE_USE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
 /**
  * Test combination of {@link Optional} and {@link UnwrapValidatedValue} on methods.

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintUsingValidatePropertyTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintUsingValidatePropertyTest.java
@@ -19,7 +19,6 @@ import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Null;
 
-import org.fest.assertions.Assertions;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -38,6 +37,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
@@ -94,7 +94,7 @@ public class OptionalTypeAnnotationConstraintUsingValidatePropertyTest {
 		Set<ConstraintViolation<Model>> constraintViolations = validator.validateProperty( model, "valueWithNotNull" );
 		assertNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNull", "valueWithNotNull" );
-		Assertions.assertThat( constraintViolations ).onProperty( "message" ).containsOnly( "container", "type" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
 		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNullTypeUse.class );
 	}
 
@@ -148,7 +148,7 @@ public class OptionalTypeAnnotationConstraintUsingValidatePropertyTest {
 		);
 		assertNumberOfViolations( constraintViolations, 2 );
 		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNullUnwrapped", "valueWithNotNullUnwrapped" );
-		Assertions.assertThat( constraintViolations ).onProperty( "message" ).containsOnly( "container", "type" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
 		assertCorrectConstraintTypes( constraintViolations, NotBlankTypeUse.class, NotNull.class );
 	}
 

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintUsingValidatePropertyTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintUsingValidatePropertyTest.java
@@ -6,6 +6,20 @@
  */
 package org.hibernate.validator.test.internal.engine.valuehandling;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -29,20 +43,6 @@ import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.constraints.NotBlankTypeUse;
 import org.hibernate.validator.testutils.constraints.NotNullTypeUse;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
-
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE_USE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
 /**
  * Test combination of {@link Optional} and {@link UnwrapValidatedValue} on fields using validate property.

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationAwareMetaDataProviderTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationAwareMetaDataProviderTest.java
@@ -30,7 +30,7 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
 import org.hibernate.validator.testutils.constraints.NotBlankTypeUse;
 import org.hibernate.validator.testutils.constraints.NotNullTypeUse;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 
 /**

--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationAwareMetaDataProviderTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationAwareMetaDataProviderTest.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.validator.test.internal.metadata.provider;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Member;
 import java.util.Collections;
@@ -29,9 +32,6 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
 import org.hibernate.validator.testutils.constraints.NotBlankTypeUse;
 import org.hibernate.validator.testutils.constraints.NotNullTypeUse;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 
 /**
  * Tests for {@link org.hibernate.validator.internal.metadata.provider.TypeAnnotationAwareMetaDataProvider}.

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -124,8 +124,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/TimeProviderFutureTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/TimeProviderFutureTest.java
@@ -6,6 +6,10 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv.future;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
+
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -29,10 +33,6 @@ import org.hibernate.validator.spi.time.TimeProvider;
 import org.hibernate.validator.test.internal.xml.XmlMappingTest;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutil.ValidationXmlTestHelper;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 
 /**
  * Test for using the {@code TimeProvider} contract in {@code @Future} validators.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/TimeProviderFutureTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/TimeProviderFutureTest.java
@@ -30,7 +30,7 @@ import org.hibernate.validator.test.internal.xml.XmlMappingTest;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutil.ValidationXmlTestHelper;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
@@ -6,6 +6,14 @@
  */
 package org.hibernate.validator.test.internal.engine.constraintvalidation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
 import java.util.Set;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorFactory;
@@ -26,14 +34,6 @@ import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintVa
 import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
-import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotSame;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
 /**
  * @author Hardy Ferentschik

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
@@ -27,7 +27,7 @@ import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 import org.hibernate.validator.testutil.TestForIssue;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 import static org.testng.Assert.assertEquals;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractConstructorValidationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractConstructorValidationTest.java
@@ -18,7 +18,7 @@ import org.hibernate.validator.test.internal.engine.methodvalidation.model.Custo
 import org.hibernate.validator.test.internal.engine.methodvalidation.service.CustomerRepositoryImpl;
 import org.hibernate.validator.test.internal.engine.methodvalidation.service.CustomerRepositoryImpl.ValidB2BRepository;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNodeKinds;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNodeNames;
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractConstructorValidationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractConstructorValidationTest.java
@@ -6,6 +6,10 @@
  */
 package org.hibernate.validator.test.internal.engine.methodvalidation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNodeKinds;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNodeNames;
+
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.ElementKind;
@@ -17,10 +21,6 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.test.internal.engine.methodvalidation.model.Customer;
 import org.hibernate.validator.test.internal.engine.methodvalidation.service.CustomerRepositoryImpl;
 import org.hibernate.validator.test.internal.engine.methodvalidation.service.CustomerRepositoryImpl.ValidB2BRepository;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNodeKinds;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNodeNames;
 
 /**
  * @author Gunnar Morling

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractMethodValidationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractMethodValidationTest.java
@@ -6,6 +6,18 @@
  */
 package org.hibernate.validator.test.internal.engine.methodvalidation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertConstraintViolation;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNodeKinds;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNodeNames;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidatingProxy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
+
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -32,18 +44,6 @@ import org.hibernate.validator.test.internal.engine.methodvalidation.service.Cus
 import org.hibernate.validator.test.internal.engine.methodvalidation.service.CustomerRepositoryWithConstrainedVoidMethodImpl;
 import org.hibernate.validator.test.internal.engine.methodvalidation.service.RepositoryBase;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertConstraintViolation;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNodeKinds;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNodeNames;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.testutils.ValidatorUtil.getValidatingProxy;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.fail;
 
 /**
  * Integration test for the method-level validation related features of {@link org.hibernate.validator.internal.engine.ValidatorImpl}.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractMethodValidationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractMethodValidationTest.java
@@ -33,7 +33,7 @@ import org.hibernate.validator.test.internal.engine.methodvalidation.service.Cus
 import org.hibernate.validator.test.internal.engine.methodvalidation.service.RepositoryBase;
 import org.hibernate.validator.testutil.TestForIssue;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertConstraintViolation;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
@@ -36,7 +36,7 @@ import org.joda.time.DateMidnight;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
@@ -6,6 +6,11 @@
  */
 package org.hibernate.validator.test.internal.metadata.aggregated;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
@@ -35,11 +40,6 @@ import org.hibernate.validator.testutil.TestForIssue;
 import org.joda.time.DateMidnight;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Tests creation of {@link ExecutableMetaData} in {@link org.hibernate.validator.internal.metadata.aggregated.BeanMetaDataImpl}.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
@@ -6,6 +6,11 @@
  */
 package org.hibernate.validator.test.internal.metadata.aggregated;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -35,11 +40,6 @@ import org.hibernate.validator.test.internal.metadata.Customer;
 import org.hibernate.validator.test.internal.metadata.CustomerRepository;
 import org.hibernate.validator.test.internal.metadata.CustomerRepository.ValidationGroup;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Tests creation of {@link org.hibernate.validator.internal.metadata.raw.ConstrainedParameter} in

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
@@ -36,7 +36,7 @@ import org.hibernate.validator.test.internal.metadata.CustomerRepository;
 import org.hibernate.validator.test.internal.metadata.CustomerRepository.ValidationGroup;
 import org.hibernate.validator.testutil.TestForIssue;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.validator.test.internal.metadata.aggregated;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+
 import java.util.Collections;
 import java.util.Set;
 import javax.validation.ConstraintDeclarationException;
@@ -26,9 +29,6 @@ import org.hibernate.validator.internal.util.ExecutableHelper;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
 
 /**
  * @author Gunnar Morling

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
@@ -27,7 +27,7 @@ import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 
 /**

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/BeanDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/BeanDescriptorTest.java
@@ -31,7 +31,7 @@ import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt;
 import org.hibernate.validator.test.internal.metadata.IllegalCustomerRepositoryExt;
 import org.hibernate.validator.testutil.TestForIssue;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 import static org.hibernate.validator.testutils.ValidatorUtil.getBeanDescriptor;
@@ -312,7 +312,7 @@ public class BeanDescriptorTest {
 		assertThat( getSignatures( constrainedConstructors ) ).containsOnly(
 				Arrays.<Class<?>>asList( String.class ),
 				Arrays.<Class<?>>asList( String.class, Customer.class ),
-				Collections.emptyList(),
+				Collections.<Class<?>>emptyList(),
 				Arrays.<Class<?>>asList( DateMidnight.class, DateMidnight.class )
 		);
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/BeanDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/BeanDescriptorTest.java
@@ -6,6 +6,16 @@
  */
 package org.hibernate.validator.test.internal.metadata.descriptor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.testutils.ValidatorUtil.getBeanDescriptor;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -30,16 +40,6 @@ import org.hibernate.validator.test.internal.metadata.CustomerRepository;
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt;
 import org.hibernate.validator.test.internal.metadata.IllegalCustomerRepositoryExt;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
-import static org.hibernate.validator.testutils.ValidatorUtil.getBeanDescriptor;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Unit test for {@link BeanDescriptor} and its creation.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/ConstructorDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/ConstructorDescriptorTest.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.validator.test.internal.metadata.descriptor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutils.ValidatorUtil.getConstructorDescriptor;
+
 import java.util.List;
 import java.util.Set;
 import javax.validation.metadata.ConstraintDescriptor;
@@ -18,9 +21,6 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.test.internal.metadata.Customer;
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt;
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt.ValidB2BRepository;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutils.ValidatorUtil.getConstructorDescriptor;
 
 /**
  * @author Gunnar Morling

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/ConstructorDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/ConstructorDescriptorTest.java
@@ -19,7 +19,7 @@ import org.hibernate.validator.test.internal.metadata.Customer;
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt;
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt.ValidB2BRepository;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConstructorDescriptor;
 
 /**

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/CrossParameterDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/CrossParameterDescriptorTest.java
@@ -20,7 +20,7 @@ import org.hibernate.validator.test.internal.metadata.CustomerRepository;
 import org.hibernate.validator.test.internal.metadata.CustomerRepository.ValidationGroup;
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertConstraintTypes;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConstructorDescriptor;
 import static org.hibernate.validator.testutils.ValidatorUtil.getMethodDescriptor;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/CrossParameterDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/CrossParameterDescriptorTest.java
@@ -6,6 +6,14 @@
  */
 package org.hibernate.validator.test.internal.metadata.descriptor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertConstraintTypes;
+import static org.hibernate.validator.testutils.ValidatorUtil.getConstructorDescriptor;
+import static org.hibernate.validator.testutils.ValidatorUtil.getMethodDescriptor;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
 import java.util.Set;
 import javax.validation.groups.Default;
 import javax.validation.metadata.ConstraintDescriptor;
@@ -19,14 +27,6 @@ import org.hibernate.validator.test.internal.metadata.ConsistentDateParameters;
 import org.hibernate.validator.test.internal.metadata.CustomerRepository;
 import org.hibernate.validator.test.internal.metadata.CustomerRepository.ValidationGroup;
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertConstraintTypes;
-import static org.hibernate.validator.testutils.ValidatorUtil.getConstructorDescriptor;
-import static org.hibernate.validator.testutils.ValidatorUtil.getMethodDescriptor;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * @author Gunnar Morling

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/MethodDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/MethodDescriptorTest.java
@@ -25,7 +25,7 @@ import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt.Cust
 import org.hibernate.validator.test.internal.metadata.IllegalCustomerRepositoryExt;
 import org.hibernate.validator.testutil.TestForIssue;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.hibernate.validator.testutils.ValidatorUtil.getMethodDescriptor;
 import static org.testng.Assert.assertEquals;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/MethodDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/MethodDescriptorTest.java
@@ -6,6 +6,13 @@
  */
 package org.hibernate.validator.test.internal.metadata.descriptor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.hibernate.validator.testutils.ValidatorUtil.getMethodDescriptor;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
 import java.util.List;
 import java.util.Set;
 import javax.validation.ConstraintDeclarationException;
@@ -24,13 +31,6 @@ import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt;
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt.CustomerExtension;
 import org.hibernate.validator.test.internal.metadata.IllegalCustomerRepositoryExt;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
-import static org.hibernate.validator.testutils.ValidatorUtil.getMethodDescriptor;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * @author Gunnar Morling

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/ReturnValueDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/ReturnValueDescriptorTest.java
@@ -6,6 +6,13 @@
  */
 package org.hibernate.validator.test.internal.metadata.descriptor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertConstraintTypes;
+import static org.hibernate.validator.testutil.DescriptorAssert.assertThat;
+import static org.hibernate.validator.testutils.ValidatorUtil.getMethodReturnValueDescriptor;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
 import java.util.Set;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -24,13 +31,6 @@ import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt;
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt.CustomerRepositoryExtBasic;
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt.CustomerRepositoryExtReturnValueComplex;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertConstraintTypes;
-import static org.hibernate.validator.testutil.DescriptorAssert.assertThat;
-import static org.hibernate.validator.testutils.ValidatorUtil.getMethodReturnValueDescriptor;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * @author Hardy Ferentschik

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/ReturnValueDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/ReturnValueDescriptorTest.java
@@ -25,7 +25,7 @@ import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt.Cust
 import org.hibernate.validator.test.internal.metadata.CustomerRepositoryExt.CustomerRepositoryExtReturnValueComplex;
 import org.hibernate.validator.testutil.TestForIssue;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertConstraintTypes;
 import static org.hibernate.validator.testutil.DescriptorAssert.assertThat;
 import static org.hibernate.validator.testutils.ValidatorUtil.getMethodReturnValueDescriptor;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
@@ -45,7 +45,7 @@ import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
 import static org.testng.Assert.assertEquals;
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
@@ -6,6 +6,12 @@
  */
 package org.hibernate.validator.test.internal.metadata.provider;
 
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+import static org.testng.Assert.assertEquals;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
@@ -42,12 +48,6 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
-
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.testng.Assert.assertEquals;
 
 /**
  * Unit test for {@link AnnotationMetaDataProvider}.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/ExecutableHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/ExecutableHelperTest.java
@@ -18,7 +18,7 @@ import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.test.internal.util.classhierarchy.Novella;
 import org.hibernate.validator.testutil.TestForIssue;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/ExecutableHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/ExecutableHelperTest.java
@@ -6,6 +6,11 @@
  */
 package org.hibernate.validator.test.internal.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Date;
@@ -17,11 +22,6 @@ import org.hibernate.validator.internal.util.ExecutableHelper;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.test.internal.util.classhierarchy.Novella;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Unit test for {@link ExecutableHelper}.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/StringHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/StringHelperTest.java
@@ -12,7 +12,7 @@ import org.testng.annotations.Test;
 
 import org.hibernate.validator.internal.util.StringHelper;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/StringHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/StringHelperTest.java
@@ -6,16 +6,16 @@
  */
 package org.hibernate.validator.test.internal.util;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
 import java.util.Arrays;
 
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.internal.util.StringHelper;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
 
 /**
  * Unit test for {@link StringHelper}.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/annotationfactory/AnnotationProxyTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/annotationfactory/AnnotationProxyTest.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.validator.test.internal.util.annotationfactory;
 
-import static org.fest.assertions.Assertions.assertThat;
-
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -18,6 +16,8 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor;
 import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredMethods;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Gunnar Morling

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/annotationfactory/AnnotationProxyTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/annotationfactory/AnnotationProxyTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.test.internal.util.annotationfactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -16,8 +18,6 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor;
 import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredMethods;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Gunnar Morling

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/classhierarchy/ClassHierarchyHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/classhierarchy/ClassHierarchyHelperTest.java
@@ -6,15 +6,14 @@
  */
 package org.hibernate.validator.test.internal.util.classhierarchy;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
 import org.hibernate.validator.internal.util.classhierarchy.Filters;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 
 /**
  * Unit test for {@link ClassHierarchyHelper}.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/classhierarchy/ClassHierarchyHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/classhierarchy/ClassHierarchyHelperTest.java
@@ -13,7 +13,8 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
 import org.hibernate.validator.internal.util.classhierarchy.Filters;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 /**
  * Unit test for {@link ClassHierarchyHelper}.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlParserHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlParserHelperTest.java
@@ -14,7 +14,7 @@ import org.testng.annotations.Test;
 
 import org.hibernate.validator.internal.xml.XmlParserHelper;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit test for {@link XmlParserHelper}.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlParserHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlParserHelperTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.test.internal.xml;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.InputStream;
 import javax.xml.stream.XMLEventReader;
 
@@ -13,8 +15,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.internal.xml.XmlParserHelper;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Unit test for {@link XmlParserHelper}.

--- a/engine/src/test/java/org/hibernate/validator/test/parameternameprovider/ParanamerParameterNameProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/parameternameprovider/ParanamerParameterNameProviderTest.java
@@ -6,6 +6,10 @@
  */
 package org.hibernate.validator.test.parameternameprovider;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
+
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -23,10 +27,6 @@ import org.testng.annotations.Test;
 
 import org.hibernate.validator.parameternameprovider.ParanamerParameterNameProvider;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
-import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 
 /**
  * Test for {@link ParanamerParameterNameProvider}.

--- a/engine/src/test/java/org/hibernate/validator/test/parameternameprovider/ParanamerParameterNameProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/parameternameprovider/ParanamerParameterNameProviderTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.parameternameprovider.ParanamerParameterNameProvider;
 import org.hibernate.validator.testutil.TestForIssue;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 

--- a/engine/src/test/java/org/hibernate/validator/test/resourceloading/PlatformResourceBundleLocatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/resourceloading/PlatformResourceBundleLocatorTest.java
@@ -6,6 +6,11 @@
  */
 package org.hibernate.validator.test.resourceloading;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+import static org.testng.Assert.assertEquals;
+
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -22,11 +27,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.testng.Assert.assertEquals;
 
 
 /**

--- a/engine/src/test/java/org/hibernate/validator/test/resourceloading/PlatformResourceBundleLocatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/resourceloading/PlatformResourceBundleLocatorTest.java
@@ -23,7 +23,7 @@ import org.testng.annotations.Test;
 
 import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
 import static org.testng.Assert.assertEquals;

--- a/pom.xml
+++ b/pom.xml
@@ -240,9 +240,9 @@
                 <version>3.4</version>
             </dependency>
             <dependency>
-                <groupId>org.easytesting</groupId>
-                <artifactId>fest-assert</artifactId>
-                <version>1.4</version>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.5.2</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -41,9 +41,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -45,9 +45,5 @@
             <artifactId>assertj-core</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-        </dependency>
     </dependencies>
 </project>

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
@@ -7,13 +7,12 @@
 package org.hibernate.validator.testutil;
 
 import static org.assertj.core.api.Fail.fail;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.PathImpl.createNewPath;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.IterableAssert;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
@@ -140,7 +139,7 @@ public final class ConstraintViolationAssert {
 	public static void assertConstraintViolation(ConstraintViolation<?> violation, String errorMessage,
 			Class<?> rootBeanClass, Object invalidValue, String propertyPath) {
 		assertTrue(
-				pathsAreEqual( violation.getPropertyPath(), createNewPath( propertyPath ) ),
+				pathsAreEqual( violation.getPropertyPath(), PathImpl.createNewPath(propertyPath) ),
 				"Wrong propertyPath"
 		);
 		assertConstraintViolation( violation, errorMessage, rootBeanClass, invalidValue );
@@ -340,12 +339,12 @@ public final class ConstraintViolationAssert {
 		return new PathExpectation();
 	}
 
-	public static class ConstraintViolationSetAssert extends ListAssert {
+	public static class ConstraintViolationSetAssert extends IterableAssert {
 
 		private final Set<? extends ConstraintViolation<?>> actualViolations;
 
 		protected ConstraintViolationSetAssert(Set<? extends ConstraintViolation<?>> actualViolations) {
-			super( new ArrayList(actualViolations) );
+			super( actualViolations );
 			this.actualViolations = actualViolations;
 		}
 

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.validator.testutil;
 
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
+
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -21,10 +24,7 @@ import javax.validation.ElementKind;
 import javax.validation.Path;
 import javax.validation.metadata.ConstraintDescriptor;
 
-import org.fest.assertions.Assertions;
-import org.fest.assertions.CollectionAssert;
-
-import static org.fest.assertions.Formatting.format;
+import static org.assertj.core.api.Fail.fail;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.PathImpl.createNewPath;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -69,7 +69,7 @@ public final class ConstraintViolationAssert {
 			actualMessages.add( violation.getMessage() );
 		}
 
-		Assertions.assertThat( actualMessages ).containsOnly( (Object[]) expectedMessages );
+		Assertions.assertThat( actualMessages ).containsOnly( expectedMessages );
 	}
 
 	public static void assertCorrectConstraintViolationMessages(ConstraintViolationException e,
@@ -340,12 +340,12 @@ public final class ConstraintViolationAssert {
 		return new PathExpectation();
 	}
 
-	public static class ConstraintViolationSetAssert extends CollectionAssert {
+	public static class ConstraintViolationSetAssert extends ListAssert {
 
 		private final Set<? extends ConstraintViolation<?>> actualViolations;
 
 		protected ConstraintViolationSetAssert(Set<? extends ConstraintViolation<?>> actualViolations) {
-			super( actualViolations );
+			super( new ArrayList(actualViolations) );
 			this.actualViolations = actualViolations;
 		}
 
@@ -363,14 +363,14 @@ public final class ConstraintViolationAssert {
 			actualPathsTmp.removeAll( expectedPaths );
 
 			if ( !actualPathsTmp.isEmpty() ) {
-				fail( format( "Found unexpected path(s): <%s>. Expected: <%s>", actualPathsTmp, expectedPaths ) );
+				fail( String.format( "Found unexpected path(s): <%s>. Expected: <%s>", actualPathsTmp, expectedPaths ) );
 			}
 
 			List<PathExpectation> expectedPathsTmp = new ArrayList<PathExpectation>( expectedPaths );
 			expectedPathsTmp.removeAll( actualPaths );
 
 			if ( !expectedPathsTmp.isEmpty() ) {
-				fail( format( "Missing expected path(s) <%s>. Actual paths: <%s>", expectedPathsTmp, actualPaths ) );
+				fail( String.format( "Missing expected path(s) <%s>. Actual paths: <%s>", expectedPathsTmp, actualPaths ) );
 			}
 		}
 
@@ -386,7 +386,7 @@ public final class ConstraintViolationAssert {
 				actualPaths.add( actual );
 			}
 
-			fail( format( "Didn't find path <%s> in actual paths <%s>.", expectedPath, actualPaths ) );
+			fail( String.format( "Didn't find path <%s> in actual paths <%s>.", expectedPath, actualPaths ) );
 		}
 
 		public void containsPaths(PathExpectation... expectedPaths) {

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
@@ -6,6 +6,12 @@
  */
 package org.hibernate.validator.testutil;
 
+import static org.assertj.core.api.Fail.fail;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.PathImpl.createNewPath;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ListAssert;
 
@@ -23,12 +29,6 @@ import javax.validation.ConstraintViolationException;
 import javax.validation.ElementKind;
 import javax.validation.Path;
 import javax.validation.metadata.ConstraintDescriptor;
-
-import static org.assertj.core.api.Fail.fail;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.PathImpl.createNewPath;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * This class provides useful functions to assert correctness of constraint violations raised

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/DescriptorAssert.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/DescriptorAssert.java
@@ -40,7 +40,7 @@ public class DescriptorAssert {
 		private final Set<? extends GroupConversionDescriptor> actual;
 
 		protected GroupConversionDescriptorSetAssert(Set<GroupConversionDescriptor> actual) {
-			super( new ArrayList(actual));
+			super( new ArrayList( actual ) );
 			this.actual = actual;
 		}
 

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/DescriptorAssert.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/DescriptorAssert.java
@@ -6,13 +6,13 @@
  */
 package org.hibernate.validator.testutil;
 
+import static org.assertj.core.api.Fail.fail;
+
 import org.assertj.core.api.ListAssert;
 
 import java.util.ArrayList;
 import java.util.Set;
 import javax.validation.metadata.GroupConversionDescriptor;
-
-import static org.assertj.core.api.Fail.fail;
 
 /**
  * Provides assertion methods for testing {@link javax.validation.metadata.ElementDescriptor}

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/DescriptorAssert.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/DescriptorAssert.java
@@ -8,9 +8,8 @@ package org.hibernate.validator.testutil;
 
 import static org.assertj.core.api.Fail.fail;
 
-import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.IterableAssert;
 
-import java.util.ArrayList;
 import java.util.Set;
 import javax.validation.metadata.GroupConversionDescriptor;
 
@@ -35,12 +34,12 @@ public class DescriptorAssert {
 	 *
 	 * @author Gunnar Morling
 	 */
-	public static class GroupConversionDescriptorSetAssert extends ListAssert {
+	public static class GroupConversionDescriptorSetAssert extends IterableAssert {
 
 		private final Set<? extends GroupConversionDescriptor> actual;
 
 		protected GroupConversionDescriptorSetAssert(Set<GroupConversionDescriptor> actual) {
-			super( new ArrayList( actual ) );
+			super( actual );
 			this.actual = actual;
 		}
 

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/DescriptorAssert.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/DescriptorAssert.java
@@ -6,12 +6,13 @@
  */
 package org.hibernate.validator.testutil;
 
+import org.assertj.core.api.ListAssert;
+
+import java.util.ArrayList;
 import java.util.Set;
 import javax.validation.metadata.GroupConversionDescriptor;
 
-import org.fest.assertions.CollectionAssert;
-
-import static org.fest.assertions.Formatting.format;
+import static org.assertj.core.api.Fail.fail;
 
 /**
  * Provides assertion methods for testing {@link javax.validation.metadata.ElementDescriptor}
@@ -34,10 +35,13 @@ public class DescriptorAssert {
 	 *
 	 * @author Gunnar Morling
 	 */
-	public static class GroupConversionDescriptorSetAssert extends CollectionAssert {
+	public static class GroupConversionDescriptorSetAssert extends ListAssert {
+
+		private final Set<? extends GroupConversionDescriptor> actual;
 
 		protected GroupConversionDescriptorSetAssert(Set<GroupConversionDescriptor> actual) {
-			super( actual );
+			super( new ArrayList(actual));
+			this.actual = actual;
 		}
 
 		public void containsConversion(Class<?> from, Class<?> to) {
@@ -57,7 +61,7 @@ public class DescriptorAssert {
 			}
 
 			if ( !foundMatchingConversion ) {
-				fail( format( "<%s> does not contain a conversion from <%s> to <%s>.", actual, from, to ) );
+				fail( String.format( "<%s> does not contain a conversion from <%s> to <%s>.", actual, from, to ) );
 			}
 		}
 	}


### PR DESCRIPTION
Changed the library from fest-assert to assertj.
Replaced all imports and migrated all method calls according to a migration guide  (http://joel-costigliola.github.io/assertj/assertj-core-migrating-from-fest.html#fest-1.4)
Two classes that require more detailed review are :  ConstraintViolationAssert and DescriptorAssert