### PR TITLE
Preview: Lambda-based constraints

### DIFF
--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -735,6 +735,18 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/constraint
 ----
 ====
 
+If your validator implementation is rather simple (i.e. no initialization from the annotation is needed,
+and `ConstraintValidatorContext` is not used), you also can use this alternative API to specify the constraint logic using a Lambda expression or method reference:
+
+[[example-using-constraint-definition-api]]
+.Adding constraint definition with a Lambda expression
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/constraintapi/ConstraintApiTest.java[tags=constraintDefinitionUsingLambda]
+----
+====
+
 Instead of directly adding a constraint mapping to the configuration object, you may use a `ConstraintMappingContributor`
 as detailed in <<section-programmatic-api-contributor>>. This can be useful when
 configuring the default validator factory using _META-INF/validation.xml_ (see

--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -6,6 +6,13 @@ in addition to the functionality defined by the Bean Validation specification. T
 fail fast mode, the API for programmatic constraint configuration and the boolean composition of
 constraints.
 
+New APIs or SPIs are tagged with the `org.hibernate.validator.Incubating` annotation as long as they
+are under development. This means that such elements (e.g. packages, types, methods, constants etc.)
+may be incompatible altered - or removed - in subsequent releases. Usage of incubating API/SPI members
+is encouraged (so the development team can get feedback on these new features) but you should be
+prepared for updating code which is using them as needed when upgrading to a new version of Hibernate
+Validator.
+
 [NOTE]
 ====
 Using the features described in the following sections may result in application code which is not

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/constraintapi/ConstraintApiTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/constraintapi/ConstraintApiTest.java
@@ -156,6 +156,24 @@ public class ConstraintApiTest {
 	}
 
 	@Test
+	public void constraintDefinitionUsingLambda() {
+		HibernateValidatorConfiguration configuration = Validation
+				.byProvider( HibernateValidator.class )
+				.configure();
+
+		//tag::constraintDefinitionUsingLambda[]
+		ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+
+		constraintMapping
+				.constraintDefinition( ValidPassengerCount.class )
+					.validateType( Bus.class )
+						.with( b -> b.getSeatCount() >= b.getPassengers().size() );
+		//end::constraintDefinitionUsingLambda[]
+
+		configuration.addMapping( constraintMapping );
+	}
+
+	@Test
 	public void urlValidationOverride() {
 		HibernateValidatorConfiguration configuration = Validation
 			.byProvider( HibernateValidator.class )

--- a/engine/src/main/java/org/hibernate/validator/Incubating.java
+++ b/engine/src/main/java/org/hibernate/validator/Incubating.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Marks the annotated element as incubating. The contract of incubating elements (e.g. packages, types, methods,
+ * constants etc.) is under active development and may be incompatible altered - or removed - in subsequent releases.
+ * <p>
+ * Usage of incubating API/SPI members is encouraged (so the development team can get feedback on these new features)
+ * but you should be prepared for updating code which is using them as needed.
+ *
+ * @author Gunnar Morling
+ */
+@Retention(RetentionPolicy.CLASS)
+public @interface Incubating {
+}

--- a/engine/src/main/java/org/hibernate/validator/cfg/context/ConstraintDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/context/ConstraintDefinitionContext.java
@@ -39,4 +39,27 @@ public interface ConstraintDefinitionContext<A extends Annotation> extends Const
 	 * @return This context for method chaining.
 	 */
 	ConstraintDefinitionContext<A> validatedBy(Class<? extends ConstraintValidator<A, ?>> validator);
+
+	/**
+	 * Allows to configure a validation implementation using a Lambda expression or method reference. Useful for simple
+	 * validations without the need for accessing constraint properties or customization of error messages etc.
+	 *
+	 * @param type The type of the value to validate
+	 * @return This context for method chaining
+	 */
+	<T> ConstraintValidatorDefinitionContext<A, T> validateType(Class<T> type);
+
+	interface ConstraintValidatorDefinitionContext<A extends Annotation, T> {
+
+		/**
+		 * Applies the given Lambda expression or referenced method to values to be validated. It is guaranteed that
+		 * never {@code null} is passed to these expressions or methods.
+		 */
+		ConstraintDefinitionContext<A> with(ValidationCallable<T> vc);
+	}
+
+	@FunctionalInterface
+	interface ValidationCallable<T> {
+		boolean isValid(T object);
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/cfg/context/ConstraintDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/context/ConstraintDefinitionContext.java
@@ -10,6 +10,8 @@ import java.lang.annotation.Annotation;
 
 import javax.validation.ConstraintValidator;
 
+import org.hibernate.validator.Incubating;
+
 
 /**
  * Constraint mapping creational context representing a constraint (i.e. annotation type). Allows to define which
@@ -43,12 +45,19 @@ public interface ConstraintDefinitionContext<A extends Annotation> extends Const
 	/**
 	 * Allows to configure a validation implementation using a Lambda expression or method reference. Useful for simple
 	 * validations without the need for accessing constraint properties or customization of error messages etc.
+	 * <p>
 	 *
 	 * @param type The type of the value to validate
 	 * @return This context for method chaining
 	 */
+	@Incubating
 	<T> ConstraintValidatorDefinitionContext<A, T> validateType(Class<T> type);
 
+	/**
+	 * Allows to specify a validation implementation for the given constraint and data type using a Lambda expression or
+	 * method reference.
+	 */
+	@Incubating
 	interface ConstraintValidatorDefinitionContext<A extends Annotation, T> {
 
 		/**
@@ -62,6 +71,7 @@ public interface ConstraintDefinitionContext<A extends Annotation> extends Const
 	 * Callable implementing a validation routine. Usually given as method reference or Lambda expression.
 	 */
 	@FunctionalInterface
+	@Incubating
 	interface ValidationCallable<T> {
 		boolean isValid(T object);
 	}

--- a/engine/src/main/java/org/hibernate/validator/cfg/context/ConstraintDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/context/ConstraintDefinitionContext.java
@@ -53,11 +53,14 @@ public interface ConstraintDefinitionContext<A extends Annotation> extends Const
 
 		/**
 		 * Applies the given Lambda expression or referenced method to values to be validated. It is guaranteed that
-		 * never {@code null} is passed to these expressions or methods.
+		 * {@code null} is never passed to these expressions or methods.
 		 */
 		ConstraintDefinitionContext<A> with(ValidationCallable<T> vc);
 	}
 
+	/**
+	 * Callable implementing a validation routine. Usually given as method reference or Lambda expression.
+	 */
 	@FunctionalInterface
 	interface ValidationCallable<T> {
 		boolean isValid(T object);

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConstraintDefinitionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConstraintDefinitionContextImpl.java
@@ -51,11 +51,32 @@ class ConstraintDefinitionContextImpl<A extends Annotation>
 		return this;
 	}
 
+	@Override
+	public <T> ConstraintDefinitionContext.ConstraintValidatorDefinitionContext<A, T> validateType(Class<T> type) {
+		return new ConstraintValidatorDefinitionContextImpl<>( type );
+	}
+
 	@SuppressWarnings("unchecked")
 	ConstraintDefinitionContribution<A> build() {
 		return new ConstraintDefinitionContribution<>(
 				annotationType,
 				CollectionHelper.newArrayList( validatorTypes ),
 				includeExistingValidators );
+	}
+
+	private class ConstraintValidatorDefinitionContextImpl<T> implements ConstraintDefinitionContext.ConstraintValidatorDefinitionContext<A, T> {
+
+		private final Class<T> type;
+
+		public ConstraintValidatorDefinitionContextImpl(Class<T> type) {
+			this.type = type;
+		}
+
+		@Override
+		public ConstraintDefinitionContext<A> with(ConstraintDefinitionContext.ValidationCallable<T> vc) {
+			validatorTypes.add( ConstraintValidatorDescriptor.forLambda( annotationType, type, vc ) );
+
+			return ConstraintDefinitionContextImpl.this;
+		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConstraintDefinitionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConstraintDefinitionContextImpl.java
@@ -32,7 +32,7 @@ class ConstraintDefinitionContextImpl<A extends Annotation>
 
 	private boolean includeExistingValidators = true;
 
-	private final Set<ConstraintValidatorDescriptor<A>> validatorTypes = new HashSet<>();
+	private final Set<ConstraintValidatorDescriptor<A>> validatorDescriptors = new HashSet<>();
 
 	ConstraintDefinitionContextImpl(DefaultConstraintMapping mapping, Class<A> annotationType) {
 		super( mapping );
@@ -47,7 +47,7 @@ class ConstraintDefinitionContextImpl<A extends Annotation>
 
 	@Override
 	public ConstraintDefinitionContext<A> validatedBy(Class<? extends ConstraintValidator<A, ?>> validator) {
-		validatorTypes.add( ConstraintValidatorDescriptor.forClass( validator ) );
+		validatorDescriptors.add( ConstraintValidatorDescriptor.forClass( validator ) );
 		return this;
 	}
 
@@ -60,7 +60,7 @@ class ConstraintDefinitionContextImpl<A extends Annotation>
 	ConstraintDefinitionContribution<A> build() {
 		return new ConstraintDefinitionContribution<>(
 				annotationType,
-				CollectionHelper.newArrayList( validatorTypes ),
+				CollectionHelper.newArrayList( validatorDescriptors ),
 				includeExistingValidators );
 	}
 
@@ -74,7 +74,7 @@ class ConstraintDefinitionContextImpl<A extends Annotation>
 
 		@Override
 		public ConstraintDefinitionContext<A> with(ConstraintDefinitionContext.ValidationCallable<T> vc) {
-			validatorTypes.add( ConstraintValidatorDescriptor.forLambda( annotationType, type, vc ) );
+			validatorDescriptors.add( ConstraintValidatorDescriptor.forLambda( annotationType, type, vc ) );
 
 			return ConstraintDefinitionContextImpl.this;
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConstraintDefinitionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConstraintDefinitionContextImpl.java
@@ -6,15 +6,15 @@
  */
 package org.hibernate.validator.internal.cfg.context;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
-
 import java.lang.annotation.Annotation;
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.validation.ConstraintValidator;
 
 import org.hibernate.validator.cfg.context.ConstraintDefinitionContext;
 import org.hibernate.validator.internal.engine.constraintdefinition.ConstraintDefinitionContribution;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 import org.hibernate.validator.internal.util.CollectionHelper;
 
 /**
@@ -32,7 +32,7 @@ class ConstraintDefinitionContextImpl<A extends Annotation>
 
 	private boolean includeExistingValidators = true;
 
-	private final Set<Class<? extends ConstraintValidator<A, ?>>> validatorTypes = newHashSet();
+	private final Set<ConstraintValidatorDescriptor<A>> validatorTypes = new HashSet<>();
 
 	ConstraintDefinitionContextImpl(DefaultConstraintMapping mapping, Class<A> annotationType) {
 		super( mapping );
@@ -47,13 +47,13 @@ class ConstraintDefinitionContextImpl<A extends Annotation>
 
 	@Override
 	public ConstraintDefinitionContext<A> validatedBy(Class<? extends ConstraintValidator<A, ?>> validator) {
-		validatorTypes.add( validator );
+		validatorTypes.add( ConstraintValidatorDescriptor.forClass( validator ) );
 		return this;
 	}
 
 	@SuppressWarnings("unchecked")
 	ConstraintDefinitionContribution<A> build() {
-		return new ConstraintDefinitionContribution<A>(
+		return new ConstraintDefinitionContribution<>(
 				annotationType,
 				CollectionHelper.newArrayList( validatorTypes ),
 				includeExistingValidators );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -520,9 +520,9 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 			throw log.getConstraintHasAlreadyBeenConfiguredViaProgrammaticApiException( constraintType );
 		}
 		definedConstraints.add( constraintType );
-		constraintHelper.putValidatorClasses(
+		constraintHelper.putValidatorDescriptors(
 				constraintType,
-				constraintDefinitionContribution.getValidatorTypes(),
+				constraintDefinitionContribution.getValidatorDescriptors(),
 				constraintDefinitionContribution.includeExisting()
 		);
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -522,7 +522,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		definedConstraints.add( constraintType );
 		constraintHelper.putValidatorClasses(
 				constraintType,
-				constraintDefinitionContribution.getConstraintValidators(),
+				constraintDefinitionContribution.getValidatorTypes(),
 				constraintDefinitionContribution.includeExisting()
 		);
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintdefinition/ConstraintDefinitionContribution.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintdefinition/ConstraintDefinitionContribution.java
@@ -19,33 +19,29 @@ import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintVa
  */
 public class ConstraintDefinitionContribution<A extends Annotation> {
 	private final Class<A> constraintType;
-	private final List<ConstraintValidatorDescriptor<A>> validatorTypes;
+	private final List<ConstraintValidatorDescriptor<A>> validatorDescriptors;
 	private final boolean includeExisting;
 
 	public ConstraintDefinitionContribution(Class<A> constraintType,
-			List<ConstraintValidatorDescriptor<A>> validatorTypes,
+			List<ConstraintValidatorDescriptor<A>> validatorDescriptors,
 			boolean includeExisting) {
 		this.constraintType = constraintType;
-		this.validatorTypes = Collections.unmodifiableList( validatorTypes );
+		this.validatorDescriptors = Collections.unmodifiableList( validatorDescriptors );
 		this.includeExisting = includeExisting;
 	}
 
 	/**
 	 * Returns the constraint annotation type for which this instance provides constraint validator instances.
-	 *
-	 * @return the constraint annotation type for which this instance provides constraint validator instances.
 	 */
 	public Class<A> getConstraintType() {
 		return constraintType;
 	}
 
 	/**
-	 * Returns a list of constraint validator types for the constraint type of this instance.
-	 *
-	 * @return a list of constraint validator types for the constraint type of this instance.
+	 * Returns a list of constraint validator descriptors for the constraint type of this instance.
 	 */
-	public List<ConstraintValidatorDescriptor<A>> getValidatorTypes() {
-		return validatorTypes;
+	public List<ConstraintValidatorDescriptor<A>> getValidatorDescriptors() {
+		return validatorDescriptors;
 	}
 
 	/**
@@ -72,7 +68,7 @@ public class ConstraintDefinitionContribution<A extends Annotation> {
 		if ( !constraintType.equals( that.constraintType ) ) {
 			return false;
 		}
-		if ( !validatorTypes.equals( that.validatorTypes ) ) {
+		if ( !validatorDescriptors.equals( that.validatorDescriptors ) ) {
 			return false;
 		}
 
@@ -82,7 +78,7 @@ public class ConstraintDefinitionContribution<A extends Annotation> {
 	@Override
 	public int hashCode() {
 		int result = constraintType.hashCode();
-		result = 31 * result + validatorTypes.hashCode();
+		result = 31 * result + validatorDescriptors.hashCode();
 		return result;
 	}
 
@@ -90,7 +86,7 @@ public class ConstraintDefinitionContribution<A extends Annotation> {
 	public String toString() {
 		return "ConstraintDefinitionContribution{" +
 				"constraintType=" + constraintType +
-				", validatorTypes=" + validatorTypes +
+				", validatorDescriptors=" + validatorDescriptors +
 				", includeExisting=" + includeExisting +
 				'}';
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintdefinition/ConstraintDefinitionContribution.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintdefinition/ConstraintDefinitionContribution.java
@@ -9,7 +9,8 @@ package org.hibernate.validator.internal.engine.constraintdefinition;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.List;
-import javax.validation.ConstraintValidator;
+
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 
 /**
  * Type-safe wrapper class for a constraint annotation and its potential list of constraint validators.
@@ -18,11 +19,11 @@ import javax.validation.ConstraintValidator;
  */
 public class ConstraintDefinitionContribution<A extends Annotation> {
 	private final Class<A> constraintType;
-	private final List<Class<? extends ConstraintValidator<A, ?>>> constraintValidators = new ArrayList<Class<? extends ConstraintValidator<A, ?>>>();
+	private final List<ConstraintValidatorDescriptor<A>> constraintValidators = new ArrayList<>();
 	private final boolean includeExisting;
 
 	public ConstraintDefinitionContribution(Class<A> constraintType,
-			List<Class<? extends ConstraintValidator<A, ?>>> constraintValidators,
+			List<ConstraintValidatorDescriptor<A>> constraintValidators,
 			boolean includeExisting) {
 		this.constraintType = constraintType;
 		this.constraintValidators.addAll( constraintValidators );
@@ -43,7 +44,7 @@ public class ConstraintDefinitionContribution<A extends Annotation> {
 	 *
 	 * @return a list of constraint validator types for the constraint type of this instance.
 	 */
-	public List<Class<? extends ConstraintValidator<A, ?>>> getConstraintValidators() {
+	public List<ConstraintValidatorDescriptor<A>> getConstraintValidators() {
 		return constraintValidators;
 	}
 
@@ -94,5 +95,3 @@ public class ConstraintDefinitionContribution<A extends Annotation> {
 				'}';
 	}
 }
-
-

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintdefinition/ConstraintDefinitionContribution.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintdefinition/ConstraintDefinitionContribution.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.engine.constraintdefinition;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
@@ -19,14 +19,14 @@ import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintVa
  */
 public class ConstraintDefinitionContribution<A extends Annotation> {
 	private final Class<A> constraintType;
-	private final List<ConstraintValidatorDescriptor<A>> constraintValidators = new ArrayList<>();
+	private final List<ConstraintValidatorDescriptor<A>> validatorTypes;
 	private final boolean includeExisting;
 
 	public ConstraintDefinitionContribution(Class<A> constraintType,
-			List<ConstraintValidatorDescriptor<A>> constraintValidators,
+			List<ConstraintValidatorDescriptor<A>> validatorTypes,
 			boolean includeExisting) {
 		this.constraintType = constraintType;
-		this.constraintValidators.addAll( constraintValidators );
+		this.validatorTypes = Collections.unmodifiableList( validatorTypes );
 		this.includeExisting = includeExisting;
 	}
 
@@ -44,8 +44,8 @@ public class ConstraintDefinitionContribution<A extends Annotation> {
 	 *
 	 * @return a list of constraint validator types for the constraint type of this instance.
 	 */
-	public List<ConstraintValidatorDescriptor<A>> getConstraintValidators() {
-		return constraintValidators;
+	public List<ConstraintValidatorDescriptor<A>> getValidatorTypes() {
+		return validatorTypes;
 	}
 
 	/**
@@ -72,7 +72,7 @@ public class ConstraintDefinitionContribution<A extends Annotation> {
 		if ( !constraintType.equals( that.constraintType ) ) {
 			return false;
 		}
-		if ( !constraintValidators.equals( that.constraintValidators ) ) {
+		if ( !validatorTypes.equals( that.validatorTypes ) ) {
 			return false;
 		}
 
@@ -82,7 +82,7 @@ public class ConstraintDefinitionContribution<A extends Annotation> {
 	@Override
 	public int hashCode() {
 		int result = constraintType.hashCode();
-		result = 31 * result + constraintValidators.hashCode();
+		result = 31 * result + validatorTypes.hashCode();
 		return result;
 	}
 
@@ -90,7 +90,7 @@ public class ConstraintDefinitionContribution<A extends Annotation> {
 	public String toString() {
 		return "ConstraintDefinitionContribution{" +
 				"constraintType=" + constraintType +
-				", constraintValidators=" + constraintValidators +
+				", validatorTypes=" + validatorTypes +
 				", includeExisting=" + includeExisting +
 				'}';
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ClassBasedValidatorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ClassBasedValidatorDescriptor.java
@@ -31,11 +31,28 @@ class ClassBasedValidatorDescriptor<A extends Annotation> implements ConstraintV
 	private static final Log LOG = LoggerFactory.make();
 
 	private final Class<? extends ConstraintValidator<A, ?>> validatorClass;
+	private final Type validatedType;
+	private final EnumSet<ValidationTarget> validationTargets;
 
 	public ClassBasedValidatorDescriptor(Class<? extends ConstraintValidator<A, ?>> validatorClass) {
 		this.validatorClass = validatorClass;
+		this.validatedType = TypeHelper.extractType( validatorClass );
+		this.validationTargets = determineValidationTargets( validatorClass );
 	}
 
+	private static EnumSet<ValidationTarget> determineValidationTargets(Class<? extends ConstraintValidator<?, ?>> validatorClass) {
+		SupportedValidationTarget supportedTargetAnnotation = validatorClass.getAnnotation(
+				SupportedValidationTarget.class
+		);
+
+		//by default constraints target the annotated element
+		if ( supportedTargetAnnotation == null ) {
+			return EnumSet.of( ValidationTarget.ANNOTATED_ELEMENT );
+		}
+		else {
+			return EnumSet.copyOf( Arrays.asList( supportedTargetAnnotation.value() ) );
+		}
+	}
 	@Override
 	public Class<? extends ConstraintValidator<A, ?>> getValidatorClass() {
 		return validatorClass;
@@ -54,21 +71,11 @@ class ClassBasedValidatorDescriptor<A extends Annotation> implements ConstraintV
 
 	@Override
 	public Type getValidatedType() {
-		return TypeHelper.extractType( validatorClass );
+		return validatedType;
 	}
 
 	@Override
 	public EnumSet<ValidationTarget> getValidationTargets() {
-		SupportedValidationTarget supportedTargetAnnotation = validatorClass.getAnnotation(
-				SupportedValidationTarget.class
-		);
-
-		//by default constraints target the annotated element
-		if ( supportedTargetAnnotation == null ) {
-			return EnumSet.of( ValidationTarget.ANNOTATED_ELEMENT );
-		}
-		else {
-			return EnumSet.copyOf( Arrays.asList( supportedTargetAnnotation.value() ) );
-		}
+		return validationTargets;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ClassBasedValidatorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ClassBasedValidatorDescriptor.java
@@ -1,0 +1,74 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.constraintvalidation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.EnumSet;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+import org.hibernate.validator.internal.util.TypeHelper;
+import org.hibernate.validator.internal.util.logging.Log;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
+
+/**
+ * Represents an implementation of {@link ConstraintValidator}.
+ *
+ * @author Gunnar Morling
+ */
+class ClassBasedValidatorDescriptor<A extends Annotation> implements ConstraintValidatorDescriptor<A> {
+
+	private static final long serialVersionUID = -8207687559460098548L;
+	private static final Log LOG = LoggerFactory.make();
+
+	private final Class<? extends ConstraintValidator<A, ?>> validatorClass;
+
+	public ClassBasedValidatorDescriptor(Class<? extends ConstraintValidator<A, ?>> validatorClass) {
+		this.validatorClass = validatorClass;
+	}
+
+	@Override
+	public Class<? extends ConstraintValidator<A, ?>> getValidatorClass() {
+		return validatorClass;
+	}
+
+	@Override
+	public ConstraintValidator<A, ?> newInstance(ConstraintValidatorFactory constraintFactory) {
+		ConstraintValidator<A, ?> constraintValidator = constraintFactory.getInstance( validatorClass );
+
+		if ( constraintValidator == null ) {
+			throw LOG.getConstraintFactoryMustNotReturnNullException( validatorClass );
+		}
+
+		return constraintValidator;
+	}
+
+	@Override
+	public Type getValidatedType() {
+		return TypeHelper.extractType( validatorClass );
+	}
+
+	@Override
+	public EnumSet<ValidationTarget> getValidationTargets() {
+		SupportedValidationTarget supportedTargetAnnotation = validatorClass.getAnnotation(
+				SupportedValidationTarget.class
+		);
+
+		//by default constraints target the annotated element
+		if ( supportedTargetAnnotation == null ) {
+			return EnumSet.of( ValidationTarget.ANNOTATED_ELEMENT );
+		}
+		else {
+			return EnumSet.copyOf( Arrays.asList( supportedTargetAnnotation.value() ) );
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
@@ -70,7 +70,7 @@ public class ConstraintTree<A extends Annotation> {
 	}
 
 	private <U extends Annotation> ConstraintTree<U> createConstraintTree(ConstraintDescriptorImpl<U> composingDescriptor) {
-		return new ConstraintTree<U>( composingDescriptor, this );
+		return new ConstraintTree<>( composingDescriptor, this );
 	}
 
 	public final List<ConstraintTree<?>> getChildren() {
@@ -92,8 +92,8 @@ public class ConstraintTree<A extends Annotation> {
 		return true;
 	}
 
-	private <T, V> void validateConstraints(ValidationContext<T> validationContext,
-			ValueContext<?, V> valueContext,
+	private <T> void validateConstraints(ValidationContext<T> validationContext,
+			ValueContext<?, ?> valueContext,
 			Set<ConstraintViolation<T>> constraintViolations) {
 		CompositionResult compositionResult = validateComposingConstraints(
 				validationContext, valueContext, constraintViolations
@@ -113,7 +113,7 @@ public class ConstraintTree<A extends Annotation> {
 			}
 
 			// find the right constraint validator
-			ConstraintValidator<A, V> validator = getInitializedConstraintValidator( validationContext, valueContext );
+			ConstraintValidator<A, ?> validator = getInitializedConstraintValidator( validationContext, valueContext );
 
 			// create a constraint validator context
 			ConstraintValidatorContextImpl constraintValidatorContext = new ConstraintValidatorContextImpl(
@@ -151,7 +151,7 @@ public class ConstraintTree<A extends Annotation> {
 		}
 	}
 
-	private <T, V> ConstraintValidator<A, V> getInitializedConstraintValidator(ValidationContext<T> validationContext,
+	private <T, V> ConstraintValidator<A, ?> getInitializedConstraintValidator(ValidationContext<T> validationContext,
 			ValueContext<?, V> valueContext) {
 		Type validatedValueType = valueContext.getDeclaredTypeOfValidatedElement();
 		@SuppressWarnings("unchecked")
@@ -182,7 +182,7 @@ public class ConstraintTree<A extends Annotation> {
 		}
 	}
 
-	private <T, V> ConstraintValidator<A, V> getInitializedValidatorInstanceForWrappedInstance(ValidationContext<T> validationContext, ValueContext<?, V> valueContext, Type validatedValueType, ValidatedValueUnwrapper<V> validatedValueUnwrapper) {
+	private <T, V> ConstraintValidator<A, ?> getInitializedValidatorInstanceForWrappedInstance(ValidationContext<T> validationContext, ValueContext<?, V> valueContext, Type validatedValueType, ValidatedValueUnwrapper<V> validatedValueUnwrapper) {
 		// make sure that unwrapper is set
 		if ( validatedValueUnwrapper == null ) {
 			throw log.getNoUnwrapperFoundForTypeException(
@@ -193,7 +193,7 @@ public class ConstraintTree<A extends Annotation> {
 		valueContext.setValidatedValueHandler( validatedValueUnwrapper );
 		validatedValueType = validatedValueUnwrapper.getValidatedValueType( validatedValueType );
 
-		ConstraintValidator<A, V> validator = validationContext.getConstraintValidatorManager()
+		ConstraintValidator<A, ?> validator = validationContext.getConstraintValidatorManager()
 				.getInitializedValidator(
 						validatedValueType,
 						descriptor,
@@ -228,7 +228,7 @@ public class ConstraintTree<A extends Annotation> {
 		}
 	}
 
-	private <T, V> ConstraintValidator<A, V> getConstraintValidatorInstanceForAutomaticUnwrapping(
+	private <T, V> ConstraintValidator<A, ?> getConstraintValidatorInstanceForAutomaticUnwrapping(
 			ValidationContext<T> validationContext,
 			ValueContext<?, V> valueContext
 	) {
@@ -244,7 +244,7 @@ public class ConstraintTree<A extends Annotation> {
 
 		// there is an unwrapper - need to find out for which type (wrapper or wrapped value there
 		// are constraint validators available
-		ConstraintValidator<A, V> validatorForWrappedValue = validationContext.getConstraintValidatorManager()
+		ConstraintValidator<A, ?> validatorForWrappedValue = validationContext.getConstraintValidatorManager()
 				.getInitializedValidator(
 						validatedValueUnwrapper.getValidatedValueType( validatedValueType ),
 						descriptor,
@@ -252,7 +252,7 @@ public class ConstraintTree<A extends Annotation> {
 				);
 
 
-		ConstraintValidator<A, V> validatorForWrapper = validationContext.getConstraintValidatorManager()
+		ConstraintValidator<A, ?> validatorForWrapper = validationContext.getConstraintValidatorManager()
 				.getInitializedValidator(
 						valueContext.getDeclaredTypeOfValidatedElement(),
 						descriptor,
@@ -291,13 +291,13 @@ public class ConstraintTree<A extends Annotation> {
 		}
 	}
 
-	private <T, V> ConstraintValidator<A, V> getConstraintValidatorNoUnwrapping(ValidationContext<T> validationContext,
-			ValueContext<?, V> valueContext) {
+	private <T> ConstraintValidator<A, ?> getConstraintValidatorNoUnwrapping(ValidationContext<T> validationContext,
+			ValueContext<?, ?> valueContext) {
 		// make sure no unwrapper is set
 		valueContext.setValidatedValueHandler( null );
 
 		Type validatedValueType = valueContext.getDeclaredTypeOfValidatedElement();
-		ConstraintValidator<A, V> validator = validationContext.getConstraintValidatorManager()
+		ConstraintValidator<A, ?> validator = validationContext.getConstraintValidatorManager()
 				.getInitializedValidator(
 						validatedValueType,
 						descriptor,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorDescriptor.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.constraintvalidation;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.EnumSet;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+/**
+ * Represents a specific validator type.
+ *
+ * @author Gunnar Morling
+ */
+public interface ConstraintValidatorDescriptor<A extends Annotation> extends Serializable {
+
+	Class<? extends ConstraintValidator<A, ?>> getValidatorClass();
+	EnumSet<ValidationTarget> getValidationTargets();
+	Type getValidatedType();
+	ConstraintValidator<A, ?> newInstance(ConstraintValidatorFactory constraintFactory);
+
+	static <A extends Annotation> ConstraintValidatorDescriptor<A> forClass(Class<? extends ConstraintValidator<A, ?>> validatorClass) {
+		return new ClassBasedValidatorDescriptor<>( validatorClass );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorDescriptor.java
@@ -18,15 +18,31 @@ import javax.validation.constraintvalidation.ValidationTarget;
 import org.hibernate.validator.cfg.context.ConstraintDefinitionContext.ValidationCallable;
 
 /**
- * Represents a specific validator type.
+ * Represents a specific validator (either based on an implementation of {@link ConstraintValidator} or given as a
+ * Lambda expression/method reference.
  *
  * @author Gunnar Morling
  */
 public interface ConstraintValidatorDescriptor<A extends Annotation> extends Serializable {
 
+	/**
+	 * The implementation type of the represented validator.
+	 */
 	Class<? extends ConstraintValidator<A, ?>> getValidatorClass();
+
+	/**
+	 * The targets supported for validation by the represented validator.
+	 */
 	EnumSet<ValidationTarget> getValidationTargets();
+
+	/**
+	 * The data type validated by the represented validator (not the constraint annotation type).
+	 */
 	Type getValidatedType();
+
+	/**
+	 * Creates a new instance of the represented implementation type.
+	 */
 	ConstraintValidator<A, ?> newInstance(ConstraintValidatorFactory constraintFactory);
 
 	static <A extends Annotation> ConstraintValidatorDescriptor<A> forClass(Class<? extends ConstraintValidator<A, ?>> validatorClass) {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorDescriptor.java
@@ -15,6 +15,8 @@ import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.constraintvalidation.ValidationTarget;
 
+import org.hibernate.validator.cfg.context.ConstraintDefinitionContext.ValidationCallable;
+
 /**
  * Represents a specific validator type.
  *
@@ -29,5 +31,9 @@ public interface ConstraintValidatorDescriptor<A extends Annotation> extends Ser
 
 	static <A extends Annotation> ConstraintValidatorDescriptor<A> forClass(Class<? extends ConstraintValidator<A, ?>> validatorClass) {
 		return new ClassBasedValidatorDescriptor<>( validatorClass );
+	}
+
+	static <A extends Annotation, T> ConstraintValidatorDescriptor<A> forLambda(Class<A> annotationType, Type validatedType, ValidationCallable<T> lambda) {
+		return new LambdaBasedValidatorDescriptor<>( validatedType, lambda );
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
@@ -115,13 +115,13 @@ public class ConstraintValidatorManager {
 			}
 		}
 
-		ConstraintValidatorDescriptor<A> validatorTypeDescriptor = findMatchingValidatorClass(
+		ConstraintValidatorDescriptor<A> validatorDescriptor = findMatchingValidatorDescriptor(
 				descriptor,
 				validatedValueType
 		);
 		ConstraintValidator<A, ?> constraintValidator = createAndInitializeValidator(
 				constraintFactory,
-				validatorTypeDescriptor,
+				validatorDescriptor,
 				descriptor
 		);
 		if ( constraintValidator == null ) {
@@ -213,13 +213,13 @@ public class ConstraintValidatorManager {
 	 *
 	 * @return The class of a matching validator.
 	 */
-	private <A extends Annotation> ConstraintValidatorDescriptor<A> findMatchingValidatorClass(ConstraintDescriptorImpl<A> descriptor, Type validatedValueType) {
-		Map<Type, ConstraintValidatorDescriptor<A>> availableValidatorTypes = TypeHelper.getValidatorTypes(
+	private <A extends Annotation> ConstraintValidatorDescriptor<A> findMatchingValidatorDescriptor(ConstraintDescriptorImpl<A> descriptor, Type validatedValueType) {
+		Map<Type, ConstraintValidatorDescriptor<A>> availableValidatorDescriptors = TypeHelper.getValidatorTypes(
 				descriptor.getAnnotationType(),
 				descriptor.getMatchingConstraintValidatorClasses()
 		);
 
-		List<Type> discoveredSuitableTypes = findSuitableValidatorTypes( validatedValueType, availableValidatorTypes.keySet() );
+		List<Type> discoveredSuitableTypes = findSuitableValidatorTypes( validatedValueType, availableValidatorDescriptors.keySet() );
 		resolveAssignableTypes( discoveredSuitableTypes );
 
 		if ( discoveredSuitableTypes.size() == 0 ) {
@@ -231,7 +231,7 @@ public class ConstraintValidatorManager {
 		}
 
 		Type suitableType = discoveredSuitableTypes.get( 0 );
-		return availableValidatorTypes.get( suitableType );
+		return availableValidatorDescriptors.get( suitableType );
 	}
 
 	private <A extends Annotation> List<Type> findSuitableValidatorTypes(Type type, Iterable<Type> availableValidatorTypes) {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
@@ -214,7 +214,7 @@ public class ConstraintValidatorManager {
 	 * @return The class of a matching validator.
 	 */
 	private <A extends Annotation> ConstraintValidatorDescriptor<A> findMatchingValidatorClass(ConstraintDescriptorImpl<A> descriptor, Type validatedValueType) {
-		Map<Type, ConstraintValidatorDescriptor<A>> availableValidatorTypes = TypeHelper.getValidatorsTypes(
+		Map<Type, ConstraintValidatorDescriptor<A>> availableValidatorTypes = TypeHelper.getValidatorTypes(
 				descriptor.getAnnotationType(),
 				descriptor.getMatchingConstraintValidatorClasses()
 		);

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
@@ -6,12 +6,15 @@
  */
 package org.hibernate.validator.internal.engine.constraintvalidation;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.ConstraintValidatorFactory;
@@ -23,8 +26,6 @@ import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.TypeHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 
 /**
  * Manager in charge of providing and caching initialized {@code ConstraintValidator} instances.
@@ -75,20 +76,19 @@ public class ConstraintValidatorManager {
 	 */
 	public ConstraintValidatorManager(ConstraintValidatorFactory constraintValidatorFactory) {
 		this.defaultConstraintValidatorFactory = constraintValidatorFactory;
-		this.constraintValidatorCache = new ConcurrentHashMap<CacheKey, ConstraintValidator<?, ?>>();
+		this.constraintValidatorCache = new ConcurrentHashMap<>();
 	}
 
 	/**
 	 * @param validatedValueType the type of the value to be validated. Cannot be {@code null}.
 	 * @param descriptor the constraint descriptor for which to get an initalized constraint validator. Cannot be {@code null}
 	 * @param constraintFactory constraint factory used to instantiate the constraint validator. Cannot be {@code null}.
-	 * @param <V> the type of the value to be validated
 	 * @param <A> the annotation type
 	 *
 	 * @return an initialized constraint validator for the given type and annotation of the value to be validated.
 	 * {@code null} is returned if no matching constraint validator could be found.
 	 */
-	public <V, A extends Annotation> ConstraintValidator<A, V> getInitializedValidator(Type validatedValueType,
+	public <A extends Annotation> ConstraintValidator<A, ?> getInitializedValidator(Type validatedValueType,
 			ConstraintDescriptorImpl<A> descriptor,
 			ConstraintValidatorFactory constraintFactory) {
 		Contracts.assertNotNull( validatedValueType );
@@ -103,7 +103,7 @@ public class ConstraintValidatorManager {
 
 		if ( constraintValidatorCache.containsKey( key ) ) {
 			@SuppressWarnings("unchecked")
-			ConstraintValidator<A, V> constraintValidator = (ConstraintValidator<A, V>) constraintValidatorCache.get(
+			ConstraintValidator<A, ?> constraintValidator = (ConstraintValidator<A, ?>) constraintValidatorCache.get(
 					key
 			);
 			if ( DUMMY_CONSTRAINT_VALIDATOR.equals( constraintValidator ) ) {
@@ -115,13 +115,13 @@ public class ConstraintValidatorManager {
 			}
 		}
 
-		Class<? extends ConstraintValidator<?, ?>> validatorClass = findMatchingValidatorClass(
+		ConstraintValidatorDescriptor<A> validatorTypeDescriptor = findMatchingValidatorClass(
 				descriptor,
 				validatedValueType
 		);
-		ConstraintValidator<A, V> constraintValidator = createAndInitializeValidator(
+		ConstraintValidator<A, ?> constraintValidator = createAndInitializeValidator(
 				constraintFactory,
-				validatorClass,
+				validatorTypeDescriptor,
 				descriptor
 		);
 		if ( constraintValidator == null ) {
@@ -164,28 +164,23 @@ public class ConstraintValidatorManager {
 		constraintValidatorCache.putIfAbsent( key, constraintValidator );
 	}
 
-	private <V, A extends Annotation> ConstraintValidator<A, V> createAndInitializeValidator(
+	private <A extends Annotation> ConstraintValidator<A, ?> createAndInitializeValidator(
 			ConstraintValidatorFactory constraintFactory,
-			Class<? extends ConstraintValidator<?, ?>> validatorClass,
+			ConstraintValidatorDescriptor<A> validatorDescriptor,
 			ConstraintDescriptor<A> descriptor) {
 
-		if ( validatorClass == null ) {
+		if ( validatorDescriptor == null ) {
 			return null;
 		}
 
-		@SuppressWarnings("unchecked")
-		ConstraintValidator<A, V> constraintValidator = (ConstraintValidator<A, V>) constraintFactory.getInstance(
-				validatorClass
-		);
-		if ( constraintValidator == null ) {
-			throw log.getConstraintFactoryMustNotReturnNullException( validatorClass );
-		}
+		ConstraintValidator<A, ?> constraintValidator = validatorDescriptor.newInstance( constraintFactory );
+
 		initializeConstraint( descriptor, constraintValidator );
 		return constraintValidator;
 	}
 
 	private void clearEntriesForFactory(ConstraintValidatorFactory constraintFactory) {
-		List<CacheKey> entriesToRemove = new ArrayList<CacheKey>();
+		List<CacheKey> entriesToRemove = new ArrayList<>();
 		for ( Map.Entry<CacheKey, ConstraintValidator<?, ?>> entry : constraintValidatorCache.entrySet() ) {
 			if ( entry.getKey().getConstraintFactory() == constraintFactory ) {
 				entriesToRemove.add( entry.getKey() );
@@ -218,13 +213,13 @@ public class ConstraintValidatorManager {
 	 *
 	 * @return The class of a matching validator.
 	 */
-	private <A extends Annotation> Class<? extends ConstraintValidator<A, ?>> findMatchingValidatorClass(ConstraintDescriptorImpl<A> descriptor, Type validatedValueType) {
-		Map<Type, Class<? extends ConstraintValidator<A, ?>>> availableValidatorTypes = TypeHelper.getValidatorsTypes(
+	private <A extends Annotation> ConstraintValidatorDescriptor<A> findMatchingValidatorClass(ConstraintDescriptorImpl<A> descriptor, Type validatedValueType) {
+		Map<Type, ConstraintValidatorDescriptor<A>> availableValidatorTypes = TypeHelper.getValidatorsTypes(
 				descriptor.getAnnotationType(),
 				descriptor.getMatchingConstraintValidatorClasses()
 		);
 
-		List<Type> discoveredSuitableTypes = findSuitableValidatorTypes( validatedValueType, availableValidatorTypes );
+		List<Type> discoveredSuitableTypes = findSuitableValidatorTypes( validatedValueType, availableValidatorTypes.keySet() );
 		resolveAssignableTypes( discoveredSuitableTypes );
 
 		if ( discoveredSuitableTypes.size() == 0 ) {
@@ -239,9 +234,9 @@ public class ConstraintValidatorManager {
 		return availableValidatorTypes.get( suitableType );
 	}
 
-	private <A extends Annotation> List<Type> findSuitableValidatorTypes(Type type, Map<Type, Class<? extends ConstraintValidator<A, ?>>> availableValidatorTypes) {
+	private <A extends Annotation> List<Type> findSuitableValidatorTypes(Type type, Iterable<Type> availableValidatorTypes) {
 		List<Type> determinedSuitableTypes = newArrayList();
-		for ( Type validatorType : availableValidatorTypes.keySet() ) {
+		for ( Type validatorType : availableValidatorTypes ) {
 			if ( TypeHelper.isAssignable( validatorType, type )
 					&& !determinedSuitableTypes.contains( validatorType ) ) {
 				determinedSuitableTypes.add( validatorType );
@@ -270,7 +265,7 @@ public class ConstraintValidatorManager {
 			return;
 		}
 
-		List<Type> typesToRemove = new ArrayList<Type>();
+		List<Type> typesToRemove = new ArrayList<>();
 		do {
 			typesToRemove.clear();
 			Type type = assignableTypes.get( 0 );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/LambdaBasedValidatorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/LambdaBasedValidatorDescriptor.java
@@ -1,0 +1,76 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.constraintvalidation;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.EnumSet;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+import org.hibernate.validator.cfg.context.ConstraintDefinitionContext.ValidationCallable;
+
+/**
+ * Represents a constraint validator based on a Lambda expression.
+ *
+ * @author Gunnar Morling
+ */
+class LambdaBasedValidatorDescriptor<A extends Annotation> implements ConstraintValidatorDescriptor<A> {
+
+	private static final long serialVersionUID = 5129757824081595723L;
+
+	private final Type validatedType;
+	private final ValidationCallable<?> lambda;
+
+	public LambdaBasedValidatorDescriptor(Type validatedType, ValidationCallable<?> lambda) {
+		this.validatedType = validatedType;
+		this.lambda = lambda;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Class<? extends ConstraintValidator<A, ?>> getValidatorClass() {
+		Class<?> clazz = LambdaExecutor.class;
+		return (Class<? extends ConstraintValidator<A, ?>>) clazz;
+	}
+
+	@Override
+	public EnumSet<ValidationTarget> getValidationTargets() {
+		return EnumSet.of( ValidationTarget.ANNOTATED_ELEMENT );
+	}
+
+	@Override
+	public Type getValidatedType() {
+		return validatedType;
+	}
+
+	@Override
+	public ConstraintValidator<A, ?> newInstance(ConstraintValidatorFactory constraintFactory) {
+		return new LambdaExecutor<>( lambda );
+	}
+
+	private static class LambdaExecutor<A extends Annotation, T> implements ConstraintValidator<A, T> {
+
+		private final ValidationCallable<T> lambda;
+
+		public LambdaExecutor(ValidationCallable<T> lambda) {
+			this.lambda = lambda;
+		}
+
+		@Override
+		public void initialize(A constraintAnnotation) {
+		}
+
+		@Override
+		public boolean isValid(T value, ConstraintValidatorContext context) {
+			return lambda.isValid( value );
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
@@ -14,6 +14,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -349,21 +350,26 @@ public class ConstraintHelper {
 	 * annotation type.
 	 *
 	 * @param annotationType The constraint annotation type
-	 * @param definitionClasses The validators to register
+	 * @param validatorTypes The validator types to register
 	 * @param keepExistingClasses Whether already-registered validators should be kept or not
 	 * @param <A> the type of the annotation
 	 */
 	public <A extends Annotation> void putValidatorClasses(Class<A> annotationType,
-														   List<ConstraintValidatorDescriptor<A>> definitionClasses,
+														   List<ConstraintValidatorDescriptor<A>> validatorTypes,
 														   boolean keepExistingClasses) {
+
+		List<ConstraintValidatorDescriptor<A>> validatorTypesToAdd = new ArrayList<>();
+
 		if ( keepExistingClasses ) {
-			List<ConstraintValidatorDescriptor<A>> existingClasses = getAllValidatorClasses( annotationType );
-			if ( existingClasses != null ) {
-				definitionClasses.addAll( 0, existingClasses );
+			List<ConstraintValidatorDescriptor<A>> existingValidatorTypes = getAllValidatorClasses( annotationType );
+			if ( existingValidatorTypes != null ) {
+				validatorTypesToAdd.addAll( 0, existingValidatorTypes );
 			}
 		}
 
-		validatorClasses.put( annotationType, definitionClasses );
+		validatorTypesToAdd.addAll( validatorTypes );
+
+		validatorClasses.put( annotationType, validatorTypesToAdd );
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ConstraintDescriptorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ConstraintDescriptorImpl.java
@@ -94,7 +94,7 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 	 * The set of classes implementing the validation for this constraint. See also
 	 * {@code ConstraintValidator} resolution algorithm.
 	 */
-	private final List<Class<? extends ConstraintValidator<T, ?>>> constraintValidatorClasses;
+	private final List<Class<? extends ConstraintValidator<T, ?>>> constraintValidatorDescriptors;
 
 	private final List<ConstraintValidatorDescriptor<T>> matchingConstraintValidatorClasses;
 
@@ -170,21 +170,21 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 		this.groups = buildGroupSet( implicitGroup );
 		this.payloads = buildPayloadSet( annotation );
 
-		this.constraintValidatorClasses = constraintHelper.getAllValidatorClasses( annotationType )
+		this.constraintValidatorDescriptors = constraintHelper.getAllValidatorDescriptors( annotationType )
 				.stream()
 				.map( ConstraintValidatorDescriptor::getValidatorClass )
 				.collect( Collectors.toList() );
 
-		List<ConstraintValidatorDescriptor<T>> crossParameterValidatorClasses = constraintHelper.findValidatorClasses(
+		List<ConstraintValidatorDescriptor<T>> crossParameterValidatorDescriptors = constraintHelper.findValidatorDescriptors(
 				annotationType,
 				ValidationTarget.PARAMETERS
 		);
-		List<ConstraintValidatorDescriptor<T>> genericValidatorClasses = constraintHelper.findValidatorClasses(
+		List<ConstraintValidatorDescriptor<T>> genericValidatorDescriptors = constraintHelper.findValidatorDescriptors(
 				annotationType,
 				ValidationTarget.ANNOTATED_ELEMENT
 		);
 
-		if ( crossParameterValidatorClasses.size() > 1 ) {
+		if ( crossParameterValidatorDescriptors.size() > 1 ) {
 			throw log.getMultipleCrossParameterValidatorClassesException( annotationType );
 		}
 
@@ -192,8 +192,8 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 				annotation.annotationType(),
 				member,
 				type,
-				!genericValidatorClasses.isEmpty(),
-				!crossParameterValidatorClasses.isEmpty(),
+				!genericValidatorDescriptors.isEmpty(),
+				!crossParameterValidatorDescriptors.isEmpty(),
 				externalConstraintType
 		);
 		this.composingConstraints = parseComposingConstraints( member, constraintHelper, constraintType );
@@ -201,10 +201,10 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 		validateComposingConstraintTypes();
 
 		if ( constraintType == ConstraintType.GENERIC ) {
-			this.matchingConstraintValidatorClasses = Collections.unmodifiableList( genericValidatorClasses );
+			this.matchingConstraintValidatorClasses = Collections.unmodifiableList( genericValidatorDescriptors );
 		}
 		else {
-			this.matchingConstraintValidatorClasses = Collections.unmodifiableList( crossParameterValidatorClasses );
+			this.matchingConstraintValidatorClasses = Collections.unmodifiableList( crossParameterValidatorDescriptors );
 		}
 
 		this.hashCode = annotation.hashCode();
@@ -255,7 +255,7 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 
 	@Override
 	public List<Class<? extends ConstraintValidator<T, ?>>> getConstraintValidatorClasses() {
-		return constraintValidatorClasses;
+		return constraintValidatorDescriptors;
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ConstraintDescriptorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ConstraintDescriptorImpl.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.validation.Constraint;
 import javax.validation.ConstraintTarget;
@@ -42,6 +43,7 @@ import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraints.CompositionType;
 import org.hibernate.validator.constraints.ConstraintComposition;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.core.ConstraintOrigin;
 import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor;
@@ -94,7 +96,7 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 	 */
 	private final List<Class<? extends ConstraintValidator<T, ?>>> constraintValidatorClasses;
 
-	private final List<Class<? extends ConstraintValidator<T, ?>>> matchingConstraintValidatorClasses;
+	private final List<ConstraintValidatorDescriptor<T>> matchingConstraintValidatorClasses;
 
 	/**
 	 * The groups for which to apply this constraint.
@@ -168,12 +170,16 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 		this.groups = buildGroupSet( implicitGroup );
 		this.payloads = buildPayloadSet( annotation );
 
-		this.constraintValidatorClasses = constraintHelper.getAllValidatorClasses( annotationType );
-		List<Class<? extends ConstraintValidator<T, ?>>> crossParameterValidatorClasses = constraintHelper.findValidatorClasses(
+		this.constraintValidatorClasses = constraintHelper.getAllValidatorClasses( annotationType )
+				.stream()
+				.map( ConstraintValidatorDescriptor::getValidatorClass )
+				.collect( Collectors.toList() );
+
+		List<ConstraintValidatorDescriptor<T>> crossParameterValidatorClasses = constraintHelper.findValidatorClasses(
 				annotationType,
 				ValidationTarget.PARAMETERS
 		);
-		List<Class<? extends ConstraintValidator<T, ?>>> genericValidatorClasses = constraintHelper.findValidatorClasses(
+		List<ConstraintValidatorDescriptor<T>> genericValidatorClasses = constraintHelper.findValidatorClasses(
 				annotationType,
 				ValidationTarget.ANNOTATED_ELEMENT
 		);
@@ -258,7 +264,7 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 	 *
 	 * @return The validators applying to type of this constraint.
 	 */
-	public List<Class<? extends ConstraintValidator<T, ?>>> getMatchingConstraintValidatorClasses() {
+	public List<ConstraintValidatorDescriptor<T>> getMatchingConstraintValidatorClasses() {
 		return matchingConstraintValidatorClasses;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ConstraintDescriptorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ConstraintDescriptorImpl.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.validator.internal.metadata.descriptor;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
@@ -17,7 +20,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
@@ -42,7 +44,6 @@ import org.hibernate.validator.constraints.CompositionType;
 import org.hibernate.validator.constraints.ConstraintComposition;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.core.ConstraintOrigin;
-import org.hibernate.validator.internal.util.TypeHelper;
 import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor;
 import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -50,9 +51,6 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetAnnotationParameter;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredMethods;
 import org.hibernate.validator.internal.util.privilegedactions.GetMethod;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 
 /**
  * Describes a single constraint (including it's composing constraints).
@@ -256,21 +254,12 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 
 	/**
 	 * Return all constraint validators classes (either generic or cross-parameter) which are registered for the
-	 * constraint of this despriptor.
+	 * constraint of this descriptor.
 	 *
 	 * @return The validators applying to type of this constraint.
 	 */
 	public List<Class<? extends ConstraintValidator<T, ?>>> getMatchingConstraintValidatorClasses() {
 		return matchingConstraintValidatorClasses;
-	}
-
-	public Map<Type, Class<? extends ConstraintValidator<T, ?>>> getAvailableValidatorTypes() {
-
-		Map<Type, Class<? extends ConstraintValidator<T, ?>>> availableValidatorTypes = TypeHelper.getValidatorsTypes(
-				getAnnotationType(),
-				getMatchingConstraintValidatorClasses()
-		);
-		return availableValidatorTypes;
 	}
 
 	@Override
@@ -692,7 +681,7 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 		final Class<U> annotationType = (Class<U>) constraintAnnotation.annotationType();
 
 		// use a annotation proxy
-		AnnotationDescriptor<U> annotationDescriptor = new AnnotationDescriptor<U>(
+		AnnotationDescriptor<U> annotationDescriptor = new AnnotationDescriptor<>(
 				annotationType, buildAnnotationParameterMap( constraintAnnotation )
 		);
 
@@ -728,7 +717,7 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 		}
 
 		U annotationProxy = AnnotationFactory.create( annotationDescriptor );
-		return new ConstraintDescriptorImpl<U>(
+		return new ConstraintDescriptorImpl<>(
 				constraintHelper, member, annotationProxy, elementType, null, definedOn, constraintType
 		);
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/TypeHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/TypeHelper.java
@@ -297,7 +297,7 @@ public final class TypeHelper {
 	 * @return Return a Map&lt;Class, Class&lt;? extends ConstraintValidator&gt;&gt; where the map
 	 *         key is the type the validator accepts and value the validator class itself.
 	 */
-	public static <A extends Annotation> Map<Type, ConstraintValidatorDescriptor<A>> getValidatorsTypes(
+	public static <A extends Annotation> Map<Type, ConstraintValidatorDescriptor<A>> getValidatorTypes(
 			Class<A> annotationType,
 			List<ConstraintValidatorDescriptor<A>> validators) {
 		Map<Type, ConstraintValidatorDescriptor<A>> validatorsTypes = newHashMap();

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.validator.internal.xml;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 
@@ -15,6 +14,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.security.AccessController;
 import java.security.PrivilegedExceptionAction;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -33,6 +33,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.Validator;
 
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptions;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
@@ -74,7 +75,7 @@ public class MappingXmlParser {
 	private static final Map<String, String> SCHEMAS_BY_VERSION = Collections.unmodifiableMap( getSchemasByVersion() );
 
 	private static Map<String, String> getSchemasByVersion() {
-		Map<String, String> schemasByVersion = new HashMap<String, String>();
+		Map<String, String> schemasByVersion = new HashMap<>();
 
 		schemasByVersion.put( "1.0", "META-INF/validation-mapping-1.0.xsd" );
 		schemasByVersion.put( "1.1", "META-INF/validation-mapping-1.1.xsd" );
@@ -286,7 +287,7 @@ public class MappingXmlParser {
 
 	private <A extends Annotation> void addValidatorDefinitions(Class<A> annotationClass, String defaultPackage,
 			ValidatedByType validatedByType) {
-		List<Class<? extends ConstraintValidator<A, ?>>> constraintValidatorClasses = newArrayList();
+		List<ConstraintValidatorDescriptor<A>> constraintValidatorClasses = new ArrayList<>();
 
 		for ( String validatorClassName : validatedByType.getValue() ) {
 			@SuppressWarnings("unchecked")
@@ -297,7 +298,7 @@ public class MappingXmlParser {
 				throw log.getIsNotAConstraintValidatorClassException( validatorClass );
 			}
 
-			constraintValidatorClasses.add( validatorClass );
+			constraintValidatorClasses.add( ConstraintValidatorDescriptor.forClass( validatorClass ) );
 		}
 		constraintHelper.putValidatorClasses(
 				annotationClass,

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
@@ -287,7 +287,7 @@ public class MappingXmlParser {
 
 	private <A extends Annotation> void addValidatorDefinitions(Class<A> annotationClass, String defaultPackage,
 			ValidatedByType validatedByType) {
-		List<ConstraintValidatorDescriptor<A>> constraintValidatorClasses = new ArrayList<>();
+		List<ConstraintValidatorDescriptor<A>> constraintValidatorDescriptors = new ArrayList<>( validatedByType.getValue().size() );
 
 		for ( String validatorClassName : validatedByType.getValue() ) {
 			@SuppressWarnings("unchecked")
@@ -298,11 +298,11 @@ public class MappingXmlParser {
 				throw log.getIsNotAConstraintValidatorClassException( validatorClass );
 			}
 
-			constraintValidatorClasses.add( ConstraintValidatorDescriptor.forClass( validatorClass ) );
+			constraintValidatorDescriptors.add( ConstraintValidatorDescriptor.forClass( validatorClass ) );
 		}
-		constraintHelper.putValidatorClasses(
+		constraintHelper.putValidatorDescriptors(
 				annotationClass,
-				constraintValidatorClasses,
+				constraintValidatorDescriptors,
 				Boolean.TRUE.equals( validatedByType.getIncludeExistingValidators() )
 		);
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
@@ -15,6 +15,7 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.Validator;
@@ -24,9 +25,6 @@ import javax.validation.metadata.BeanDescriptor;
 import javax.validation.metadata.ConstraintDescriptor;
 import javax.validation.metadata.PropertyDescriptor;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator;
 import org.hibernate.validator.internal.engine.ValueContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
@@ -34,6 +32,8 @@ import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintVa
 import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 import org.hibernate.validator.testutil.TestForIssue;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
@@ -214,17 +214,17 @@ public class ConstraintValidatorManagerTest {
 				validator, User.class, "lastName"
 		);
 
-		ConstraintValidator<?, Object> notNullValidatorForFirstName1 = constraintValidatorManager.getInitializedValidator(
+		ConstraintValidator<?, ?> notNullValidatorForFirstName1 = constraintValidatorManager.getInitializedValidator(
 				valueContext.getDeclaredTypeOfValidatedElement(),
 				notNullOnFirstNameDescriptor,
 				constraintValidatorFactory
 		);
-		ConstraintValidator<?, Object> notNullValidatorForFirstName2 = constraintValidatorManager.getInitializedValidator(
+		ConstraintValidator<?, ?> notNullValidatorForFirstName2 = constraintValidatorManager.getInitializedValidator(
 				valueContext.getDeclaredTypeOfValidatedElement(),
 				notNullOnFirstNameDescriptor,
 				constraintValidatorFactory
 		);
-		ConstraintValidator<?, Object> notNullValidatorForLastName = constraintValidatorManager.getInitializedValidator(
+		ConstraintValidator<?, ?> notNullValidatorForLastName = constraintValidatorManager.getInitializedValidator(
 				valueContext.getDeclaredTypeOfValidatedElement(),
 				notNullOnLastNameDescriptor,
 				constraintValidatorFactory
@@ -259,13 +259,13 @@ public class ConstraintValidatorManagerTest {
 				validator, User.class, "address2"
 		);
 
-		ConstraintValidator<?, Object> sizeValidatorForMiddleName = constraintValidatorManager.getInitializedValidator(
+		ConstraintValidator<?, ?> sizeValidatorForMiddleName = constraintValidatorManager.getInitializedValidator(
 				valueContext.getDeclaredTypeOfValidatedElement(), sizeOnMiddleNameDescriptor, constraintValidatorFactory
 		);
-		ConstraintValidator<?, Object> sizeValidatorForAddress1 = constraintValidatorManager.getInitializedValidator(
+		ConstraintValidator<?, ?> sizeValidatorForAddress1 = constraintValidatorManager.getInitializedValidator(
 				valueContext.getDeclaredTypeOfValidatedElement(), sizeOnAddress1Descriptor, constraintValidatorFactory
 		);
-		ConstraintValidator<?, Object> sizeValidatorForAddress2 = constraintValidatorManager.getInitializedValidator(
+		ConstraintValidator<?, ?> sizeValidatorForAddress2 = constraintValidatorManager.getInitializedValidator(
 				valueContext.getDeclaredTypeOfValidatedElement(), sizeOnAddress2Descriptor, constraintValidatorFactory
 		);
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
@@ -857,10 +857,10 @@ public class TypeHelperTest {
 
 	@Test
 	public void testTypeDiscovery() {
-		List<ConstraintValidatorDescriptor<Positive>> validatorTypes = new ArrayList<>();
-		validatorTypes.add( ConstraintValidatorDescriptor.forClass( PositiveConstraintValidator.class ) );
+		List<ConstraintValidatorDescriptor<Positive>> validatorDescriptors = new ArrayList<>();
+		validatorDescriptors.add( ConstraintValidatorDescriptor.forClass( PositiveConstraintValidator.class ) );
 		Map<Type, ConstraintValidatorDescriptor<Positive>> validatorsTypes = TypeHelper
-				.getValidatorTypes( Positive.class, validatorTypes );
+				.getValidatorTypes( Positive.class, validatorDescriptors );
 
 		assertEquals( validatorsTypes.get( Integer.class ).getValidatorClass(), PositiveConstraintValidator.class );
 		assertNull( validatorsTypes.get( String.class ) );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
@@ -17,6 +17,11 @@
  */
 package org.hibernate.validator.test.internal.util;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
 import java.io.Serializable;
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.InvocationHandler;
@@ -34,18 +39,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.validation.ConstraintValidator;
 
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 import org.hibernate.validator.internal.util.TypeHelper;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 /**
  * Tests {@code TypeUtils}.
@@ -858,12 +857,12 @@ public class TypeHelperTest {
 
 	@Test
 	public void testTypeDiscovery() {
-		List<Class<? extends ConstraintValidator<Positive, ?>>> validators = newArrayList();
-		validators.add( PositiveConstraintValidator.class );
-		Map<Type, Class<? extends ConstraintValidator<Positive, ?>>> validatorsTypes = TypeHelper
+		List<ConstraintValidatorDescriptor<Positive>> validators = new ArrayList<>();
+		validators.add( ConstraintValidatorDescriptor.forClass( PositiveConstraintValidator.class ) );
+		Map<Type, ConstraintValidatorDescriptor<Positive>> validatorsTypes = TypeHelper
 				.getValidatorsTypes( Positive.class, validators );
 
-		assertEquals( validatorsTypes.get( Integer.class ), PositiveConstraintValidator.class );
+		assertEquals( validatorsTypes.get( Integer.class ).getValidatorClass(), PositiveConstraintValidator.class );
 		assertNull( validatorsTypes.get( String.class ) );
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
@@ -857,10 +857,10 @@ public class TypeHelperTest {
 
 	@Test
 	public void testTypeDiscovery() {
-		List<ConstraintValidatorDescriptor<Positive>> validators = new ArrayList<>();
-		validators.add( ConstraintValidatorDescriptor.forClass( PositiveConstraintValidator.class ) );
+		List<ConstraintValidatorDescriptor<Positive>> validatorTypes = new ArrayList<>();
+		validatorTypes.add( ConstraintValidatorDescriptor.forClass( PositiveConstraintValidator.class ) );
 		Map<Type, ConstraintValidatorDescriptor<Positive>> validatorsTypes = TypeHelper
-				.getValidatorsTypes( Positive.class, validators );
+				.getValidatorTypes( Positive.class, validatorTypes );
 
 		assertEquals( validatorsTypes.get( Integer.class ).getValidatorClass(), PositiveConstraintValidator.class );
 		assertNull( validatorsTypes.get( String.class ) );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
@@ -46,21 +46,21 @@ public class MappingXmlParserTest {
 	@Test
 	@TestForIssue(jiraKey = "HV-782")
 	public void testAdditionalConstraintValidatorsGetAddedAndAreLastInList() {
-		List<ConstraintValidatorDescriptor<DecimalMin>> validators = constraintHelper.getAllValidatorClasses(
+		List<ConstraintValidatorDescriptor<DecimalMin>> validatorTypes = constraintHelper.getAllValidatorClasses(
 				DecimalMin.class
 		);
 
-		assertFalse( validators.isEmpty(), "Wrong number of default validators" );
-		assertEquals( getIndex( validators, DecimalMinValidatorForFoo.class ), -1, "The custom validator must be absent" );
+		assertFalse( validatorTypes.isEmpty(), "Wrong number of default validators" );
+		assertEquals( getIndex( validatorTypes, DecimalMinValidatorForFoo.class ), -1, "The custom validator must be absent" );
 
 		Set<InputStream> mappingStreams = newHashSet();
 		mappingStreams.add( MappingXmlParserTest.class.getResourceAsStream( "decimal-min-mapping-1.xml" ) );
 
 		xmlMappingParser.parse( mappingStreams );
 
-		validators = constraintHelper.getAllValidatorClasses( DecimalMin.class );
-		assertFalse( validators.isEmpty(), "Wrong number of default validators" );
-		assertEquals( getIndex( validators, DecimalMinValidatorForFoo.class ), validators.size() - 1,
+		validatorTypes = constraintHelper.getAllValidatorClasses( DecimalMin.class );
+		assertFalse( validatorTypes.isEmpty(), "Wrong number of default validators" );
+		assertEquals( getIndex( validatorTypes, DecimalMinValidatorForFoo.class ), validatorTypes.size() - 1,
 				"The custom validator must be last" );
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
@@ -6,26 +6,28 @@
  */
 package org.hibernate.validator.test.internal.xml;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
 import java.io.InputStream;
 import java.util.List;
 import java.util.Set;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.ValidationException;
 import javax.validation.constraints.DecimalMin;
 
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.xml.MappingXmlParser;
 import org.hibernate.validator.testutil.TestForIssue;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * @author Hardy Ferentschik
@@ -44,12 +46,12 @@ public class MappingXmlParserTest {
 	@Test
 	@TestForIssue(jiraKey = "HV-782")
 	public void testAdditionalConstraintValidatorsGetAddedAndAreLastInList() {
-		List<Class<? extends ConstraintValidator<DecimalMin, ?>>> validators = constraintHelper.getAllValidatorClasses(
+		List<ConstraintValidatorDescriptor<DecimalMin>> validators = constraintHelper.getAllValidatorClasses(
 				DecimalMin.class
 		);
 
 		assertFalse( validators.isEmpty(), "Wrong number of default validators" );
-		assertFalse( validators.contains( DecimalMinValidatorForFoo.class ) , "The custom validator must be absent" );
+		assertEquals( getIndex( validators, DecimalMinValidatorForFoo.class ), -1, "The custom validator must be absent" );
 
 		Set<InputStream> mappingStreams = newHashSet();
 		mappingStreams.add( MappingXmlParserTest.class.getResourceAsStream( "decimal-min-mapping-1.xml" ) );
@@ -58,9 +60,22 @@ public class MappingXmlParserTest {
 
 		validators = constraintHelper.getAllValidatorClasses( DecimalMin.class );
 		assertFalse( validators.isEmpty(), "Wrong number of default validators" );
-		assertTrue( validators.contains( DecimalMinValidatorForFoo.class ), "Missing xml configured validator" );
-		assertTrue( validators.indexOf( DecimalMinValidatorForFoo.class ) == validators.size() - 1,
+		assertEquals( getIndex( validators, DecimalMinValidatorForFoo.class ), validators.size() - 1,
 				"The custom validator must be last" );
+	}
+
+	private int getIndex(Iterable<? extends ConstraintValidatorDescriptor<?>> descriptors, Class<?> validatorType) {
+		int i = 0;
+
+		for ( ConstraintValidatorDescriptor<?> constraintValidatorDescriptor : descriptors ) {
+			if ( constraintValidatorDescriptor.getValidatorClass() == validatorType ) {
+				return i;
+			}
+
+			i++;
+		}
+
+		return -1;
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
@@ -46,21 +46,21 @@ public class MappingXmlParserTest {
 	@Test
 	@TestForIssue(jiraKey = "HV-782")
 	public void testAdditionalConstraintValidatorsGetAddedAndAreLastInList() {
-		List<ConstraintValidatorDescriptor<DecimalMin>> validatorTypes = constraintHelper.getAllValidatorClasses(
+		List<ConstraintValidatorDescriptor<DecimalMin>> validatorDescriptors = constraintHelper.getAllValidatorDescriptors(
 				DecimalMin.class
 		);
 
-		assertFalse( validatorTypes.isEmpty(), "Wrong number of default validators" );
-		assertEquals( getIndex( validatorTypes, DecimalMinValidatorForFoo.class ), -1, "The custom validator must be absent" );
+		assertFalse( validatorDescriptors.isEmpty(), "Wrong number of default validators" );
+		assertEquals( getIndex( validatorDescriptors, DecimalMinValidatorForFoo.class ), -1, "The custom validator must be absent" );
 
 		Set<InputStream> mappingStreams = newHashSet();
 		mappingStreams.add( MappingXmlParserTest.class.getResourceAsStream( "decimal-min-mapping-1.xml" ) );
 
 		xmlMappingParser.parse( mappingStreams );
 
-		validatorTypes = constraintHelper.getAllValidatorClasses( DecimalMin.class );
-		assertFalse( validatorTypes.isEmpty(), "Wrong number of default validators" );
-		assertEquals( getIndex( validatorTypes, DecimalMinValidatorForFoo.class ), validatorTypes.size() - 1,
+		validatorDescriptors = constraintHelper.getAllValidatorDescriptors( DecimalMin.class );
+		assertFalse( validatorDescriptors.isEmpty(), "Wrong number of default validators" );
+		assertEquals( getIndex( validatorDescriptors, DecimalMinValidatorForFoo.class ), validatorDescriptors.size() - 1,
 				"The custom validator must be last" );
 	}
 


### PR DESCRIPTION
Hey @gsmet, @emmanuelbernard That's a preview how Lambda-based constraints could look like as proposed in [BVAL-515](https://hibernate.atlassian.net/browse/BVAL-515). Check out the test for the actual usage. Some thoughts from my side:

* I kinda like how it optimizes for the simplest case (no initialize() needed as the constraint has no parameters; no access to constraint validator context needed)
* Should we provide an alternative for where these things are needed (or leave that to implementing an actual class)?
* It doesn't pose a compatability issues as originally was David's concern, as we just add new types but don't alter `ConstraintValidator`

On the implementation, I've added it to our DSL to get quickly going, in BV it'd likely be on `Configuration` or some other defined place in the bootstrap API. And don't get hung up on the usage of ByteBuddy, it was just the quickest thing for me to use it, I think it can be implemented without bytecode generation (needs some changes in HV though which expects actual class types for validators)

I think it'd make sense to have this as some sort of prototype API first in HV 6 (Alpha/Beta) and then add it to the spec. Thoughts?