### PR TITLE
HV-1102 Add org.junit to the Checkstyle IllegalImport rule

### DIFF
--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/ConstraintCheckFactory.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/ConstraintCheckFactory.java
@@ -70,16 +70,18 @@ public class ConstraintCheckFactory {
 		methodChecks = CollectionHelper.newHashMap();
 		methodChecks.put(
 				AnnotationType.CONSTRAINT_ANNOTATION,
-				new SingleValuedChecks( new GetterCheck(methodConstraintsSupported), new StaticCheck(), new MethodAnnotationCheck(constraintHelper), new TypeCheck( constraintHelper ) )
+				new SingleValuedChecks( new GetterCheck( methodConstraintsSupported ), new StaticCheck(), new MethodAnnotationCheck( constraintHelper ),
+						new TypeCheck( constraintHelper ) )
 		);
 		methodChecks.put(
 				AnnotationType.MULTI_VALUED_CONSTRAINT_ANNOTATION, new MultiValuedChecks(
-						constraintHelper, new GetterCheck(methodConstraintsSupported), new StaticCheck(), new MethodAnnotationCheck(constraintHelper), new TypeCheck( constraintHelper )
-				)
+						constraintHelper, new GetterCheck( methodConstraintsSupported ), new StaticCheck(), new MethodAnnotationCheck( constraintHelper ),
+						new TypeCheck( constraintHelper ) )
 		);
 		methodChecks.put(
 				AnnotationType.GRAPH_VALIDATION_ANNOTATION,
-				new SingleValuedChecks( new GetterCheck(methodConstraintsSupported), new StaticCheck(), new MethodAnnotationCheck(constraintHelper), new PrimitiveCheck() )
+				new SingleValuedChecks( new GetterCheck( methodConstraintsSupported ), new StaticCheck(), new MethodAnnotationCheck( constraintHelper ),
+						new PrimitiveCheck() )
 		);
 		methodChecks.put( AnnotationType.NO_CONSTRAINT_ANNOTATION, NULL_CHECKS );
 
@@ -99,7 +101,7 @@ public class ConstraintCheckFactory {
 						new TargetCheck( annotationApiHelper ),
 						new ConstraintValidatorCheck( constraintHelper, annotationApiHelper ),
 						new AnnotationTypeMemberCheck( annotationApiHelper, typeUtils ),
-						new CrossParameterConstraintCheck(annotationApiHelper, constraintHelper, typeUtils)
+						new CrossParameterConstraintCheck( annotationApiHelper, constraintHelper, typeUtils )
 				)
 		);
 		annotationTypeChecks.put( AnnotationType.NO_CONSTRAINT_ANNOTATION, NULL_CHECKS );

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/util/ConstraintHelper.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/util/ConstraintHelper.java
@@ -770,7 +770,7 @@ public class ConstraintHelper {
 		for ( AnnotationValue oneValidatorClassReference : validatorClassReferences ) {
 
 			if ( isValidationTargetSupported( oneValidatorClassReference, target ) ) {
-				TypeMirror supportedType = determineSupportedType( oneValidatorClassReference);
+				TypeMirror supportedType = determineSupportedType( oneValidatorClassReference );
 				supportedTypes.add( supportedType );
 			}
 		}

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/AnnotationTypeValidationTest.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/AnnotationTypeValidationTest.java
@@ -179,7 +179,7 @@ public class AnnotationTypeValidationTest extends ConstraintValidationProcessorT
 		};
 
 		boolean compilationResult =
-				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles);
+				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles );
 
 		assertFalse( compilationResult );
 		assertThatDiagnosticsMatch(
@@ -197,7 +197,7 @@ public class AnnotationTypeValidationTest extends ConstraintValidationProcessorT
 		};
 
 		boolean compilationResult =
-				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles);
+				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles );
 
 		assertFalse( compilationResult );
 		assertThatDiagnosticsMatch(
@@ -215,7 +215,7 @@ public class AnnotationTypeValidationTest extends ConstraintValidationProcessorT
 		};
 
 		boolean compilationResult =
-				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles);
+				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles );
 
 		assertFalse( compilationResult );
 		assertThatDiagnosticsMatch(
@@ -233,7 +233,7 @@ public class AnnotationTypeValidationTest extends ConstraintValidationProcessorT
 		};
 
 		boolean compilationResult =
-				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles);
+				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles );
 
 		assertFalse( compilationResult );
 		assertThatDiagnosticsMatch(
@@ -252,7 +252,7 @@ public class AnnotationTypeValidationTest extends ConstraintValidationProcessorT
 		};
 
 		boolean compilationResult =
-				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles);
+				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles );
 
 		assertFalse( compilationResult );
 		assertThatDiagnosticsMatch(
@@ -274,7 +274,7 @@ public class AnnotationTypeValidationTest extends ConstraintValidationProcessorT
 		};
 
 		boolean compilationResult =
-				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles);
+				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFiles );
 
 		assertTrue( compilationResult );
 	}

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorTest.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorTest.java
@@ -560,7 +560,7 @@ public class ConstraintValidationProcessorTest extends ConstraintValidationProce
 		};
 
 		boolean compilationResult =
