### PR TITLE
HV-1126 Upgrade the plexus-archiver dependency to support JDK9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -549,6 +549,22 @@
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>2.6</version>
+                    <dependencies>
+                        <!--
+                        We need to use a more recent version of the plexus-archiver to support JDK 9
+                        due to https://github.com/codehaus-plexus/plexus-archiver/pull/12
+                        -->
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-archiver</artifactId>
+                            <version>3.4</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-io</artifactId>
+                            <version>2.7.1</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
* https://hibernate.atlassian.net/browse/HV-1126

The maven-assembly-plugin uses a version which does not support JDK9.

See https://github.com/codehaus-plexus/plexus-archiver/pull/12