### PR TITLE
HV-1117 Downgrade surefire and failsafe to 2.18.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -478,8 +478,12 @@
                     </executions>
                 </plugin>
                 <plugin>
+                    <!--
+                    Do not upgrade Surefire and Failsafe to 2.19+.
+                    See https://hibernate.atlassian.net/browse/HV-1117
+                    -->
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.18.1</version>
                     <configuration>
                         <forkMode>once</forkMode>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -490,7 +494,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-report-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.18.1</version>
                     <executions>
                         <execution>
                             <id>generate-test-report</id>
@@ -507,7 +511,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.19.1</version>
+                    <version>2.18.1</version>
                     <executions>
                         <execution>
                             <id>integration-test</id>


### PR DESCRIPTION
Newer versions cause random failures in our OSGi integration tests.