-				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, false, true, sourceFiles);
+				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, false, true, sourceFiles );
 
 		assertFalse( compilationResult );
 		assertThatDiagnosticsMatch(

--- a/build-config/src/main/resources/checkstyle-documentation.xml
+++ b/build-config/src/main/resources/checkstyle-documentation.xml
@@ -125,11 +125,9 @@
                         STATIC_INIT, INSTANCE_INIT" />
         </module>
 
-        <!-- METHOD_CALL breaks inline casts
-            (i.e. Iterable<?> collection = ((Map<?,?>) value).values();)
-            in 6.15-->
         <module name="ParenPad">
-            <property name="tokens" value="CTOR_CALL, SUPER_CTOR_CALL"/>
+            <property name="tokens" value="CTOR_CALL, METHOD_CALL, SUPER_CTOR_CALL, LITERAL_FOR, LITERAL_IF,
+                        LITERAL_WHILE, LITERAL_SWITCH, LITERAL_NEW"/>
             <property name="option" value="space"/>
         </module>
 

--- a/build-config/src/main/resources/checkstyle-documentation.xml
+++ b/build-config/src/main/resources/checkstyle-documentation.xml
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+<module name="Checker">
+
+    <module name="TreeWalker">
+        <property name="cacheFile" value="${checkstyle.cache.file}"/>
+
+        <module name="RegexpSinglelineJava">
+            <!-- do not allow a package declaration that contains ".target." or "target;"  -->
+            <property name="format" value="^package .*\.target[\.;]"/>
+            <property name="message" value="Do not use &quot;target&quot; as package name element"/>
+        </module>
+
+        <!-- Use tabs -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^ +\t*\S" />
+            <property name="message" value="Line has leading space characters; indentation should be performed with tabs only." />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <!-- Check parentheses padding -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t+(if|for|while|catch)([^ ])\(" />
+            <property name="message" value="Left parentheses should be preceeded by 1 whitespace" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t+(if|for|while) \( .+[^ ]\) \{$" />
+            <property name="message" value="Right parentheses should be preceeded by 1 white space" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t+(if|for|while) \([^ $]" />
+            <property name="message" value="Left parentheses should be followed by 1 whitespace" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="\)([^ ])\{$" />
+            <property name="message" value="Right parentheses should be followed by 1 white space" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="catch \([^\w]" />
+            <property name="message" value="'catch' clause does not require white space after left parentheses" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="catch \(.*\s\) \{" />
+            <property name="message" value="'catch' clause does not require white space before right parentheses" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="\)\s+;$" />
+            <property name="message" value="Unecessary whitespace after parentheses" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <!-- Checks for imports -->
+        <module name="AvoidStarImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+
+        <!-- Checks for common coding problems -->
+        <module name="EqualsHashCode" />
+        <module name="IllegalInstantiation" />
+
+        <!-- Miscellaneous other checks. -->
+        <module name="ModifierOrder" />
+        <module name="GenericWhitespace" />
+        <module name="PackageAnnotation" />
+        <module name="CovariantEquals" />
+        <module name="ModifiedControlVariable" />
+        <module name="NeedBraces" />
+        <module name="OneStatementPerLine" />
+        <module name="EmptyStatement" />
+        <module name="DefaultComesLast" />
+        <module name="WhitespaceAround" />
+        <module name="TypecastParenPad" />
+        <module name="HideUtilityClassConstructor"/>
+        <module name="MutableException"/>
+        <module name="CovariantEquals" />
+        <module name="EqualsAvoidNull" />
+        <module name="UpperEll"/>
+        <module name="ArrayTypeStyle"/>
+
+        <!-- not checking for Constructor here: -->
+        <module name="RedundantModifier">
+            <property name="tokens"
+                      value="METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF, CLASS_DEF, ENUM_DEF"/>
+        </module>
+        <module name="MissingOverride" />
+
+        <module name="MethodParamPad">
+            <property name="option" value="nospace" />
+            <property name="allowLineBreaks" value="false" />
+        </module>
+
+        <!-- Checks for blocks. You know, those {}'s, not doing this for methods because of 1 line getters/setters-->
+        <module name="LeftCurly">
+            <property name="option" value="eol"/>
+            <property name="tokens" value="INTERFACE_DEF, CLASS_DEF, ANNOTATION_DEF, ENUM_DEF, CTOR_DEF,
+                        ENUM_CONSTANT_DEF, LITERAL_WHILE, LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY,
+                        LITERAL_SYNCHRONIZED, LITERAL_SWITCH, LITERAL_DO, LITERAL_IF, LITERAL_ELSE, LITERAL_FOR,
+                        STATIC_INIT, OBJBLOCK" />
+        </module>
+        <!-- not doing this for methods because of 1 line getters/setters -->
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF,
+                        LITERAL_ELSE, CLASS_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE,
+                        STATIC_INIT, INSTANCE_INIT" />
+        </module>
+
+        <!-- METHOD_CALL breaks inline casts
+            (i.e. Iterable<?> collection = ((Map<?,?>) value).values();)
+            in 6.15-->
+        <module name="ParenPad">
+            <property name="tokens" value="CTOR_CALL, SUPER_CTOR_CALL"/>
+            <property name="option" value="space"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="System\.(out)|(err)\.print(ln)?\(" />
+            <!-- The last sentence of the message is a keyword to trigger exclusion: see ExcludeTestPackages -->
+            <property name="message" value="Not allowed to print to System.out: if you're damn sure you want it, disable Checkstyle on this line. [not required for tests]" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <!-- Nobody should be using StringBuffer anymore -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value=" StringBuffer" />
+            <!-- The last sentence of the message is a keyword to trigger exclusion: see ExcludeTestPackages -->
+            <property name="message" value="Nobody should be using StringBuffer anymore" />
+        </module>
+
+        <!-- Required to get SuppressionCommentFilter to work -->
+        <module name="FileContentsHolder" />
+
+        <!--  Avoid some import statements -->
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="java.awt, sun, org.slf4j, junit.framework"/>
+        </module>
+
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$" />
+        <property name="message" value="White spaces at the end of line" />
+    </module>
+
+    <module name="SuppressionCommentFilter" />
+
+    <module name="SuppressionFilter">
+        <property name="file" value="/suppressions.xml" />
+    </module>
+
+    <!-- Checks that a file ends with a new line  -->
+    <module name="NewlineAtEndOfFile"/>
+
+</module>

--- a/build-config/src/main/resources/checkstyle-junit.xml
+++ b/build-config/src/main/resources/checkstyle-junit.xml
@@ -135,11 +135,9 @@
                         STATIC_INIT, INSTANCE_INIT" />
         </module>
 
-        <!-- METHOD_CALL breaks inline casts
-            (i.e. Iterable<?> collection = ((Map<?,?>) value).values();)
-            in 6.15-->
         <module name="ParenPad">
-            <property name="tokens" value="CTOR_CALL, SUPER_CTOR_CALL"/>
+            <property name="tokens" value="CTOR_CALL, METHOD_CALL, SUPER_CTOR_CALL, LITERAL_FOR, LITERAL_IF,
+                        LITERAL_WHILE, LITERAL_SWITCH, LITERAL_NEW"/>
             <property name="option" value="space"/>
         </module>
 

--- a/build-config/src/main/resources/checkstyle-junit.xml
+++ b/build-config/src/main/resources/checkstyle-junit.xml
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+<module name="Checker">
+
+    <module name="RegexpHeader">
+        <property name="headerFile" value="/java.header"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
+    <module name="RegexpHeader">
+        <property name="headerFile" value="/xml.header"/>
+        <property name="fileExtensions" value="xml"/>
+    </module>
+
+    <module name="TreeWalker">
+        <property name="cacheFile" value="${checkstyle.cache.file}"/>
+
+        <module name="RegexpSinglelineJava">
+            <!-- do not allow a package declaration that contains ".target." or "target;"  -->
+            <property name="format" value="^package .*\.target[\.;]"/>
+            <property name="message" value="Do not use &quot;target&quot; as package name element"/>
+        </module>
+
+        <!-- Use tabs -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^ +\t*\S" />
+            <property name="message" value="Line has leading space characters; indentation should be performed with tabs only." />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <!-- Check parentheses padding -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t+(if|for|while|catch)([^ ])\(" />
+            <property name="message" value="Left parentheses should be preceeded by 1 whitespace" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t+(if|for|while) \( .+[^ ]\) \{$" />
+            <property name="message" value="Right parentheses should be preceeded by 1 white space" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="^\t+(if|for|while) \([^ $]" />
+            <property name="message" value="Left parentheses should be followed by 1 whitespace" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="\)([^ ])\{$" />
+            <property name="message" value="Right parentheses should be followed by 1 white space" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="catch \([^\w]" />
+            <property name="message" value="'catch' clause does not require white space after left parentheses" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="catch \(.*\s\) \{" />
+            <property name="message" value="'catch' clause does not require white space before right parentheses" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="\)\s+;$" />
+            <property name="message" value="Unecessary whitespace after parentheses" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <!-- Checks for imports -->
+        <module name="AvoidStarImport"/>
+        <module name="RedundantImport"/>
+        <module name="UnusedImports"/>
+
+        <!-- Checks for common coding problems -->
+        <module name="EqualsHashCode" />
+        <module name="IllegalInstantiation" />
+
+        <!-- Miscellaneous other checks. -->
+        <module name="ModifierOrder" />
+        <module name="GenericWhitespace" />
+        <module name="PackageAnnotation" />
+        <module name="CovariantEquals" />
+        <module name="ModifiedControlVariable" />
+        <module name="NeedBraces" />
+        <module name="OneStatementPerLine" />
+        <module name="EmptyStatement" />
+        <module name="DefaultComesLast" />
+        <module name="WhitespaceAround" />
+        <module name="TypecastParenPad" />
+        <module name="HideUtilityClassConstructor"/>
+        <module name="MutableException"/>
+        <module name="CovariantEquals" />
+        <module name="EqualsAvoidNull" />
+        <module name="UpperEll"/>
+        <module name="ArrayTypeStyle"/>
+
+        <!-- not checking for Constructor here: -->
+        <module name="RedundantModifier">
+            <property name="tokens"
+                      value="METHOD_DEF, VARIABLE_DEF, ANNOTATION_FIELD_DEF, INTERFACE_DEF, CLASS_DEF, ENUM_DEF"/>
+        </module>
+        <module name="MissingOverride" />
+
+        <module name="MethodParamPad">
+            <property name="option" value="nospace" />
+            <property name="allowLineBreaks" value="false" />
+        </module>
+
+        <!-- Checks for blocks. You know, those {}'s, not doing this for methods because of 1 line getters/setters-->
+        <module name="LeftCurly">
+            <property name="option" value="eol"/>
+            <property name="tokens" value="INTERFACE_DEF, CLASS_DEF, ANNOTATION_DEF, ENUM_DEF, CTOR_DEF,
+                        ENUM_CONSTANT_DEF, LITERAL_WHILE, LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY,
+                        LITERAL_SYNCHRONIZED, LITERAL_SWITCH, LITERAL_DO, LITERAL_IF, LITERAL_ELSE, LITERAL_FOR,
+                        STATIC_INIT, OBJBLOCK" />
+        </module>
+        <!-- not doing this for methods because of 1 line getters/setters -->
+        <module name="RightCurly">
+            <property name="option" value="alone"/>
+            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF,
+                        LITERAL_ELSE, CLASS_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE,
+                        STATIC_INIT, INSTANCE_INIT" />
+        </module>
+
+        <!-- METHOD_CALL breaks inline casts
+            (i.e. Iterable<?> collection = ((Map<?,?>) value).values();)
+            in 6.15-->
+        <module name="ParenPad">
+            <property name="tokens" value="CTOR_CALL, SUPER_CTOR_CALL"/>
+            <property name="option" value="space"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="System\.(out)|(err)\.print(ln)?\(" />
+            <!-- The last sentence of the message is a keyword to trigger exclusion: see ExcludeTestPackages -->
+            <property name="message" value="Not allowed to print to System.out: if you're damn sure you want it, disable Checkstyle on this line. [not required for tests]" />
+            <property name="ignoreComments" value="true" />
+        </module>
+
+        <!-- Nobody should be using StringBuffer anymore -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value=" StringBuffer" />
+            <!-- The last sentence of the message is a keyword to trigger exclusion: see ExcludeTestPackages -->
+            <property name="message" value="Nobody should be using StringBuffer anymore" />
+        </module>
+
+        <!-- Required to get SuppressionCommentFilter to work -->
+        <module name="FileContentsHolder" />
+
+        <!--  Avoid some import statements -->
+        <module name="IllegalImport">
+            <property name="illegalPkgs" value="java.awt, sun, org.slf4j, junit.framework"/>
+        </module>
+
+    </module>
+
+    <module name="RegexpSingleline">
+        <property name="format" value="\s+$" />
+        <property name="message" value="White spaces at the end of line" />
+    </module>
+
+    <module name="SuppressionCommentFilter" />
+
+    <module name="SuppressionFilter">
+        <property name="file" value="/suppressions.xml" />
+    </module>
+
+    <!-- Checks that a file ends with a new line  -->
+    <module name="NewlineAtEndOfFile"/>
+
+</module>

--- a/build-config/src/main/resources/checkstyle.xml
+++ b/build-config/src/main/resources/checkstyle.xml
@@ -162,7 +162,7 @@
 
         <!--  Avoid some import statements -->
         <module name="IllegalImport">
-            <property name="illegalPkgs" value="java.awt, sun, org.slf4j, junit.framework"/>
+            <property name="illegalPkgs" value="java.awt, sun, org.slf4j, junit.framework, org.junit"/>
         </module>
 
     </module>

--- a/build-config/src/main/resources/checkstyle.xml
+++ b/build-config/src/main/resources/checkstyle.xml
@@ -135,11 +135,9 @@
                         STATIC_INIT, INSTANCE_INIT" />
         </module>
 
-        <!-- METHOD_CALL breaks inline casts
-            (i.e. Iterable<?> collection = ((Map<?,?>) value).values();)
-            in 6.15-->
         <module name="ParenPad">
-            <property name="tokens" value="CTOR_CALL, SUPER_CTOR_CALL"/>
+            <property name="tokens" value="CTOR_CALL, METHOD_CALL, SUPER_CTOR_CALL, LITERAL_FOR, LITERAL_IF,
+                        LITERAL_WHILE, LITERAL_SWITCH, LITERAL_NEW"/>
             <property name="option" value="space"/>
         </module>
 

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -48,13 +48,18 @@
         Test dependencies
         -->
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -68,8 +73,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/InjectingConstraintValidatorFactoryTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/InjectingConstraintValidatorFactoryTest.java
@@ -6,6 +6,12 @@
  */
 package org.hibernate.validator.test.internal.cdi;
 
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.testng.Assert.fail;
+
 import javax.enterprise.context.spi.CreationalContext;
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.BeanManager;
@@ -14,16 +20,9 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.constraints.Min;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import org.hibernate.validator.internal.cdi.InjectingConstraintValidatorFactory;
-
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.fail;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
@@ -35,7 +34,7 @@ public class InjectingConstraintValidatorFactoryTest {
 	private InjectionTarget<MyValidator> injectionTargetMock;
 	private CreationalContext<MyValidator> creationalContextMock;
 
-	@Before
+	@BeforeClass
 	@SuppressWarnings("unchecked")
 	public void setUp() {
 		beanManagerMock = createMock( BeanManager.class );

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/ValidationExtensionTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/ValidationExtensionTest.java
@@ -6,11 +6,20 @@
  */
 package org.hibernate.validator.test.internal.cdi;
 
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.isA;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.testng.Assert.fail;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.spi.AfterBeanDiscovery;
 import javax.enterprise.inject.spi.Annotated;
@@ -23,21 +32,12 @@ import javax.validation.ValidatorFactory;
 
 import org.easymock.EasyMock;
 import org.easymock.IAnswer;
-import org.junit.Before;
-import org.junit.Test;
-
 import org.hibernate.validator.internal.cdi.ValidationExtension;
 import org.hibernate.validator.internal.cdi.ValidationProviderHelper;
 import org.hibernate.validator.internal.cdi.ValidatorBean;
 import org.hibernate.validator.internal.cdi.ValidatorFactoryBean;
-
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.expectLastCall;
-import static org.easymock.EasyMock.isA;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
-import static org.junit.Assert.fail;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
@@ -51,7 +51,7 @@ public class ValidationExtensionTest {
 	private BeanManager beanManagerMock;
 
 	@SuppressWarnings("unchecked")
-	@Before
+	@BeforeMethod
 	public void setUp() {
 		extension = new ValidationExtension();
 		afterBeanDiscoveryMock = createMock( AfterBeanDiscovery.class );

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/injection/InjectionOfCustomProviderTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/injection/InjectionOfCustomProviderTest.java
@@ -6,37 +6,33 @@
  */
 package org.hibernate.validator.test.internal.cdi.injection;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javax.inject.Inject;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import javax.validation.constraints.NotNull;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.hibernate.validator.HibernateValidatorFactory;
 import org.hibernate.validator.cdi.HibernateValidator;
 import org.hibernate.validator.internal.engine.ValidatorImpl;
 import org.hibernate.validator.test.internal.cdi.injection.MyValidationProvider.MyValidator;
 import org.hibernate.validator.test.internal.cdi.injection.MyValidationProvider.MyValidatorFactory;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.testng.annotations.Test;
 
 /**
  * Tests the injection of validator and validator factory if the default provider is not Hibernate Validator.
  *
  * @author Gunnar Morling
  */
-@RunWith(Arquillian.class)
 @TestForIssue(jiraKey = "HV-858")
-public class InjectionOfCustomProviderTest {
+public class InjectionOfCustomProviderTest extends Arquillian {
 
 	@Deployment
 	public static JavaArchive createDeployment() {
@@ -78,43 +74,43 @@ public class InjectionOfCustomProviderTest {
 
 	@Test
 	public void testInjectionOfDefaultFactory() throws Exception {
-		assertNotNull( defaultValidatorFactory );
-		assertTrue( defaultValidatorFactory instanceof MyValidatorFactory );
-		assertTrue( defaultValidatorFactory.unwrap( MyValidatorFactory.class ) instanceof MyValidatorFactory );
+		assertThat( defaultValidatorFactory ).isNotNull();
+		assertThat( defaultValidatorFactory ).isInstanceOf( MyValidatorFactory.class );
+		assertThat( defaultValidatorFactory.unwrap( MyValidatorFactory.class ) ).isInstanceOf( MyValidatorFactory.class );
 
-		assertNotNull( myValidatorFactory );
+		assertThat( myValidatorFactory ).isNotNull();
 	}
 
 	@Test
 	public void testInjectionOfDefaultValidator() throws Exception {
-		assertNotNull( defaultValidator );
-		assertTrue( defaultValidator instanceof MyValidator );
-		assertNotNull( defaultValidator.forExecutables() );
+		assertThat( defaultValidator ).isNotNull();
+		assertThat( defaultValidator ).isInstanceOf( MyValidator.class );
+		assertThat( defaultValidator.forExecutables() ).isNotNull();
 
-		assertNotNull( myValidator );
-		assertNotNull( myValidator.forExecutables() );
+		assertThat( myValidator ).isNotNull();
+		assertThat( myValidator.forExecutables() ).isNotNull();
 
-		assertEquals( 1, defaultValidator.validate( new TestEntity() ).size() );
-		assertEquals( 1, myValidator.validate( new TestEntity() ).size() );
+		assertThat( defaultValidator.validate( new TestEntity() ) ).hasSize( 1 );
+		assertThat( myValidator.validate( new TestEntity() ) ).hasSize( 1 );
 	}
 
 	@Test
 	public void testInjectionOfHibernateFactory() throws Exception {
-		assertNotNull( hibernateValidatorFactory );
-		assertNotNull( hibernateValidatorSpecificFactory );
+		assertThat( hibernateValidatorFactory ).isNotNull();
+		assertThat( hibernateValidatorSpecificFactory ).isNotNull();
 
-		assertEquals( ValidatorImpl.class, hibernateValidatorFactory.getValidator().getClass() );
-		assertEquals( ValidatorImpl.class, hibernateValidatorSpecificFactory.getValidator().getClass() );
+		assertThat( hibernateValidatorFactory.getValidator() ).isExactlyInstanceOf( ValidatorImpl.class );
+		assertThat( hibernateValidatorSpecificFactory.getValidator() ).isExactlyInstanceOf( ValidatorImpl.class );
 	}
 
 	@Test
 	public void testInjectionOfHibernateValidator() throws Exception {
-		assertNotNull( hibernateValidator );
-		assertNotNull( hibernateValidator.forExecutables() );
+		assertThat( hibernateValidator ).isNotNull();
+		assertThat( hibernateValidator.forExecutables() ).isNotNull();
 
-		assertNotNull( hibernateValidator.unwrap( Validator.class ) );
+		assertThat( hibernateValidator.unwrap( Validator.class ) ).isNotNull();
 
-		assertEquals( 1, hibernateValidator.validate( new TestEntity() ).size() );
+		assertThat( hibernateValidator.validate( new TestEntity() ) ).hasSize( 1 );
 	}
 
 	public static class TestEntity {

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/injection/InjectionTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/injection/InjectionTest.java
@@ -6,30 +6,26 @@
  */
 package org.hibernate.validator.test.internal.cdi.injection;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javax.inject.Inject;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.validator.HibernateValidatorFactory;
+import org.hibernate.validator.cdi.HibernateValidator;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.hibernate.validator.HibernateValidatorFactory;
-import org.hibernate.validator.cdi.HibernateValidator;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class InjectionTest {
+public class InjectionTest extends Arquillian {
 
 	@Deployment
 	public static JavaArchive createDeployment() {
@@ -56,24 +52,24 @@ public class InjectionTest {
 
 	@Test
 	public void testInjectionOfQualifiedBeans() throws Exception {
-		assertNotNull( validatorFactory );
-		assertNotNull( validator );
+		assertThat( validatorFactory ).isNotNull();
+		assertThat( validator ).isNotNull();
 
-		assertEquals( 1, validator.validate( new TestEntity() ).size() );
+		assertThat( validator.validate( new TestEntity() ) ).hasSize( 1 );
 	}
 
 	@Test
 	public void testInjectionOfDefaultBeans() throws Exception {
-		assertNotNull( defaultValidatorFactory );
-		assertNotNull( defaultValidator );
+		assertThat( defaultValidatorFactory ).isNotNull();
+		assertThat( defaultValidator ).isNotNull();
 
-		assertEquals( 1, defaultValidator.validate( new TestEntity() ).size() );
+		assertThat( defaultValidator.validate( new TestEntity() ) ).hasSize( 1 );
 	}
 
 	@Test
 	public void testInjectionOfHibernateValidatorFactory() throws Exception {
-		assertNotNull( hibernateValidatorFactory );
-		assertEquals( 1, hibernateValidatorFactory.getValidator().validate( new TestEntity() ).size() );
+		assertThat( hibernateValidatorFactory ).isNotNull();
+		assertThat( hibernateValidatorFactory.getValidator().validate( new TestEntity() ) ).hasSize( 1 );
 	}
 
 	public static class TestEntity {

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/injection/InjectionWithExternallyProvidedDefaultBeansTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/injection/InjectionWithExternallyProvidedDefaultBeansTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.test.internal.cdi.injection;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Produces;
@@ -15,19 +17,14 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.validator.HibernateValidatorFactory;
+import org.hibernate.validator.cdi.HibernateValidator;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.hibernate.validator.HibernateValidatorFactory;
-import org.hibernate.validator.cdi.HibernateValidator;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.testng.annotations.Test;
 
 /**
  * Tests the case where {@code @Default}-scoped beans for validator and validator factory have already been registered
@@ -36,8 +33,7 @@ import static org.junit.Assert.assertNotNull;
  * @author Hardy Ferentschik
  * @author Gunnar Morling
  */
-@RunWith(Arquillian.class)
-public class InjectionWithExternallyProvidedDefaultBeansTest {
+public class InjectionWithExternallyProvidedDefaultBeansTest extends Arquillian {
 
 	@Deployment
 	public static JavaArchive createDeployment() {
@@ -65,24 +61,24 @@ public class InjectionWithExternallyProvidedDefaultBeansTest {
 
 	@Test
 	public void testInjectionOfQualifiedBeans() throws Exception {
-		assertNotNull( validatorFactory );
-		assertNotNull( validator );
+		assertThat( validatorFactory ).isNotNull();
+		assertThat( validator ).isNotNull();
 
-		assertEquals( 1, validator.validate( new TestEntity() ).size() );
+		assertThat( validator.validate( new TestEntity() ) ).hasSize( 1 );
 	}
 
 	@Test
 	public void testInjectionOfDefaultBeans() throws Exception {
-		assertNotNull( defaultValidatorFactory );
-		assertNotNull( defaultValidator );
+		assertThat( defaultValidatorFactory ).isNotNull();
+		assertThat( defaultValidator ).isNotNull();
 
-		assertEquals( 1, defaultValidator.validate( new TestEntity() ).size() );
+		assertThat( defaultValidator.validate( new TestEntity() ) ).hasSize( 1 );
 	}
 
 	@Test
 	public void testInjectionOfHibernateValidatorFactory() throws Exception {
-		assertNotNull( hibernateValidatorFactory );
-		assertEquals( 1, hibernateValidatorFactory.getValidator().validate( new TestEntity() ).size() );
+		assertThat( hibernateValidatorFactory ).isNotNull();
+		assertThat( hibernateValidatorFactory.getValidator().validate( new TestEntity() ) ).hasSize( 1 );
 	}
 
 	public static class TestEntity {

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/BasicMethodValidationTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/BasicMethodValidationTest.java
@@ -6,25 +6,23 @@
  */
 package org.hibernate.validator.test.internal.cdi.methodvalidation;
 
+import static org.testng.Assert.fail;
+
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class BasicMethodValidationTest {
+public class BasicMethodValidationTest extends Arquillian {
 
 	@Deployment
 	public static JavaArchive createDeployment() {

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/DisableExecutableValidationInXmlTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/DisableExecutableValidationInXmlTest.java
@@ -6,25 +6,23 @@
  */
 package org.hibernate.validator.test.internal.cdi.methodvalidation;
 
+import static org.testng.Assert.fail;
+
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 
 import org.hibernate.validator.test.util.TestHelper;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class DisableExecutableValidationInXmlTest {
+public class DisableExecutableValidationInXmlTest extends Arquillian {
 	@Deployment
 	public static JavaArchive createDeployment() {
 		return ShrinkWrap.create( JavaArchive.class )

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/EmptyExecutableTypeTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/EmptyExecutableTypeTest.java
@@ -6,25 +6,23 @@
  */
 package org.hibernate.validator.test.internal.cdi.methodvalidation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class EmptyExecutableTypeTest {
+public class EmptyExecutableTypeTest extends Arquillian {
 
 	@Deployment
 	public static JavaArchive createDeployment() {
@@ -39,7 +37,7 @@ public class EmptyExecutableTypeTest {
 	@Test
 	public void testEmptyExecutableTypeParameterIsTreatedAsExecutableTypeNone() throws Exception {
 		try {
-			assertNull( snafu.foo() );
+			assertThat( snafu.foo() ).isNull();
 		}
 		catch (ConstraintViolationException e) {
 			fail( "CDI method interceptor should not throw an exception" );

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/getter/EnableGetterValidationInXmlTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/getter/EnableGetterValidationInXmlTest.java
@@ -6,26 +6,23 @@
  */
 package org.hibernate.validator.test.internal.cdi.methodvalidation.getter;
 
+import static org.testng.Assert.fail;
+
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 
+import org.hibernate.validator.test.util.TestHelper;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.hibernate.validator.test.util.TestHelper;
-
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class EnableGetterValidationInXmlTest {
+public class EnableGetterValidationInXmlTest extends Arquillian {
 	@Deployment
 	public static JavaArchive createDeployment() {
 		return ShrinkWrap.create( JavaArchive.class )

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/getter/GetterValidationOnlyTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/getter/GetterValidationOnlyTest.java
@@ -6,25 +6,23 @@
  */
 package org.hibernate.validator.test.internal.cdi.methodvalidation.getter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class GetterValidationOnlyTest {
+public class GetterValidationOnlyTest extends Arquillian {
 
 	@Deployment
 	public static JavaArchive createDeployment() {
@@ -39,7 +37,7 @@ public class GetterValidationOnlyTest {
 	@Test
 	public void testNonGetterValidationDoesNotOccur() throws Exception {
 		try {
-			assertNull( onlyGetterValidated.foo() );
+			assertThat( onlyGetterValidated.foo() ).isNull();
 		}
 		catch (ConstraintViolationException e) {
 			fail( "CDI method interceptor should not throw an exception" );

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/getter/ImplicitValidateOnExecutionDoesNotTriggerGetterValidationTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/getter/ImplicitValidateOnExecutionDoesNotTriggerGetterValidationTest.java
@@ -36,9 +36,9 @@ public class ImplicitValidateOnExecutionDoesNotTriggerGetterValidationTest exten
 	public void testValidationOfConstrainedGetter() {
 		Delivery delivery = deliveryService.getAnotherDelivery();
 		assertThat( delivery )
-				.as("the constraint is invalid, but no violation exception is expected since " +
+				.as( "the constraint is invalid, but no violation exception is expected since " +
 						"@ValidateOnExecution(type=IMPLICIT) on the type-level should have no effect " +
-						"and thus the default settings apply")
+						"and thus the default settings apply" )
 				.isNull();
 	}
 }

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/getter/ImplicitValidateOnExecutionDoesNotTriggerGetterValidationTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/getter/ImplicitValidateOnExecutionDoesNotTriggerGetterValidationTest.java
@@ -6,23 +6,21 @@
  */
 package org.hibernate.validator.test.internal.cdi.methodvalidation.getter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertNull;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class ImplicitValidateOnExecutionDoesNotTriggerGetterValidationTest {
+public class ImplicitValidateOnExecutionDoesNotTriggerGetterValidationTest extends Arquillian {
 	@Deployment
 	public static JavaArchive createDeployment() {
 		return ShrinkWrap.create( JavaArchive.class )
@@ -37,11 +35,10 @@ public class ImplicitValidateOnExecutionDoesNotTriggerGetterValidationTest {
 	@Test
 	public void testValidationOfConstrainedGetter() {
 		Delivery delivery = deliveryService.getAnotherDelivery();
-		assertNull(
-				"the constraint is invalid, but no violation exception is expected since " +
+		assertThat( delivery )
+				.as("the constraint is invalid, but no violation exception is expected since " +
 						"@ValidateOnExecution(type=IMPLICIT) on the type-level should have no effect " +
-						"and thus the default settings apply",
-				delivery
-		);
+						"and thus the default settings apply")
+				.isNull();
 	}
 }

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/inheritance/InvalidConfiguredClassInheritanceMethodValidationTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/inheritance/InvalidConfiguredClassInheritanceMethodValidationTest.java
@@ -6,29 +6,26 @@
  */
 package org.hibernate.validator.test.internal.cdi.methodvalidation.inheritance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
 import javax.enterprise.inject.spi.AnnotatedType;
 import javax.enterprise.inject.spi.BeanManager;
 import javax.enterprise.inject.spi.ProcessAnnotatedType;
 import javax.inject.Inject;
 import javax.validation.ValidationException;
 
+import org.hibernate.validator.internal.cdi.ValidationExtension;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.hibernate.validator.internal.cdi.ValidationExtension;
-
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class InvalidConfiguredClassInheritanceMethodValidationTest {
+public class InvalidConfiguredClassInheritanceMethodValidationTest extends Arquillian {
 
 	@Deployment
 	public static JavaArchive createDeployment() {
@@ -52,7 +49,7 @@ public class InvalidConfiguredClassInheritanceMethodValidationTest {
 			);
 		}
 		catch (ValidationException e) {
-			assertTrue( e.getMessage().startsWith( "HV000166" ) );
+			assertThat( e.getMessage() ).startsWith( "HV000166" );
 		}
 	}
 

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/inheritance/MultipleInterfaceInheritanceMethodValidationTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/inheritance/MultipleInterfaceInheritanceMethodValidationTest.java
@@ -6,26 +6,24 @@
  */
 package org.hibernate.validator.test.internal.cdi.methodvalidation.inheritance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 import javax.validation.constraints.NotNull;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class MultipleInterfaceInheritanceMethodValidationTest {
+public class MultipleInterfaceInheritanceMethodValidationTest extends Arquillian {
 
 	@Deployment
 	public static JavaArchive createDeployment() {
@@ -47,14 +45,14 @@ public class MultipleInterfaceInheritanceMethodValidationTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch (ConstraintViolationException e) {
-			assertEquals(
+			assertThat(
 					e.getConstraintViolations()
 							.iterator()
 							.next()
 							.getConstraintDescriptor()
 							.getAnnotation()
-							.annotationType(), NotNull.class
-			);
+							.annotationType() )
+					.isEqualTo( NotNull.class );
 		}
 	}
 }

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/inheritance/SuccessfulClassInheritanceMethodValidationTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/inheritance/SuccessfulClassInheritanceMethodValidationTest.java
@@ -6,26 +6,24 @@
  */
 package org.hibernate.validator.test.internal.cdi.methodvalidation.inheritance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 import javax.validation.constraints.NotNull;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class SuccessfulClassInheritanceMethodValidationTest {
+public class SuccessfulClassInheritanceMethodValidationTest extends Arquillian {
 
 	@Deployment
 	public static JavaArchive createDeployment() {
@@ -45,14 +43,14 @@ public class SuccessfulClassInheritanceMethodValidationTest {
 			fail( "Method invocation should have caused a ConstraintViolationException" );
 		}
 		catch (ConstraintViolationException e) {
-			assertEquals(
+			assertThat(
 					e.getConstraintViolations()
 							.iterator()
 							.next()
 							.getConstraintDescriptor()
 							.getAnnotation()
-							.annotationType(), NotNull.class
-			);
+							.annotationType() )
+					.isEqualTo( NotNull.class );
 		}
 	}
 }

--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/inheritance/ValidationOfInheritedMethodTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/methodvalidation/inheritance/ValidationOfInheritedMethodTest.java
@@ -6,25 +6,23 @@
  */
 package org.hibernate.validator.test.internal.cdi.methodvalidation.inheritance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
+
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class ValidationOfInheritedMethodTest {
+public class ValidationOfInheritedMethodTest extends Arquillian {
 
 	@Deployment
 	public static JavaArchive createDeployment() {
@@ -57,7 +55,7 @@ public class ValidationOfInheritedMethodTest {
 	@Test
 	public void testInterfaceMethodWithExecutableTypeNoneDoesNotGetValidated() throws Exception {
 		try {
-			assertNull( encryptor.encrypt( "top secret" ) );
+			assertThat( encryptor.encrypt( "top secret" ) ).isNull();
 		}
 		catch (ConstraintViolationException e) {
 			fail( "Encryptor#encrypt should not be validated, because it is explicitly excluded from executable validation" );

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -61,6 +61,12 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <configLocation>checkstyle-documentation.xml</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.asciidoctor</groupId>
                 <artifactId>asciidoctor-maven-plugin</artifactId>
                 <executions>

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter02/typeargument/map/Car.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter02/typeargument/map/Car.java
@@ -16,7 +16,7 @@ public class Car {
 	}
 
 	@Valid
-	private EnumMap<FuelConsumption, @MaxAllowedFuelConsumption Integer> fuelConsumption = new EnumMap<>(FuelConsumption.class);
+	private EnumMap<FuelConsumption, @MaxAllowedFuelConsumption Integer> fuelConsumption = new EnumMap<>( FuelConsumption.class );
 
 	public void setFuelConsumption(FuelConsumption consumption, int value) {
 		fuelConsumption.put( consumption, value );

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter07/XMLConfigurationTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter07/XMLConfigurationTest.java
@@ -82,12 +82,12 @@ public class XMLConfigurationTest {
 		MethodDescriptor methodDescriptor = beanDescriptor.getConstraintsForMethod( "buildCar", java.util.List.class );
 		CrossParameterDescriptor crossParameterDescriptor = methodDescriptor.getCrossParameterDescriptor();
 		Set<ConstraintDescriptor<?>> constraintDescriptors = crossParameterDescriptor.getConstraintDescriptors();
-		assertCorrectConstraintTypes( constraintDescriptors, ELAssert.class);
+		assertCorrectConstraintTypes( constraintDescriptors, ELAssert.class );
 
 		methodDescriptor = beanDescriptor.getConstraintsForMethod( "paintCar", int.class );
 		ReturnValueDescriptor returnValueDescriptor = methodDescriptor.getReturnValueDescriptor();
 		constraintDescriptors = returnValueDescriptor.getConstraintDescriptors();
-		assertCorrectConstraintTypes( constraintDescriptors, ELAssert.class);
+		assertCorrectConstraintTypes( constraintDescriptors, ELAssert.class );
 	}
 
 	private void assertCorrectConstraintTypes( Set<ConstraintDescriptor<?>> constraintDescriptors,

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/relaxation/RelaxationTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/relaxation/RelaxationTest.java
@@ -11,11 +11,11 @@ public class RelaxationTest {
 	@Test
 	public void testRelaxation() {
 		//tag::testRelaxation[]
-		HibernateValidatorConfiguration configuration = Validation.byProvider(HibernateValidator.class).configure();
+		HibernateValidatorConfiguration configuration = Validation.byProvider( HibernateValidator.class ).configure();
 
-		configuration.allowMultipleCascadedValidationOnReturnValues(true)
-				.allowOverridingMethodAlterParameterConstraint(true)
-				.allowParallelMethodsDefineParameterConstraints(true);
+		configuration.allowMultipleCascadedValidationOnReturnValues( true )
+				.allowOverridingMethodAlterParameterConstraint( true )
+				.allowParallelMethodsDefineParameterConstraints( true );
 		//end::testRelaxation[]
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
@@ -186,7 +186,7 @@ public class BeanMetaDataManager {
 	 */
 	private <T> BeanMetaDataImpl<T> createBeanMetaData(Class<T> clazz) {
 		BeanMetaDataBuilder<T> builder = BeanMetaDataBuilder.getInstance(
-				constraintHelper, executableHelper, validationOrderGenerator, clazz, methodValidationConfiguration);
+				constraintHelper, executableHelper, validationOrderGenerator, clazz, methodValidationConfiguration );
 
 		for ( MetaDataProvider provider : metaDataProviders ) {
 			for ( BeanConfiguration<? super T> beanConfiguration : provider.getBeanConfigurationForHierarchy( clazz ) ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -551,7 +551,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 					executableHelper,
 					validationOrderGenerator,
 					beanClass,
-					methodValidationConfiguration);
+					methodValidationConfiguration );
 		}
 
 		public void add(BeanConfiguration<? super T> configuration) {

--- a/engine/src/test/java/org/hibernate/validator/bugs/TooBigMessageTest.java
+++ b/engine/src/test/java/org/hibernate/validator/bugs/TooBigMessageTest.java
@@ -17,7 +17,7 @@ import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.ValidatorUtil;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 /**
  * Ensure large error messages can be interpolated.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/FutureValidatorForInstantTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/FutureValidatorForInstantTest.java
@@ -36,7 +36,7 @@ public class FutureValidatorForInstantTest {
 		Instant past = Instant.now().minusSeconds( 3600 );
 
 		assertTrue( constraint.isValid( null, null ), "null fails validation." );
-		assertTrue( constraint.isValid( future, getConstraintValidatorContext() ), "Future Instant '" + future + "' fails validation.");
-		assertFalse( constraint.isValid( past, getConstraintValidatorContext() ), "Past Instant '" + past + "' validated as future.");
+		assertTrue( constraint.isValid( future, getConstraintValidatorContext() ), "Future Instant '" + future + "' fails validation." );
+		assertFalse( constraint.isValid( past, getConstraintValidatorContext() ), "Past Instant '" + past + "' validated as future." );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/FutureValidatorForOffsetDateTimeTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/FutureValidatorForOffsetDateTimeTest.java
@@ -40,8 +40,8 @@ public class FutureValidatorForOffsetDateTimeTest {
 			ZoneOffset offset = ZoneOffset.ofHours( i );
 			OffsetDateTime future = OffsetDateTime.now( offset ).plusHours( 1 );
 			OffsetDateTime past = OffsetDateTime.now( offset ).minusHours( 1 );
-			assertTrue( constraint.isValid( future, getConstraintValidatorContext() ), "Future OffsetDateTime '" + future + "' fails validation.");
-			assertFalse( constraint.isValid( past, getConstraintValidatorContext() ), "Past OffsetDateTime '" + past + "' validated as future.");
+			assertTrue( constraint.isValid( future, getConstraintValidatorContext() ), "Future OffsetDateTime '" + future + "' fails validation." );
+			assertFalse( constraint.isValid( past, getConstraintValidatorContext() ), "Past OffsetDateTime '" + past + "' validated as future." );
 		}
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForChronoZonedDateTimeTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForChronoZonedDateTimeTest.java
@@ -41,8 +41,8 @@ public class PastValidatorForChronoZonedDateTimeTest {
 			ZoneId zone = ZoneId.ofOffset( "UTC", ZoneOffset.ofHours( i ) );
 			ZonedDateTime future = ZonedDateTime.now( zone ).plusHours( 1 );
 			ZonedDateTime past = ZonedDateTime.now( zone ).minusHours( 1 );
-			assertTrue( constraint.isValid( past, getConstraintValidatorContext() ), "Past ZonedDateTime '" + past + "' fails validation.");
-			assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future ZonedDateTime '" + future + "' validated as past.");
+			assertTrue( constraint.isValid( past, getConstraintValidatorContext() ), "Past ZonedDateTime '" + past + "' fails validation." );
+			assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future ZonedDateTime '" + future + "' validated as past." );
 		}
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForInstantTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForInstantTest.java
@@ -36,7 +36,7 @@ public class PastValidatorForInstantTest {
 		Instant past = Instant.now().minusSeconds( 3600 );
 
 		assertTrue( constraint.isValid( null, null ), "null fails validation." );
-		assertTrue( constraint.isValid( past, getConstraintValidatorContext() ), "Past Instant '" + past + "' fails validation.");
-		assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future Instant '" + future + "' validated as past.");
+		assertTrue( constraint.isValid( past, getConstraintValidatorContext() ), "Past Instant '" + past + "' fails validation." );
+		assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future Instant '" + future + "' validated as past." );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForOffsetDateTimeTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForOffsetDateTimeTest.java
@@ -40,8 +40,8 @@ public class PastValidatorForOffsetDateTimeTest {
 			ZoneOffset offset = ZoneOffset.ofHours( i );
 			OffsetDateTime future = OffsetDateTime.now( offset ).plusHours( 1 );
 			OffsetDateTime past = OffsetDateTime.now( offset ).minusHours( 1 );
-			assertTrue( constraint.isValid( past, getConstraintValidatorContext() ), "Past OffsetDateTime '" + past + "' fails validation.");
-			assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future OffsetDateTime '" + future + "' validated as past.");
+			assertTrue( constraint.isValid( past, getConstraintValidatorContext() ), "Past OffsetDateTime '" + past + "' fails validation." );
+			assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future OffsetDateTime '" + future + "' validated as past." );
 		}
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlParsingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlParsingTest.java
@@ -32,7 +32,7 @@ public class XmlParsingTest {
 	public void xmlConstraintMappingSupportsTabsWithoutNewLines() {
 		Validator validator = getConfiguration()
 				.addMapping(
-						XmlParsingTest.class.getResourceAsStream("hv-1101-tabs-mapping.xml" ) )
+						XmlParsingTest.class.getResourceAsStream( "hv-1101-tabs-mapping.xml" ) )
 				.buildValidatorFactory()
 				.getValidator();
 
@@ -47,7 +47,7 @@ public class XmlParsingTest {
 	public void xmlConstraintMappingSupportsEmptyElementForStrings() {
 		Validator validator = getConfiguration()
 				.addMapping(
-						XmlParsingTest.class.getResourceAsStream("hv-1101-empty-element-mapping.xml" ) )
+						XmlParsingTest.class.getResourceAsStream( "hv-1101-empty-element-mapping.xml" ) )
 				.buildValidatorFactory()
 				.getValidator();
 

--- a/engine/src/test/java/org/hibernate/validator/testutils/ValidatorUtil.java
+++ b/engine/src/test/java/org/hibernate/validator/testutils/ValidatorUtil.java
@@ -235,6 +235,6 @@ public final class ValidatorUtil {
 	}
 
 	public static HibernateConstraintValidatorContext getConstraintValidatorContext() {
-		return new ConstraintValidatorContextImpl(null, DefaultTimeProvider.getInstance(), null, null);
+		return new ConstraintValidatorContextImpl( null, DefaultTimeProvider.getInstance(), null, null );
 	}
 }

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -27,8 +27,13 @@
     <dependencies>
         <!-- test -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -57,8 +62,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
+            <groupId>org.jboss.arquillian.testng</groupId>
+            <artifactId>arquillian-testng-container</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration/src/test/java/org/hibernate/validator/integration/AbstractArquillianIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/AbstractArquillianIT.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.integration;
+
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+/**
+ * Base class for all the TestNG tests using Arquillian
+ * .
+ * @author Guillaume Smet
+ */
+public abstract class AbstractArquillianIT extends Arquillian {
+
+	public static WebArchive buildTestArchive(String warFileName) {
+		return ShrinkWrap
+				.create( WebArchive.class, warFileName )
+				.addClass( AbstractArquillianIT.class )
+				.addAsLibraries(
+						Maven.resolver().resolve( "org.testng:testng:6.8" ).withTransitivity().asFile()
+				)
+				.addAsLibraries(
+						Maven.resolver().resolve( "org.assertj:assertj-core:3.5.2" ).withTransitivity().asFile()
+				)
+				.addAsResource( "log4j.properties" );
+	}
+
+}

--- a/integration/src/test/java/org/hibernate/validator/integration/cdi/ConstraintValidatorInjectionUnitIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/cdi/ConstraintValidatorInjectionUnitIT.java
@@ -6,31 +6,27 @@
  */
 package org.hibernate.validator.integration.cdi;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javax.inject.Inject;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.ValidatorFactory;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import org.hibernate.validator.cdi.HibernateValidator;
+import org.hibernate.validator.integration.AbstractArquillianIT;
 import org.hibernate.validator.integration.cdi.constraint.Pingable;
 import org.hibernate.validator.integration.cdi.constraint.PingableValidator;
 import org.hibernate.validator.integration.cdi.service.PingService;
 import org.hibernate.validator.integration.cdi.service.PingServiceImpl;
-
-import static org.junit.Assert.assertNotNull;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class ConstraintValidatorInjectionUnitIT {
+public class ConstraintValidatorInjectionUnitIT extends AbstractArquillianIT {
 	private static final String WAR_FILE_NAME = ConstraintValidatorInjectionUnitIT.class.getSimpleName() + ".war";
 
 	@Inject
@@ -39,15 +35,13 @@ public class ConstraintValidatorInjectionUnitIT {
 
 	@Deployment
 	public static WebArchive createTestArchive() throws Exception {
-		return ShrinkWrap
-				.create( WebArchive.class, WAR_FILE_NAME )
+		return buildTestArchive( WAR_FILE_NAME )
 				.addClasses(
 						Pingable.class,
 						PingService.class,
 						PingServiceImpl.class,
 						PingableValidator.class
 				)
-				.addAsResource( "log4j.properties" )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" );
 	}
 
@@ -56,7 +50,7 @@ public class ConstraintValidatorInjectionUnitIT {
 		ConstraintValidatorFactory constraintValidatorFactory = validatorFactory.getConstraintValidatorFactory();
 		PingableValidator validator = constraintValidatorFactory.getInstance( PingableValidator.class );
 
-		assertNotNull( "Constraint Validator could not be created", validator );
-		assertNotNull( "The ping service did not get injected", validator.getPingService() );
+		assertThat( validator ).as( "Constraint Validator could not be created" ).isNotNull();
+		assertThat( validator.getPingService() ).as( "The ping service did not get injected" ).isNotNull();
 	}
 }

--- a/integration/src/test/java/org/hibernate/validator/integration/cdi/DefaultInjectionUnitIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/cdi/DefaultInjectionUnitIT.java
@@ -6,25 +6,22 @@
  */
 package org.hibernate.validator.integration.cdi;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javax.enterprise.inject.spi.BeanManager;
 import javax.inject.Inject;
 import javax.validation.ValidatorFactory;
 
+import org.hibernate.validator.integration.AbstractArquillianIT;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import static org.junit.Assert.assertNotNull;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class DefaultInjectionUnitIT {
+public class DefaultInjectionUnitIT extends AbstractArquillianIT {
 	private static final String WAR_FILE_NAME = DefaultInjectionUnitIT.class.getSimpleName() + ".war";
 
 	@Inject
@@ -35,15 +32,14 @@ public class DefaultInjectionUnitIT {
 
 	@Deployment
 	public static WebArchive createTestArchive() throws Exception {
-		return ShrinkWrap
-				.create( WebArchive.class, WAR_FILE_NAME )
+		return buildTestArchive( WAR_FILE_NAME )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" );
 	}
 
 	@Test
 	public void testDefaultValidatorFactoryInjected() {
-		assertNotNull( "The bean manager should have been injected", beanManager );
-		assertNotNull( "The validator factory should have been injected", validatorFactory );
+		assertThat( beanManager ).as( "The bean manager should have been injected" ).isNotNull();
+		assertThat( validatorFactory ).as( "The validator factory should have been injected" ).isNotNull();
 	}
 
 }

--- a/integration/src/test/java/org/hibernate/validator/integration/cdi/QualifiedInjectionUnitIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/cdi/QualifiedInjectionUnitIT.java
@@ -6,30 +6,27 @@
  */
 package org.hibernate.validator.integration.cdi;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.Serializable;
+
 import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
+import org.hibernate.validator.cdi.HibernateValidator;
+import org.hibernate.validator.integration.AbstractArquillianIT;
+import org.hibernate.validator.testutil.TestForIssue;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import org.hibernate.validator.cdi.HibernateValidator;
-import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.junit.Assert.assertNotNull;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class QualifiedInjectionUnitIT {
+public class QualifiedInjectionUnitIT extends AbstractArquillianIT {
 	private static final String WAR_FILE_NAME = QualifiedInjectionUnitIT.class.getSimpleName() + ".war";
 
 	@Inject
@@ -45,24 +42,22 @@ public class QualifiedInjectionUnitIT {
 
 	@Deployment
 	public static WebArchive createTestArchive() throws Exception {
-		return ShrinkWrap
-				.create( WebArchive.class, WAR_FILE_NAME )
-				.addAsResource( "log4j.properties" )
+		return buildTestArchive( WAR_FILE_NAME )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" );
 	}
 
 	@Test
 	public void testQualifiedValidatorFactoryAndValidatorInjectable() {
-		assertNotNull( "The validator factory should have been injected", validatorFactory );
-		assertNotNull( "The validator should have been injected", validator );
+		assertThat( validatorFactory ).as( "The validator factory should have been injected" ).isNotNull();
+		assertThat( validator ).as( "The validator should have been injected" ).isNotNull();
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HV-787")
 	public void testInjectionIntoBeanWithPassivatingScope() throws Exception {
-		assertNotNull( testEntity );
-		assertNotNull( testEntity.getValidatorFactory() );
-		assertNotNull( testEntity.getValidator() );
+		assertThat( testEntity ).isNotNull();
+		assertThat( testEntity.getValidatorFactory() ).isNotNull();
+		assertThat( testEntity.getValidator() ).isNotNull();
 	}
 
 	@SessionScoped

--- a/integration/src/test/java/org/hibernate/validator/integration/cdi/configuration/ConfigurationInjectionUnitIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/cdi/configuration/ConfigurationInjectionUnitIT.java
@@ -6,28 +6,24 @@
  */
 package org.hibernate.validator.integration.cdi.configuration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import javax.inject.Inject;
 import javax.validation.ValidatorFactory;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import org.hibernate.validator.cdi.HibernateValidator;
+import org.hibernate.validator.integration.AbstractArquillianIT;
 import org.hibernate.validator.integration.cdi.service.PingService;
 import org.hibernate.validator.integration.cdi.service.PingServiceImpl;
-
-import static org.junit.Assert.assertEquals;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class ConfigurationInjectionUnitIT {
+public class ConfigurationInjectionUnitIT extends AbstractArquillianIT {
 	private static final String WAR_FILE_NAME = ConfigurationInjectionUnitIT.class.getSimpleName() + ".war";
 
 	@Inject
@@ -36,8 +32,7 @@ public class ConfigurationInjectionUnitIT {
 
 	@Deployment
 	public static WebArchive createTestArchive() throws Exception {
-		return ShrinkWrap
-				.create( WebArchive.class, WAR_FILE_NAME )
+		return buildTestArchive( WAR_FILE_NAME )
 				.addClasses(
 						PingService.class,
 						PingServiceImpl.class,
@@ -46,7 +41,6 @@ public class ConfigurationInjectionUnitIT {
 						ParameterNameProviderWithInjection.class,
 						TraversableResolverWithInjection.class
 				)
-				.addAsResource( "log4j.properties" )
 				.addAsResource( "validation-custom-config.xml", "META-INF/validation.xml" )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" );
 	}
@@ -76,6 +70,6 @@ public class ConfigurationInjectionUnitIT {
 	}
 
 	private void assertPingService(PingService pingService) {
-		assertEquals( "The ping service should respond", "pong", pingService.ping() );
+		assertThat( pingService.ping() ).as( "The ping service should respond" ).isEqualTo( "pong" );
 	}
 }

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/ConstraintDefinitionContributorIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/ConstraintDefinitionContributorIT.java
@@ -6,8 +6,7 @@
  */
 package org.hibernate.validator.integration.wildfly;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -16,22 +15,19 @@ import javax.inject.Inject;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
+import org.hibernate.validator.integration.AbstractArquillianIT;
 import org.hibernate.validator.integration.util.IntegrationTestUtil;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class ConstraintDefinitionContributorIT {
+public class ConstraintDefinitionContributorIT extends AbstractArquillianIT {
 	private static final String WAR_FILE_NAME = ConstraintDefinitionContributorIT.class.getSimpleName() + ".war";
 
 	@Inject
@@ -40,8 +36,7 @@ public class ConstraintDefinitionContributorIT {
 
 	@Deployment
 	public static WebArchive createTestArchive() throws Exception {
-		return ShrinkWrap
-				.create( WebArchive.class, WAR_FILE_NAME )
+		return buildTestArchive( WAR_FILE_NAME )
 				.addClass( TestEntity.class )
 				.addAsLibrary(
 						IntegrationTestUtil.createAcmeConstraintDefinitionContributorJar()
@@ -51,7 +46,6 @@ public class ConstraintDefinitionContributorIT {
 						IntegrationTestUtil.createOxBerryConstraintDefinitionContributorJar()
 								.as( JavaArchive.class )
 				)
-				.addAsResource( "log4j.properties" )
 				.addAsWebInfResource( "jboss-deployment-structure.xml", "jboss-deployment-structure.xml" )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" );
 	}
@@ -62,14 +56,14 @@ public class ConstraintDefinitionContributorIT {
 	public void testConstraintContributionsGetDiscovered() throws Exception {
 		TestEntity testEntity = new TestEntity( "foo" );
 		Set<ConstraintViolation<TestEntity>> constraintViolations = validator.validate( testEntity );
-		assertEquals( "There should be two constraint violations", 2, constraintViolations.size() );
+		assertThat( constraintViolations ).as( "There should be two constraint violations" ).hasSize( 2 );
 
 		Set<String> messages = new HashSet<String>();
 		for ( ConstraintViolation<TestEntity> constraintViolation : constraintViolations ) {
 			messages.add( constraintViolation.getMessage() );
 		}
 
-		assertTrue( "Expected message 'acme' not in set - " + messages, messages.contains( "acme" ) );
-		assertTrue( "Expected message 'oxberry' not in set - " + messages, messages.contains( "oxberry" ) );
+		assertThat( messages ).contains( "acme" );
+		assertThat( messages ).contains( "oxberry" );
 	}
 }

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/ConstraintMappingContributorIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/ConstraintMappingContributorIT.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.integration.wildfly;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 
@@ -15,29 +15,25 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.validator.integration.AbstractArquillianIT;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.testng.annotations.Test;
 
 /**
  * Asserts constraints mappings contributed via {@code validation.xml} are applied.
  *
  * @author Gunnar Morling
  */
-@RunWith(Arquillian.class)
-public class ConstraintMappingContributorIT {
+public class ConstraintMappingContributorIT extends AbstractArquillianIT {
 
 	private static final String WAR_FILE_NAME = ConstraintMappingContributorIT.class
 			.getSimpleName() + ".war";
 
 	@Deployment
 	public static Archive<?> createTestArchive() {
-		return ShrinkWrap.create( WebArchive.class, WAR_FILE_NAME )
+		return buildTestArchive( WAR_FILE_NAME )
 				.addClasses( Broomstick.class, MyConstraintMappingContributor.class )
 				.addAsResource( "constraint-mapping-contributor-validation.xml", "META-INF/validation.xml" )
 				.addAsWebInfResource( "jboss-deployment-structure.xml", "jboss-deployment-structure.xml" )
@@ -51,10 +47,7 @@ public class ConstraintMappingContributorIT {
 	public void shouldApplyContributedConstraintMapping() {
 		Set<ConstraintViolation<Broomstick>> violations = validator.validate( new Broomstick() );
 
-		assertEquals( 1, violations.size() );
-		assertEquals(
-				NotNull.class,
-				violations.iterator().next().getConstraintDescriptor().getAnnotation().annotationType()
-		);
+		assertThat( violations ).hasSize( 1 );
+		assertThat( violations.iterator().next().getConstraintDescriptor().getAnnotation().annotationType() ).isEqualTo( NotNull.class );
 	}
 }

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/CustomValidationProviderInDeploymentUnitIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/CustomValidationProviderInDeploymentUnitIT.java
@@ -6,24 +6,21 @@
  */
 package org.hibernate.validator.integration.wildfly;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.inject.Inject;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
 import org.apache.log4j.Logger;
+import org.hibernate.validator.integration.AbstractArquillianIT;
 import org.hibernate.validator.integration.util.IntegrationTestUtil;
 import org.hibernate.validator.integration.util.MyValidator;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.testng.annotations.Test;
 
 /**
  * Tests the usage of a custom validation provider coming as part of the deployment unit.
@@ -31,16 +28,14 @@ import org.junit.runner.RunWith;
  * @author Hardy Ferentschik
  * @author Gunnar Morling
  */
-@RunWith(Arquillian.class)
-public class CustomValidationProviderInDeploymentUnitIT {
+public class CustomValidationProviderInDeploymentUnitIT extends AbstractArquillianIT {
 
 	private static final String WAR_FILE_NAME = CustomValidationProviderInDeploymentUnitIT.class.getSimpleName() + ".war";
 	private static final Logger log = Logger.getLogger( CustomValidationProviderInDeploymentUnitIT.class );
 
 	@Deployment
 	public static Archive<?> createTestArchive() {
-		return ShrinkWrap
-				.create( WebArchive.class, WAR_FILE_NAME )
+		return buildTestArchive( WAR_FILE_NAME )
 				.addAsLibrary( IntegrationTestUtil.createCustomBeanValidationProviderJar()
 								.as( JavaArchive.class )
 								.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" ) )
@@ -60,11 +55,10 @@ public class CustomValidationProviderInDeploymentUnitIT {
 		Validator validator = validatorFactory.getValidator();
 
 		// Asserting the validator type as the VF is the wrapper type used within WildFly (LazyValidatorFactory)
-		assertTrue(
-				"The custom validator implementation as retrieved from the default provider configured in META-INF/validation.xml should be used but actually "
-						+ validator + " is used",
-				validator instanceof MyValidator
-		);
+		assertThat( validator )
+				.as( "The custom validator implementation as retrieved from the default provider configured in META-INF/validation.xml should be used but actually "
+						+ validator + " is used" )
+				.isInstanceOf( MyValidator.class );
 
 		log.debug( "testValidatorFactoryFromCustomValidationProvider completed" );
 	}

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/JndiLookupOfValidatorFactoryIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/JndiLookupOfValidatorFactoryIT.java
@@ -6,9 +6,8 @@
  */
 package org.hibernate.validator.integration.wildfly;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
@@ -16,31 +15,26 @@ import javax.naming.NamingException;
 import javax.validation.ValidatorFactory;
 
 import org.apache.log4j.Logger;
+import org.hibernate.validator.integration.AbstractArquillianIT;
+import org.hibernate.validator.internal.engine.ValidatorImpl;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.testng.annotations.Test;
 
 /**
  * Tests the integration of Hibernate Validator in Wildfly.
  *
  * @author Hardy Ferentschik
  */
-@RunWith(Arquillian.class)
-public class JndiLookupOfValidatorFactoryIT {
+public class JndiLookupOfValidatorFactoryIT extends AbstractArquillianIT {
 	private static final String WAR_FILE_NAME = JndiLookupOfValidatorFactoryIT.class.getSimpleName() + ".war";
 	private static final Logger log = Logger.getLogger( JndiLookupOfValidatorFactoryIT.class );
 	private static final String DEFAULT_JNDI_NAME_OF_VALIDATOR_FACTORY = "java:comp/ValidatorFactory";
 
 	@Deployment
 	public static Archive<?> createTestArchive() {
-		return ShrinkWrap
-				.create( WebArchive.class, WAR_FILE_NAME )
-				.addAsWebInfResource( "jboss-deployment-structure.xml", "jboss-deployment-structure.xml" )
-				.addAsResource( "log4j.properties" );
+		return buildTestArchive( WAR_FILE_NAME )
+				.addAsWebInfResource( "jboss-deployment-structure.xml", "jboss-deployment-structure.xml" );
 	}
 
 	@Test
@@ -49,13 +43,11 @@ public class JndiLookupOfValidatorFactoryIT {
 		try {
 			Context ctx = new InitialContext();
 			Object obj = ctx.lookup( DEFAULT_JNDI_NAME_OF_VALIDATOR_FACTORY );
-			assertTrue( "The default validator factory should be bound", obj != null );
+			assertThat( obj ).as( "The default validator factory should be bound" ).isNotNull();
 			ValidatorFactory factory = (ValidatorFactory) obj;
-			assertEquals(
-					"The Hibernate Validator implementation should be used",
-					"ValidatorImpl",
-					factory.getValidator().getClass().getSimpleName()
-			);
+			assertThat( factory.getValidator() )
+					.as( "The Hibernate Validator implementation should be used" )
+					.isExactlyInstanceOf( ValidatorImpl.class );
 		}
 		catch (NamingException e) {
 			fail( "The default validator factory should be bound" );

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/MethodValidationWithCustomValidatorIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/MethodValidationWithCustomValidatorIT.java
@@ -6,19 +6,16 @@
  */
 package org.hibernate.validator.integration.wildfly;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.validator.integration.AbstractArquillianIT;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.testng.annotations.Test;
 
 /**
  * Asserts that the validation interceptor picks up a {@code Validator} provided by the application and uses it for
@@ -26,8 +23,7 @@ import org.junit.runner.RunWith;
  *
  * @author Gunnar Morling
  */
-@RunWith(Arquillian.class)
-public class MethodValidationWithCustomValidatorIT {
+public class MethodValidationWithCustomValidatorIT extends AbstractArquillianIT {
 
 	private static final String WAR_FILE_NAME = MethodValidationWithCustomValidatorIT.class
 			.getSimpleName() + ".war";
@@ -40,7 +36,7 @@ public class MethodValidationWithCustomValidatorIT {
 
 	@Deployment
 	public static Archive<?> createTestArchive() {
-		return ShrinkWrap.create( WebArchive.class, WAR_FILE_NAME )
+		return buildTestArchive( WAR_FILE_NAME )
 				.addClasses( MyValidator.class )
 				.addAsWebInfResource( "jboss-deployment-structure.xml", "jboss-deployment-structure.xml" )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" );
@@ -54,12 +50,10 @@ public class MethodValidationWithCustomValidatorIT {
 
 	@Test
 	public void shouldUseApplicationProvidedValidatorForMethodValidation() {
-		assertEquals( 0, validator.getForExecutablesInvocationCount() );
+		assertThat( validator.getForExecutablesInvocationCount() ).isEqualTo( 0 );
 		myService.doSomething( "foobar" );
-		assertEquals(
-				"MyValidator#forExecutable() should have been invoked once.",
-				1,
-				validator.getForExecutablesInvocationCount()
-		);
+		assertThat( validator.getForExecutablesInvocationCount() )
+				.as( "MyValidator#forExecutable() should have been invoked once." )
+				.isEqualTo( 1 );
 	}
 }

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/generictype/GenericParameterTypeValidationUnitIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/generictype/GenericParameterTypeValidationUnitIT.java
@@ -6,9 +6,8 @@
  */
 package org.hibernate.validator.integration.wildfly.generictype;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
 
 import java.util.Set;
 
@@ -18,21 +17,20 @@ import javax.validation.ConstraintViolationException;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.validator.integration.AbstractArquillianIT;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.testng.annotations.Test;
 
 @TestForIssue(jiraKey = "HV-978")
-@RunWith(Arquillian.class)
-public class GenericParameterTypeValidationUnitIT {
+public class GenericParameterTypeValidationUnitIT extends AbstractArquillianIT {
+	private static final String WAR_FILE_NAME = GenericParameterTypeValidationUnitIT.class.getSimpleName() + ".war";
+
 	@Deployment
 	public static WebArchive deployment() {
-		return ShrinkWrap.create( WebArchive.class )
+		return buildTestArchive( WAR_FILE_NAME )
 				.addAsWebInfResource( "jboss-deployment-structure.xml", "jboss-deployment-structure.xml" )
 				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" )
 				.addPackage( GenericParameterTypeValidationUnitIT.class.getPackage() );
@@ -52,13 +50,11 @@ public class GenericParameterTypeValidationUnitIT {
 		}
 		catch (ConstraintViolationException e) {
 			Set<ConstraintViolation<?>> violations = e.getConstraintViolations();
-			assertTrue( "Unexpected number of constraint violations", violations.size() == 1 );
+			assertThat( violations ).as( "Unexpected number of constraint violations" ).hasSize( 1 );
 			ConstraintViolation<?> constraintViolation = violations.iterator().next();
-			assertEquals(
-					"Unexpected constraint type ",
-					NotNull.class,
-					constraintViolation.getConstraintDescriptor().getAnnotation().annotationType()
-			);
+			assertThat( constraintViolation.getConstraintDescriptor().getAnnotation().annotationType() )
+					.as( "Unexpected constraint type" )
+					.isEqualTo( NotNull.class );
 		}
 	}
 
@@ -70,13 +66,11 @@ public class GenericParameterTypeValidationUnitIT {
 		}
 		catch (ConstraintViolationException e) {
 			Set<ConstraintViolation<?>> violations = e.getConstraintViolations();
-			assertTrue( "Unexpected number of constraint violations", violations.size() == 1 );
+			assertThat( violations ).as( "Unexpected number of constraint violations" ).hasSize( 1 );
 			ConstraintViolation<?> constraintViolation = violations.iterator().next();
-			assertEquals(
-					"Unexpected constraint type ",
-					Min.class,
-					constraintViolation.getConstraintDescriptor().getAnnotation().annotationType()
-			);
+			assertThat( constraintViolation.getConstraintDescriptor().getAnnotation().annotationType() )
+					.as( "Unexpected constraint type" )
+					.isEqualTo( Min.class );
 		}
 	}
 }

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/jpa/CustomValidatorFactoryInPersistenceUnitIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/jpa/CustomValidatorFactoryInPersistenceUnitIT.java
@@ -6,25 +6,22 @@
  */
 package org.hibernate.validator.integration.wildfly.jpa;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.fail;
 
 import javax.inject.Inject;
 import javax.validation.ConstraintViolationException;
 
 import org.apache.log4j.Logger;
+import org.hibernate.validator.integration.AbstractArquillianIT;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.persistence20.PersistenceDescriptor;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.testng.annotations.Test;
 
 /**
  * Tests the usage of HV by JPA, applying a custom validation.xml. Also making sure that the VF is CDI-enabled.
@@ -32,18 +29,15 @@ import org.junit.runner.RunWith;
  * @author Hardy Ferentschik
  * @author Gunnar Morling
  */
-@RunWith(Arquillian.class)
-public class CustomValidatorFactoryInPersistenceUnitIT {
+public class CustomValidatorFactoryInPersistenceUnitIT extends AbstractArquillianIT {
 
 	private static final String WAR_FILE_NAME = CustomValidatorFactoryInPersistenceUnitIT.class.getSimpleName() + ".war";
 	private static final Logger log = Logger.getLogger( CustomValidatorFactoryInPersistenceUnitIT.class );
 
 	@Deployment
 	public static Archive<?> createTestArchive() {
-		return ShrinkWrap
-				.create( WebArchive.class, WAR_FILE_NAME )
+		return buildTestArchive( WAR_FILE_NAME )
 				.addClasses( Magician.class, ValidMagicianName.class, MagicianService.class, Wand.class, WandConstraintMappingContributor.class )
-				.addAsResource( "log4j.properties" )
 				.addAsResource( persistenceXml(), "META-INF/persistence.xml" )
 				.addAsResource( "validation.xml", "META-INF/validation.xml" )
 				.addAsResource( "constraints-magician.xml", "META-INF/validation/constraints-magician.xml" )
@@ -79,11 +73,12 @@ public class CustomValidatorFactoryInPersistenceUnitIT {
 		}
 		catch (Exception e) {
 			Throwable rootException = getRootException( e );
-			assertEquals( ConstraintViolationException.class, rootException.getClass() );
+			assertThat( rootException ).isExactlyInstanceOf( ConstraintViolationException.class );
 
 			ConstraintViolationException constraintViolationException = (ConstraintViolationException) rootException;
-			assertEquals( 1, constraintViolationException.getConstraintViolations().size() );
-			assertEquals( "Invalid magician name", constraintViolationException.getConstraintViolations().iterator().next().getMessage() );
+			assertThat( constraintViolationException.getConstraintViolations() ).hasSize( 1 );
+			assertThat( constraintViolationException.getConstraintViolations().iterator().next().getMessage() )
+					.isEqualTo( "Invalid magician name" );
 		}
 
 		log.debug( "testValidatorFactoryPassedToPersistenceUnitIsCorrectlyConfigured completed" );
@@ -104,11 +99,12 @@ public class CustomValidatorFactoryInPersistenceUnitIT {
 		}
 		catch (Exception e) {
 			Throwable rootException = getRootException( e );
-			assertEquals( ConstraintViolationException.class, rootException.getClass() );
+			assertThat( rootException ).isExactlyInstanceOf( ConstraintViolationException.class );
 
 			ConstraintViolationException constraintViolationException = (ConstraintViolationException) rootException;
-			assertEquals( 1, constraintViolationException.getConstraintViolations().size() );
-			assertEquals( "size must be between 5 and 2147483647", constraintViolationException.getConstraintViolations().iterator().next().getMessage() );
+			assertThat( constraintViolationException.getConstraintViolations() ).hasSize( 1 );
+			assertThat( constraintViolationException.getConstraintViolations().iterator().next().getMessage() )
+					.isEqualTo( "size must be between 5 and 2147483647" );
 		}
 
 		log.debug( "testValidatorFactoryPassedToPersistenceUnitIsContributedFromPortableExtensionOfCurrentModuleZip completed" );

--- a/osgi/integrationtest/pom.xml
+++ b/osgi/integrationtest/pom.xml
@@ -136,8 +136,10 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+                <configuration>
+                    <configLocation>checkstyle-documentation.xml</configLocation>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -35,8 +35,12 @@
             <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
     </dependencies>
 

--- a/performance/src/main/java/org/hibernate/validator/performance/cascaded/CascadedValidationTest.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/cascaded/CascadedValidationTest.java
@@ -6,12 +6,15 @@
  */
 package org.hibernate.validator.performance.cascaded;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+
 import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
 import javax.validation.Validation;
@@ -19,10 +22,8 @@ import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 import javax.validation.constraints.NotNull;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
@@ -32,7 +33,7 @@ public class CascadedValidationTest {
 	private static final int NUMBER_OF_RUNNABLES = 10000;
 	private static final int SIZE_OF_THREAD_POOL = 50;
 
-	@BeforeClass
+	@BeforeTest
 	public static void setupValidatorInstance() {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -50,7 +51,7 @@ public class CascadedValidationTest {
 		gonzo.addFriend( kermit ).addFriend( piggy );
 
 		Set<ConstraintViolation<Person>> violations = validator.validate( kermit );
-		assertEquals( 0, violations.size() );
+		assertThat( violations ).hasSize( 0 );
 	}
 
 	/**

--- a/performance/src/main/java/org/hibernate/validator/performance/simple/SimpleValidationTest.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/simple/SimpleValidationTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.performance.simple;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Random;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
@@ -16,10 +18,8 @@ import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
@@ -41,7 +41,7 @@ public class SimpleValidationTest {
 	private static Validator validator;
 	private static Random random;
 
-	@BeforeClass
+	@BeforeTest
 	public static void setUpValidatorFactory() {
 		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
 		validator = factory.getValidator();
@@ -52,7 +52,7 @@ public class SimpleValidationTest {
 	public void testSimpleBeanValidation() {
 		DriverSetup driverSetup = new DriverSetup();
 		Set<ConstraintViolation<Driver>> violations = validator.validate( driverSetup.getDriver() );
-		assertEquals( driverSetup.getExpectedViolationCount(), violations.size() );
+		assertThat( violations ).hasSize( driverSetup.getExpectedViolationCount() );
 	}
 
 	@Test
@@ -60,7 +60,7 @@ public class SimpleValidationTest {
 		DriverSetup driverSetup = new DriverSetup();
 		Validator localValidator = Validation.buildDefaultValidatorFactory().getValidator();
 		Set<ConstraintViolation<Driver>> violations = localValidator.validate( driverSetup.getDriver() );
-		assertEquals( driverSetup.getExpectedViolationCount(), violations.size() );
+		assertThat( violations ).hasSize( driverSetup.getExpectedViolationCount() );
 	}
 
 	public class Driver {

--- a/performance/src/main/java/org/hibernate/validator/performance/statistical/StatisticalValidationTest.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/statistical/StatisticalValidationTest.java
@@ -6,19 +6,19 @@
  */
 package org.hibernate.validator.performance.statistical;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.InputStream;
 import java.util.Set;
+
 import javax.validation.Configuration;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
@@ -29,7 +29,7 @@ public class StatisticalValidationTest {
 	private static Validator validator;
 	private static TestEntity[] entitiesUnderTest = new TestEntity[NUMBER_OF_TEST_ENTITIES];
 
-	@BeforeClass
+	@BeforeTest
 	public static void setUpValidatorFactory() throws Exception {
 		ValidatorFactory factory;
 		final Configuration<?> configuration = Validation.byDefaultProvider().configure();
@@ -37,7 +37,7 @@ public class StatisticalValidationTest {
 		try {
 			configuration.addMapping( mappingStream );
 			factory = configuration.buildValidatorFactory();
-			assertNotNull( factory );
+			assertThat( factory ).isNotNull();
 		}
 		finally {
 			mappingStream.close();
@@ -54,7 +54,7 @@ public class StatisticalValidationTest {
 	public void testValidationWithStatisticalGraphDepthAndConstraintValidator() throws Exception {
 		for ( int i = 0; i < NUMBER_OF_TEST_ENTITIES; i++ ) {
 			Set<ConstraintViolation<TestEntity>> violations = validator.validate( entitiesUnderTest[i] );
-			assertEquals( StatisticalConstraintValidator.threadLocalCounter.get().getFailures(), violations.size() );
+			assertThat( violations ).hasSize( StatisticalConstraintValidator.threadLocalCounter.get().getFailures() );
 			StatisticalConstraintValidator.threadLocalCounter.get().reset();
 		}
 	}

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
@@ -140,7 +140,7 @@ public final class ConstraintViolationAssert {
 	public static void assertConstraintViolation(ConstraintViolation<?> violation, String errorMessage,
 			Class<?> rootBeanClass, Object invalidValue, String propertyPath) {
 		assertTrue(
-				pathsAreEqual( violation.getPropertyPath(), PathImpl.createNewPath(propertyPath) ),
+				pathsAreEqual( violation.getPropertyPath(), PathImpl.createNewPath( propertyPath ) ),
 				"Wrong propertyPath"
 		);
 		assertConstraintViolation( violation, errorMessage, rootBeanClass, invalidValue );


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1102
 * https://hibernate.atlassian.net/browse/HV-1107

I'm not convinced switching to TestNG and assertj is a good choice for the integration tests as we need to deploy them but, at the time, I hoped we might get everything consistent so the work was already done when I had the issue with the OSGi integration tests.

Consistency is IMHO a good thing to avoid bad surprises.

As for the OSGi integration tests, I didn't get TestNG working in Karaf (well I did get it working but it didn't find any runnable tests). Adding TestNG at Karaf deployment didn't help so I decided to let it go, especially because the tests are very concise and we probably won't add anything there.