### PR TITLE
HV-1113-1115 Assorted fixes to the XML parsing

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -267,7 +267,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <packageName>org.hibernate.validator.internal.xml</packageName>
+                            <packageName>org.hibernate.validator.internal.xml.binding</packageName>
                             <extension>true</extension>
                             <!-- Generate correct getters for Boolean properties -->
                             <enableIntrospection>true</enableIntrospection>

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/XmlMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/XmlMetaDataProvider.java
@@ -18,7 +18,7 @@ import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
-import org.hibernate.validator.internal.xml.XmlMappingParser;
+import org.hibernate.validator.internal.xml.MappingXmlParser;
 
 /**
  * A {@link MetaDataProvider} providing constraint related meta data based on
@@ -46,19 +46,19 @@ public class XmlMetaDataProvider extends MetaDataProviderKeyedByClassName {
 		this( constraintHelper, createMappingParser( constraintHelper, parameterNameProvider, mappingStreams, externalClassLoader ) );
 	}
 
-	private XmlMetaDataProvider(ConstraintHelper constraintHelper, XmlMappingParser mappingParser) {
+	private XmlMetaDataProvider(ConstraintHelper constraintHelper, MappingXmlParser mappingParser) {
 		super( constraintHelper, createBeanConfigurations( mappingParser ) );
 		annotationProcessingOptions = mappingParser.getAnnotationProcessingOptions();
 	}
 
-	private static XmlMappingParser createMappingParser(ConstraintHelper constraintHelper, ParameterNameProvider parameterNameProvider, Set<InputStream> mappingStreams,
+	private static MappingXmlParser createMappingParser(ConstraintHelper constraintHelper, ParameterNameProvider parameterNameProvider, Set<InputStream> mappingStreams,
 			ClassLoader externalClassLoader) {
-		XmlMappingParser mappingParser = new XmlMappingParser( constraintHelper, parameterNameProvider, externalClassLoader );
+		MappingXmlParser mappingParser = new MappingXmlParser( constraintHelper, parameterNameProvider, externalClassLoader );
 		mappingParser.parse( mappingStreams );
 		return mappingParser;
 	}
 
-	private static Map<String, BeanConfiguration<?>> createBeanConfigurations(XmlMappingParser mappingParser) {
+	private static Map<String, BeanConfiguration<?>> createBeanConfigurations(MappingXmlParser mappingParser) {
 		final Map<String, BeanConfiguration<?>> configuredBeans = new HashMap<String, BeanConfiguration<?>>();
 		for ( Class<?> clazz : mappingParser.getXmlConfiguredClasses() ) {
 			Set<ConstrainedElement> constrainedElements = mappingParser.getConstrainedElementsForClass( clazz );

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/CloseIgnoringInputStream.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/CloseIgnoringInputStream.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.xml;
+
+import java.io.FilterInputStream;
+import java.io.InputStream;
+
+/**
+ * HV-1025 - On some JVMs (eg the IBM JVM) the JAXB implementation closes the underlying input stream.
+ * <p>
+ * To prevent this we wrap the input stream to be able to ignore the close event. It is the responsibility of the client
+ * API to close the stream (as per Bean Validation spec, see javax.validation.Configuration).
+ *
+ * @author Guillaume Smet
+ */
+class CloseIgnoringInputStream extends FilterInputStream {
+
+	public CloseIgnoringInputStream(InputStream in) {
+		super( in );
+	}
+
+	@Override
+	public void close() {
+		// do nothing
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedExecutableBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedExecutableBuilder.java
@@ -6,6 +6,10 @@
  */
 package org.hibernate.validator.internal.xml;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.security.AccessController;
@@ -14,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.validation.ParameterNameProvider;
 import javax.validation.ValidationException;
 
@@ -26,15 +31,16 @@ import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
-import org.hibernate.validator.internal.util.StringHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredConstructor;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredMethod;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import org.hibernate.validator.internal.xml.binding.ConstraintType;
+import org.hibernate.validator.internal.xml.binding.ConstructorType;
+import org.hibernate.validator.internal.xml.binding.CrossParameterType;
+import org.hibernate.validator.internal.xml.binding.MethodType;
+import org.hibernate.validator.internal.xml.binding.ParameterType;
+import org.hibernate.validator.internal.xml.binding.ReturnValueType;
 
 /**
  * Builder for constrained methods and constructors.

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedFieldBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedFieldBuilder.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.validator.internal.xml;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
 import java.lang.reflect.Field;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -23,9 +26,8 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredField;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import org.hibernate.validator.internal.xml.binding.ConstraintType;
+import org.hibernate.validator.internal.xml.binding.FieldType;
 
 /**
  * Builder for constraint fields.

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedGetterBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedGetterBuilder.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.validator.internal.xml;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -24,9 +27,8 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetMethodFromPropertyName;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import org.hibernate.validator.internal.xml.binding.ConstraintType;
+import org.hibernate.validator.internal.xml.binding.GetterType;
 
 /**
  * Builder for constraint getters.

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedParameterBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedParameterBuilder.java
@@ -6,11 +6,15 @@
  */
 package org.hibernate.validator.internal.xml;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
 import java.lang.annotation.ElementType;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.validation.ParameterNameProvider;
 
 import org.hibernate.validator.internal.engine.valuehandling.UnwrapMode;
@@ -21,9 +25,8 @@ import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
 import org.hibernate.validator.internal.metadata.raw.ExecutableElement;
 import org.hibernate.validator.internal.util.ReflectionHelper;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import org.hibernate.validator.internal.xml.binding.ConstraintType;
+import org.hibernate.validator.internal.xml.binding.ParameterType;
 
 /**
  * Builder for constraint parameters.

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedTypeBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedTypeBuilder.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.validator.internal.xml;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -15,9 +18,9 @@ import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import org.hibernate.validator.internal.xml.binding.ClassType;
+import org.hibernate.validator.internal.xml.binding.ConstraintType;
+import org.hibernate.validator.internal.xml.binding.GroupSequenceType;
 
 /**
  * Builder for constraint types.

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/GroupConversionBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/GroupConversionBuilder.java
@@ -6,10 +6,12 @@
  */
 package org.hibernate.validator.internal.xml;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+
 import java.util.List;
 import java.util.Map;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+import org.hibernate.validator.internal.xml.binding.GroupConversionType;
 
 /**
  * Builder for group conversions.

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/LocalNamespace.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/LocalNamespace.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.xml;
+
+/**
+ * Bean Validation namespaces reference.
+ *
+ * @author Guillaume Smet
+ */
+public enum LocalNamespace {
+	VALIDATION_1_CONFIGURATION("http://jboss.org/xml/ns/javax/validation/configuration"),
+	VALIDATION_1_MAPPING("http://jboss.org/xml/ns/javax/validation/mapping"),
+
+	VALIDATION_2_CONFIGURATION("http://xmlns.jcp.org/xml/ns/validation/configuration"),
+	VALIDATION_2_MAPPING("http://xmlns.jcp.org/xml/ns/validation/mapping");
+
+	private String namespaceURI;
+
+	private LocalNamespace(String namespaceURI) {
+		this.namespaceURI = namespaceURI;
+	}
+
+	public String getNamespaceURI() {
+		return namespaceURI;
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
@@ -52,7 +52,7 @@ import org.xml.sax.SAXException;
  *
  * @author Hardy Ferentschik
  */
-public class XmlMappingParser {
+public class MappingXmlParser {
 
 	private static final Log log = LoggerFactory.make();
 
@@ -79,7 +79,7 @@ public class XmlMappingParser {
 		return schemasByVersion;
 	}
 
-	public XmlMappingParser(ConstraintHelper constraintHelper, ParameterNameProvider parameterNameProvider,
+	public MappingXmlParser(ConstraintHelper constraintHelper, ParameterNameProvider parameterNameProvider,
 			ClassLoader externalClassLoader) {
 		this.constraintHelper = constraintHelper;
 		this.annotationProcessingOptions = new AnnotationProcessingOptionsImpl();

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
@@ -45,6 +45,10 @@ import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.NewJaxbContext;
 import org.hibernate.validator.internal.util.privilegedactions.Unmarshal;
+import org.hibernate.validator.internal.xml.binding.BeanType;
+import org.hibernate.validator.internal.xml.binding.ConstraintDefinitionType;
+import org.hibernate.validator.internal.xml.binding.ConstraintMappingsType;
+import org.hibernate.validator.internal.xml.binding.ValidatedByType;
 import org.xml.sax.SAXException;
 
 /**

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/MetaConstraintBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/MetaConstraintBuilder.java
@@ -31,6 +31,11 @@ import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetMethod;
+import org.hibernate.validator.internal.xml.binding.AnnotationType;
+import org.hibernate.validator.internal.xml.binding.ConstraintType;
+import org.hibernate.validator.internal.xml.binding.ElementType;
+import org.hibernate.validator.internal.xml.binding.GroupsType;
+import org.hibernate.validator.internal.xml.binding.PayloadType;
 
 /**
  * Build meta constraint from XML

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/MetaConstraintBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/MetaConstraintBuilder.java
@@ -158,7 +158,7 @@ class MetaConstraintBuilder {
 	}
 
 	private static void removeEmptyContentElements(ElementType elementType) {
-		for ( Iterator<Serializable> contentIterator = elementType.getContent().iterator(); contentIterator.hasNext(); ){
+		for ( Iterator<Serializable> contentIterator = elementType.getContent().iterator(); contentIterator.hasNext(); ) {
 			Serializable content = contentIterator.next();
 			if ( content instanceof String && IS_ONLY_WHITESPACE.matcher( (String) content ).matches() ) {
 				contentIterator.remove();

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/NamespaceNormalizingXMLEventReaderDelegate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/NamespaceNormalizingXMLEventReaderDelegate.java
@@ -1,0 +1,101 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.xml;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventFactory;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.Namespace;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+import javax.xml.stream.util.EventReaderDelegate;
+
+/**
+ * An XML {@link EventReaderDelegate} designed to normalize the XML namespaces.
+ * <p>
+ * From BV 1.x to BV 2, we changed the namespaces and we need to normalize the namespaces to the ones of BV 2 so that
+ * the unmarshaller can do its job.
+ * <p>
+ * Note: it used to work in JDK 1.8 before the 102 release but the JDK is now stricter:
+ * <a href="https://bugs.openjdk.java.net/browse/JDK-8134111">https://bugs.openjdk.java.net/browse/JDK-8134111</a>.
+ *
+ * @author Guillaume Smet
+ */
+public class NamespaceNormalizingXMLEventReaderDelegate extends EventReaderDelegate {
+
+	private final XMLEventFactory eventFactory;
+
+	private final Map<String, String> namespaceMapping;
+
+	public NamespaceNormalizingXMLEventReaderDelegate(XMLEventReader eventReader, XMLEventFactory eventFactory, Map<String, String> namespaceMapping) {
+		super( eventReader );
+		this.eventFactory = eventFactory;
+		this.namespaceMapping = namespaceMapping;
+	}
+
+	@Override
+	public XMLEvent peek() throws XMLStreamException {
+		return normalizeXMLEvent( super.peek() );
+	}
+
+	@Override
+	public XMLEvent nextEvent() throws XMLStreamException {
+		return normalizeXMLEvent( super.nextEvent() );
+	}
+
+	public XMLEvent normalizeXMLEvent(XMLEvent xmlEvent) {
+		if ( xmlEvent.isStartElement() ) {
+			return normalizeNamespace( xmlEvent.asStartElement() );
+		}
+		else if ( xmlEvent.isEndElement() ) {
+			return normalizeNamespace( xmlEvent.asEndElement() );
+		}
+		else {
+			return xmlEvent;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	public StartElement normalizeNamespace(StartElement element) {
+		eventFactory.setLocation( element.getLocation() );
+		return eventFactory.createStartElement( normalizeQName( element.getName() ), element.getAttributes(), normalizeNamespaces( element.getNamespaces() ) );
+	}
+
+	@SuppressWarnings("unchecked")
+	public EndElement normalizeNamespace(EndElement element) {
+		eventFactory.setLocation( element.getLocation() );
+		return eventFactory.createEndElement( normalizeQName( element.getName() ), normalizeNamespaces( element.getNamespaces() ) );
+	}
+
+	public QName normalizeQName(QName qName) {
+		return new QName( normalizeNamespaceURI( qName.getNamespaceURI() ), qName.getLocalPart() );
+	}
+
+	public Iterator<Namespace> normalizeNamespaces(Iterator<Namespace> namespaces) {
+		List<Namespace> newNamespaces = new ArrayList<>();
+		while ( namespaces.hasNext() ) {
+			newNamespaces.add( normalizeNamespace( namespaces.next() ) );
+		}
+		return newNamespaces.iterator();
+	}
+
+	public Namespace normalizeNamespace(Namespace namespace) {
+		return eventFactory.createNamespace( namespace.getPrefix(), normalizeNamespaceURI( namespace.getNamespaceURI() ) );
+	}
+
+	public String normalizeNamespaceURI(String namespaceURI) {
+		return namespaceMapping.getOrDefault( namespaceURI, namespaceURI );
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ResourceLoaderHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ResourceLoaderHelper.java
@@ -23,6 +23,10 @@ import org.hibernate.validator.internal.util.privilegedactions.GetClassLoader;
 final class ResourceLoaderHelper {
 	private static final Log log = LoggerFactory.make();
 
+	private ResourceLoaderHelper() {
+		// Not allowed
+	}
+
 	/**
 	 * Returns an input stream for the given path, which supports the mark/reset
 	 * contract.

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationXmlParser.java
@@ -31,6 +31,10 @@ import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.NewJaxbContext;
 import org.hibernate.validator.internal.util.privilegedactions.Unmarshal;
+import org.hibernate.validator.internal.xml.binding.DefaultValidatedExecutableTypesType;
+import org.hibernate.validator.internal.xml.binding.ExecutableValidationType;
+import org.hibernate.validator.internal.xml.binding.PropertyType;
+import org.hibernate.validator.internal.xml.binding.ValidationConfigType;
 import org.xml.sax.SAXException;
 
 /**

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/XmlMappingParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/XmlMappingParser.java
@@ -10,7 +10,6 @@ import static org.hibernate.validator.internal.util.CollectionHelper.newArrayLis
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -29,7 +28,10 @@ import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
+import javax.xml.validation.Validator;
 
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptions;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
@@ -43,6 +45,7 @@ import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.NewJaxbContext;
 import org.hibernate.validator.internal.util.privilegedactions.Unmarshal;
+import org.xml.sax.SAXException;
 
 /**
  * XML parser for validation-mapping files.
@@ -131,22 +134,30 @@ public class XmlMappingParser {
 
 			Set<String> alreadyProcessedConstraintDefinitions = newHashSet();
 			for ( InputStream in : mappingStreams ) {
-
-				// check whether mark is supported, if so we can reset the stream in order to allow reuse of Configuration
-				boolean markSupported = in.markSupported();
-				if ( markSupported ) {
-					in.mark( Integer.MAX_VALUE );
-				}
+				// the InputStreams passed in parameters support mark and reset
+				in.mark( Integer.MAX_VALUE );
 
 				XMLEventReader xmlEventReader = xmlParserHelper.createXmlEventReader( "constraint mapping file", new CloseIgnoringInputStream( in ) );
 				String schemaVersion = xmlParserHelper.getSchemaVersion( "constraint mapping file", xmlEventReader );
+				xmlEventReader.close();
+
+				in.reset();
+
+				// The validation is done first as we manipulate the XML document before pushing it to the unmarshaller
+				// and it might not be valid anymore as we might have switched the namespace to the latest namespace
+				// supported.
 				String schemaResourceName = getSchemaResourceName( schemaVersion );
 				Schema schema = xmlParserHelper.getSchema( schemaResourceName );
+				Validator validator = schema.newValidator();
+				validator.validate( new StreamSource( new CloseIgnoringInputStream( in ) ) );
 
+				in.reset();
+
+				xmlEventReader = xmlParserHelper.createXmlEventReader( "constraint mapping file", new CloseIgnoringInputStream( in ) );
 				Unmarshaller unmarshaller = jc.createUnmarshaller();
-				unmarshaller.setSchema( schema );
-
 				ConstraintMappingsType mapping = getValidationConfig( xmlEventReader, unmarshaller );
+				xmlEventReader.close();
+
 				String defaultPackage = mapping.getDefaultPackage();
 
 				parseConstraintDefinitions(
@@ -166,17 +177,10 @@ public class XmlMappingParser {
 					);
 				}
 
-				if ( markSupported ) {
-					try {
-						in.reset();
-					}
-					catch (IOException e) {
-						log.debug( "Unable to reset input stream." );
-					}
-				}
+				in.reset();
 			}
 		}
-		catch (JAXBException e) {
+		catch (JAXBException | SAXException | IOException | XMLStreamException e) {
 			throw log.getErrorParsingMappingFileException( e );
 		}
 	}
@@ -388,17 +392,4 @@ public class XmlMappingParser {
 		}
 	}
 
-	// HV-1025 - On some JVMs (eg the IBM JVM) the JAXB implementation closes the underlying input stream.
-	// To prevent this we wrap the input stream to be able to ignore the close event. It is the responsibility
-	// of the client API to close the stream (as per Bean Validation spec, see javax.validation.Configuration).
-	private static class CloseIgnoringInputStream extends FilterInputStream {
-		public CloseIgnoringInputStream(InputStream in) {
-			super( in );
-		}
-
-		@Override
-		public void close() {
-			// do nothing
-		}
-	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
@@ -21,7 +21,7 @@ import org.hibernate.validator.internal.constraintvalidators.bv.DecimalMinValida
 import org.hibernate.validator.internal.constraintvalidators.bv.DecimalMinValidatorForNumber;
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
-import org.hibernate.validator.internal.xml.XmlMappingParser;
+import org.hibernate.validator.internal.xml.MappingXmlParser;
 import org.hibernate.validator.testutil.TestForIssue;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
@@ -32,15 +32,15 @@ import static org.testng.Assert.fail;
 /**
  * @author Hardy Ferentschik
  */
-public class XmlMappingParserTest {
+public class MappingXmlParserTest {
 
-	private XmlMappingParser xmlMappingParser;
+	private MappingXmlParser xmlMappingParser;
 	private ConstraintHelper constraintHelper;
 
 	@BeforeMethod
 	public void setupParserHelper() {
 		constraintHelper = new ConstraintHelper();
-		xmlMappingParser = new XmlMappingParser( constraintHelper, new DefaultParameterNameProvider(), null );
+		xmlMappingParser = new MappingXmlParser( constraintHelper, new DefaultParameterNameProvider(), null );
 	}
 
 	@Test
@@ -55,7 +55,7 @@ public class XmlMappingParserTest {
 		assertTrue( validators.contains( DecimalMinValidatorForNumber.class ), "Missing default validator" );
 
 		Set<InputStream> mappingStreams = newHashSet();
-		mappingStreams.add( XmlMappingParserTest.class.getResourceAsStream( "decimal-min-mapping-1.xml" ) );
+		mappingStreams.add( MappingXmlParserTest.class.getResourceAsStream( "decimal-min-mapping-1.xml" ) );
 
 		xmlMappingParser.parse( mappingStreams );
 
@@ -71,8 +71,8 @@ public class XmlMappingParserTest {
 	@TestForIssue(jiraKey = "HV-782")
 	public void testOverridingOfConstraintValidatorsFromMultipleMappingFilesThrowsException() {
 		Set<InputStream> mappingStreams = newHashSet();
-		mappingStreams.add( XmlMappingParserTest.class.getResourceAsStream( "decimal-min-mapping-1.xml" ) );
-		mappingStreams.add( XmlMappingParserTest.class.getResourceAsStream( "decimal-min-mapping-2.xml" ) );
+		mappingStreams.add( MappingXmlParserTest.class.getResourceAsStream( "decimal-min-mapping-1.xml" ) );
+		mappingStreams.add( MappingXmlParserTest.class.getResourceAsStream( "decimal-min-mapping-2.xml" ) );
 
 		try {
 			xmlMappingParser.parse( mappingStreams );

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/decimal-min-mapping-1.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/decimal-min-mapping-1.xml
@@ -6,7 +6,7 @@
 
     <constraint-definition annotation="javax.validation.constraints.DecimalMin">
         <validated-by include-existing-validators="true">
-            <value>org.hibernate.validator.test.internal.xml.XmlMappingParserTest$DecimalMinValidatorForFoo</value>
+            <value>org.hibernate.validator.test.internal.xml.MappingXmlParserTest$DecimalMinValidatorForFoo</value>
         </validated-by>
     </constraint-definition>
 </constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/decimal-min-mapping-2.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/decimal-min-mapping-2.xml
@@ -6,7 +6,7 @@
 
     <constraint-definition annotation="javax.validation.constraints.DecimalMin">
         <validated-by include-existing-validators="true">
-            <value>org.hibernate.validator.test.internal.xml.XmlMappingParserTest$DecimalMinValidatorForBar</value>
+            <value>org.hibernate.validator.test.internal.xml.MappingXmlParserTest$DecimalMinValidatorForBar</value>
         </validated-by>
     </constraint-definition>
 </constraint-mappings>

--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,7 @@
                         <!-- These classes are either imported from other sources and re-formatted
                         or generated or present significant reasons to not follow the rules. -->
                         <excludes>
-                            **/org/hibernate/validator/internal/xml/*.java,
+                            **/org/hibernate/validator/internal/xml/binding/*.java,
                             **/Log_$logger.java,
                             **/Messages_$bundle.java,
                             **/ConcurrentReferenceHashMap.java,


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1113
 * https://hibernate.atlassian.net/browse/HV-1114

@gunnar wondering if we should have a more comprehensive form of `LocalNamespace` in validation-api? It could include the `MappingXmlParser.SCHEMAS_BY_VERSION` information too.

Something similar to https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/boot/jaxb/internal/stax/LocalSchema.java without the 3 static methods.