### PR TITLE
HV-1056 Avoid usage of ReflectionHelper#getPropertyName() in validation code path

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -558,9 +558,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 
 		if ( metaConstraint.getElementType() != ElementType.TYPE ) {
 			PropertyMetaData propertyMetaData = beanMetaDataManager.getBeanMetaData( valueContext.getCurrentBeanType() )
-					.getMetaDataFor(
-							ReflectionHelper.getPropertyName( metaConstraint.getLocation().getMember() )
-					);
+					.getMetaDataFor( metaConstraint.getLocation().getPropertyName() );
 
 			if ( !propertyPathComplete ) {
 				valueContext.appendNode( propertyMetaData );
@@ -592,9 +590,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		boolean validationSuccessful;
 
 		PropertyMetaData propertyMetaData = beanMetaDataManager.getBeanMetaData( valueContext.getCurrentBeanType() )
-				.getMetaDataFor(
-						ReflectionHelper.getPropertyName( metaConstraint.getLocation().getMember() )
-				);
+				.getMetaDataFor( metaConstraint.getLocation().getPropertyName() );
 
 		if ( !propertyPathComplete ) {
 			valueContext.appendNode( propertyMetaData );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/PropertyMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/PropertyMetaData.java
@@ -235,7 +235,7 @@ public class PropertyMetaData extends AbstractConstraintMetaData implements Casc
 		public Builder(Class<?> beanClass, ConstrainedField constrainedField, ConstraintHelper constraintHelper) {
 			super( beanClass, constraintHelper );
 
-			this.propertyName = ReflectionHelper.getPropertyName( constrainedField.getLocation().getMember() );
+			this.propertyName = constrainedField.getLocation().getPropertyName();
 			this.propertyType = ReflectionHelper.typeOf( constrainedField.getLocation().getMember() );
 			add( constrainedField );
 		}
@@ -251,7 +251,7 @@ public class PropertyMetaData extends AbstractConstraintMetaData implements Casc
 		public Builder(Class<?> beanClass, ConstrainedExecutable constrainedMethod, ConstraintHelper constraintHelper) {
 			super( beanClass, constraintHelper );
 
-			this.propertyName = ReflectionHelper.getPropertyName( constrainedMethod.getLocation().getMember() );
+			this.propertyName = constrainedMethod.getLocation().getPropertyName();
 			this.propertyType = ReflectionHelper.typeOf( constrainedMethod.getLocation().getMember() );
 			add( constrainedMethod );
 		}
@@ -268,7 +268,7 @@ public class PropertyMetaData extends AbstractConstraintMetaData implements Casc
 			}
 
 			return equals(
-					ReflectionHelper.getPropertyName( constrainedElement.getLocation().getMember() ),
+					constrainedElement.getLocation().getPropertyName(),
 					propertyName
 			);
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/location/ConstraintLocation.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/location/ConstraintLocation.java
@@ -46,6 +46,11 @@ public class ConstraintLocation {
 	 */
 	private final Type typeForValidatorResolution;
 
+	/**
+	 * The property name of a member.
+	 */
+	private final String propertyName;
+
 	public static ConstraintLocation forClass(Class<?> declaringClass) {
 		// HV-623 - create a ParameterizedType in case the class has type parameters. Needed for constraint validator
 		// resolution (HF)
@@ -99,6 +104,7 @@ public class ConstraintLocation {
 	private ConstraintLocation(Class<?> declaringClass, Member member, Type typeOfAnnotatedElement) {
 		this.declaringClass = declaringClass;
 		this.member = member;
+		this.propertyName = member == null ? null : ReflectionHelper.getPropertyName( member );
 
 		if ( typeOfAnnotatedElement instanceof Class && ( (Class<?>) typeOfAnnotatedElement ).isPrimitive() ) {
 			this.typeForValidatorResolution = ReflectionHelper.boxedType( (Class<?>) typeOfAnnotatedElement );
@@ -124,6 +130,14 @@ public class ConstraintLocation {
 	 */
 	public Member getMember() {
 		return member;
+	}
+
+	/**
+	 * Returns the property name of the member represented by this location.
+	 * @return the property name of member represented by this location. Will be {@code null} when this location represents a type.
+	 */
+	public String getPropertyName() {
+		return propertyName;
 	}
 
 	/**


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1056

added cached property name to ConstraintLocation and replaced calls to ReflectionHelper#getPropertyName() with a getter from ConstraintLocation

@gunnarmorling is that what you had in mind ? Should it be lazy initialised ?