### PR TITLE
HV-455 The annotation processor should verify the groups parameter of a constraint declaration

### DIFF
--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/ConstraintCheckFactory.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/ConstraintCheckFactory.java
@@ -13,6 +13,7 @@ import javax.lang.model.util.Types;
 
 import org.hibernate.validator.ap.checks.annotationparameters.AnnotationParametersDecimalMinMaxCheck;
 import org.hibernate.validator.ap.checks.annotationparameters.AnnotationParametersDigitsCheck;
+import org.hibernate.validator.ap.checks.annotationparameters.AnnotationParametersGroupsCheck;
 import org.hibernate.validator.ap.checks.annotationparameters.AnnotationParametersPatternCheck;
 import org.hibernate.validator.ap.checks.annotationparameters.AnnotationParametersScriptAssertCheck;
 import org.hibernate.validator.ap.checks.annotationparameters.AnnotationParametersSizeLengthCheck;
@@ -70,7 +71,8 @@ public class ConstraintCheckFactory {
 						new AnnotationParametersPatternCheck( annotationApiHelper ),
 						new AnnotationParametersScriptAssertCheck( annotationApiHelper ),
 						new AnnotationParametersDigitsCheck( annotationApiHelper ),
-						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper )
+						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper ),
+						new AnnotationParametersGroupsCheck( annotationApiHelper )
 				)
 		);
 		parameterChecks.put(
@@ -81,7 +83,8 @@ public class ConstraintCheckFactory {
 						new AnnotationParametersPatternCheck( annotationApiHelper ),
 						new AnnotationParametersScriptAssertCheck( annotationApiHelper ),
 						new AnnotationParametersDigitsCheck( annotationApiHelper ),
-						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper )
+						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper ),
+						new AnnotationParametersGroupsCheck( annotationApiHelper )
 				)
 		);
 		parameterChecks.put(
@@ -99,7 +102,8 @@ public class ConstraintCheckFactory {
 						new AnnotationParametersPatternCheck( annotationApiHelper ),
 						new AnnotationParametersScriptAssertCheck( annotationApiHelper ),
 						new AnnotationParametersDigitsCheck( annotationApiHelper ),
-						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper )
+						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper ),
+						new AnnotationParametersGroupsCheck( annotationApiHelper )
 				)
 		);
 		fieldChecks.put(
@@ -112,7 +116,8 @@ public class ConstraintCheckFactory {
 						new AnnotationParametersPatternCheck( annotationApiHelper ),
 						new AnnotationParametersScriptAssertCheck( annotationApiHelper ),
 						new AnnotationParametersDigitsCheck( annotationApiHelper ),
-						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper )
+						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper ),
+						new AnnotationParametersGroupsCheck( annotationApiHelper )
 				)
 		);
 		fieldChecks.put(
@@ -133,7 +138,8 @@ public class ConstraintCheckFactory {
 						new AnnotationParametersPatternCheck( annotationApiHelper ),
 						new AnnotationParametersScriptAssertCheck( annotationApiHelper ),
 						new AnnotationParametersDigitsCheck( annotationApiHelper ),
-						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper )
+						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper ),
+						new AnnotationParametersGroupsCheck( annotationApiHelper )
 				)
 		);
 		methodChecks.put(
@@ -148,7 +154,8 @@ public class ConstraintCheckFactory {
 						new AnnotationParametersPatternCheck( annotationApiHelper ),
 						new AnnotationParametersScriptAssertCheck( annotationApiHelper ),
 						new AnnotationParametersDigitsCheck( annotationApiHelper ),
-						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper )
+						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper ),
+						new AnnotationParametersGroupsCheck( annotationApiHelper )
 				)
 		);
 		methodChecks.put(
@@ -167,7 +174,8 @@ public class ConstraintCheckFactory {
 						new AnnotationParametersPatternCheck( annotationApiHelper ),
 						new AnnotationParametersScriptAssertCheck( annotationApiHelper ),
 						new AnnotationParametersDigitsCheck( annotationApiHelper ),
-						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper )
+						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper ),
+						new AnnotationParametersGroupsCheck( annotationApiHelper )
 				)
 		);
 		annotationTypeChecks.put(
@@ -179,7 +187,8 @@ public class ConstraintCheckFactory {
 						new AnnotationParametersPatternCheck( annotationApiHelper ),
 						new AnnotationParametersScriptAssertCheck( annotationApiHelper ),
 						new AnnotationParametersDigitsCheck( annotationApiHelper ),
-						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper )
+						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper ),
+						new AnnotationParametersGroupsCheck( annotationApiHelper )
 				)
 		);
 		annotationTypeChecks.put(
@@ -203,7 +212,8 @@ public class ConstraintCheckFactory {
 						new AnnotationParametersPatternCheck( annotationApiHelper ),
 						new AnnotationParametersScriptAssertCheck( annotationApiHelper ),
 						new AnnotationParametersDigitsCheck( annotationApiHelper ),
-						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper )
+						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper ),
+						new AnnotationParametersGroupsCheck( annotationApiHelper )
 				)
 		);
 		nonAnnotationTypeChecks.put(
@@ -215,7 +225,8 @@ public class ConstraintCheckFactory {
 						new AnnotationParametersPatternCheck( annotationApiHelper ),
 						new AnnotationParametersScriptAssertCheck( annotationApiHelper ),
 						new AnnotationParametersDigitsCheck( annotationApiHelper ),
-						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper )
+						new AnnotationParametersDecimalMinMaxCheck( annotationApiHelper ),
+						new AnnotationParametersGroupsCheck( annotationApiHelper )
 				)
 		);
 		nonAnnotationTypeChecks.put( AnnotationType.NO_CONSTRAINT_ANNOTATION, NULL_CHECKS );

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/AnnotationParametersAbstractCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/AnnotationParametersAbstractCheck.java
@@ -62,7 +62,7 @@ public abstract class AnnotationParametersAbstractCheck extends AbstractConstrai
 	 * @param annotation annotation you want to process by this class
 	 * @return {@code true} if such annotation can be processed, {@code false} otherwise.
 	 */
-	private boolean canCheckThisAnnotation(AnnotationMirror annotation) {
+	protected boolean canCheckThisAnnotation(AnnotationMirror annotation) {
 		return annotationClasses.contains( annotation.getAnnotationType().asElement().toString() );
 	}
 

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/AnnotationParametersGroupsCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/AnnotationParametersGroupsCheck.java
@@ -12,6 +12,8 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
 
 import org.hibernate.validator.ap.checks.ConstraintCheckError;
 import org.hibernate.validator.ap.util.AnnotationApiHelper;
@@ -24,11 +26,9 @@ import org.hibernate.validator.ap.util.CollectionHelper;
  */
 public class AnnotationParametersGroupsCheck extends AnnotationParametersAbstractCheck {
 
-
 	public AnnotationParametersGroupsCheck(AnnotationApiHelper annotationApiHelper) {
 		super( annotationApiHelper );
 	}
-
 
 	@Override
 	protected boolean canCheckThisAnnotation(AnnotationMirror annotation) {
@@ -41,7 +41,8 @@ public class AnnotationParametersGroupsCheck extends AnnotationParametersAbstrac
 		Set<ConstraintCheckError> issues = CollectionHelper.newHashSet();
 
 		for ( AnnotationValue value : annotationValue ) {
-			if ( value.getValue() instanceof DeclaredType && !( (DeclaredType) value.getValue() ).asElement().getKind().isInterface() ) {
+			TypeMirror typeValue = (TypeMirror) value.getValue();
+			if ( !TypeKind.DECLARED.equals( typeValue.getKind() ) || !( (DeclaredType) typeValue ).asElement().getKind().isInterface() ) {
 				issues.add( new ConstraintCheckError(
 						element, annotation, "INVALID_GROUPS_VALUE_ANNOTATION_PARAMETERS"
 				) );

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/AnnotationParametersGroupsCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/AnnotationParametersGroupsCheck.java
@@ -1,0 +1,53 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.ap.checks.annotationparameters;
+
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.lang.model.type.DeclaredType;
+
+import org.hibernate.validator.ap.checks.ConstraintCheckError;
+import org.hibernate.validator.ap.util.AnnotationApiHelper;
+import org.hibernate.validator.ap.util.CollectionHelper;
+
+/**
+ * Checks that the groups parameter of any constraint annotation contains only interfaces.
+ *
+ * @author Marko Bekhta
+ */
+public class AnnotationParametersGroupsCheck extends AnnotationParametersAbstractCheck {
+
+
+	public AnnotationParametersGroupsCheck(AnnotationApiHelper annotationApiHelper) {
+		super( annotationApiHelper );
+	}
+
+
+	@Override
+	protected boolean canCheckThisAnnotation(AnnotationMirror annotation) {
+		return true;
+	}
+
+	@Override
+	protected Set<ConstraintCheckError> doCheck(Element element, AnnotationMirror annotation) {
+		List<? extends AnnotationValue> annotationValue = annotationApiHelper.getAnnotationArrayValue( annotation, "groups" );
+		Set<ConstraintCheckError> issues = CollectionHelper.newHashSet();
+
+		for ( AnnotationValue value : annotationValue ) {
+			if ( value.getValue() instanceof DeclaredType && !( (DeclaredType) value.getValue() ).asElement().getKind().isInterface() ) {
+				issues.add( new ConstraintCheckError(
+						element, annotation, "INVALID_GROUPS_VALUE_ANNOTATION_PARAMETERS"
+				) );
+			}
+		}
+
+		return issues;
+	}
+}

--- a/annotation-processor/src/main/resources/org/hibernate/validator/ap/ValidationProcessorMessages.properties
+++ b/annotation-processor/src/main/resources/org/hibernate/validator/ap/ValidationProcessorMessages.properties
@@ -38,3 +38,4 @@ INVALID_PATTERN_ANNOTATION_PARAMETERS=Invalid annotation parameters. Regular exp
 INVALID_SCRIPT_ASSERT_ANNOTATION_PARAMETERS=Invalid annotation parameters. Script, lang and alias parameters cannot be blank.
 INVALID_DIGITS_ANNOTATION_PARAMETERS=Invalid annotation parameters. Fraction and integer should be greater than or equal to 0.
 INVALID_DECIMAL_MIN_MAX_ANNOTATION_PARAMETERS=Invalid annotation parameters. Value should be a valid BigDecimal string representation.
+INVALID_GROUPS_VALUE_ANNOTATION_PARAMETERS=Invalid annotation parameters. Groups are represented by interfaces.

--- a/annotation-processor/src/main/resources/org/hibernate/validator/ap/ValidationProcessorMessages.properties
+++ b/annotation-processor/src/main/resources/org/hibernate/validator/ap/ValidationProcessorMessages.properties
@@ -38,4 +38,4 @@ INVALID_PATTERN_ANNOTATION_PARAMETERS=Invalid annotation parameters. Regular exp
 INVALID_SCRIPT_ASSERT_ANNOTATION_PARAMETERS=Invalid annotation parameters. Script, lang and alias parameters cannot be blank.
 INVALID_DIGITS_ANNOTATION_PARAMETERS=Invalid annotation parameters. Fraction and integer should be greater than or equal to 0.
 INVALID_DECIMAL_MIN_MAX_ANNOTATION_PARAMETERS=Invalid annotation parameters. Value should be a valid BigDecimal string representation.
-INVALID_GROUPS_VALUE_ANNOTATION_PARAMETERS=Invalid annotation parameters. Groups are represented by interfaces.
+INVALID_GROUPS_VALUE_ANNOTATION_PARAMETERS=Invalid annotation parameters. Groups should be represented by interfaces.

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/AnnotationParametersValidationTest.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/AnnotationParametersValidationTest.java
@@ -18,6 +18,7 @@ import org.hibernate.validator.ap.testmodel.annotationparameters.InvalidScriptAs
 import org.hibernate.validator.ap.testmodel.annotationparameters.InvalidSizeParameters;
 import org.hibernate.validator.ap.testmodel.annotationparameters.ValidDecimalMinMaxParameters;
 import org.hibernate.validator.ap.testmodel.annotationparameters.ValidDigitsParameters;
+import org.hibernate.validator.ap.testmodel.annotationparameters.ValidGroupsParameters;
 import org.hibernate.validator.ap.testmodel.annotationparameters.ValidLengthParameters;
 import org.hibernate.validator.ap.testmodel.annotationparameters.ValidPatternParameters;
 import org.hibernate.validator.ap.testmodel.annotationparameters.ValidScriptAssertParameters;
@@ -250,4 +251,21 @@ public class AnnotationParametersValidationTest extends ConstraintValidationProc
 		);
 	}
 
+	@Test
+	public void testValidGroupsParameter() {
+		File sourceFile = compilerHelper.getSourceFile( ValidGroupsParameters.class );
+
+		boolean compilationResult =
+				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFile );
+
+		assertFalse( compilationResult );
+		assertThatDiagnosticsMatch(
+				diagnostics,
+				new DiagnosticExpectation( Kind.ERROR, 26 ),
+				new DiagnosticExpectation( Kind.ERROR, 29 ),
+				new DiagnosticExpectation( Kind.ERROR, 32 ),
+				new DiagnosticExpectation( Kind.ERROR, 37 ),
+				new DiagnosticExpectation( Kind.ERROR, 42 )
+		);
+	}
 }

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/AnnotationParametersValidationTest.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/AnnotationParametersValidationTest.java
@@ -261,11 +261,12 @@ public class AnnotationParametersValidationTest extends ConstraintValidationProc
 		assertFalse( compilationResult );
 		assertThatDiagnosticsMatch(
 				diagnostics,
-				new DiagnosticExpectation( Kind.ERROR, 26 ),
-				new DiagnosticExpectation( Kind.ERROR, 29 ),
-				new DiagnosticExpectation( Kind.ERROR, 32 ),
-				new DiagnosticExpectation( Kind.ERROR, 37 ),
-				new DiagnosticExpectation( Kind.ERROR, 42 )
+				new DiagnosticExpectation( Kind.ERROR, 25 ),
+				new DiagnosticExpectation( Kind.ERROR, 28 ),
+				new DiagnosticExpectation( Kind.ERROR, 31 ),
+				new DiagnosticExpectation( Kind.ERROR, 36 ),
+				new DiagnosticExpectation( Kind.ERROR, 41 ),
+				new DiagnosticExpectation( Kind.ERROR, 53 )
 		);
 	}
 }

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/annotationparameters/ValidGroupsParameters.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/annotationparameters/ValidGroupsParameters.java
@@ -13,7 +13,6 @@ import javax.validation.constraints.Size;
  */
 public class ValidGroupsParameters {
 
-
 	@Size(groups = { })
 	private String string;
 
@@ -51,6 +50,8 @@ public class ValidGroupsParameters {
 	)
 	private String string6;
 
+	@Size(groups = { int.class })
+	private String string7;
 
 	public interface Group1 {
 	}

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/annotationparameters/ValidGroupsParameters.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/annotationparameters/ValidGroupsParameters.java
@@ -1,0 +1,66 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.ap.testmodel.annotationparameters;
+
+import javax.validation.constraints.Size;
+
+/**
+ * @author Marko Bekhta
+ */
+public class ValidGroupsParameters {
+
+
+	@Size(groups = { })
+	private String string;
+
+	@Size(groups = { Group1.class })
+	private String string1;
+
+	@Size(groups = { Group1.class, Group2.class })
+	private String string2;
+
+	@Size(groups = { InvalidGroup1.class })
+	private String string3;
+
+	@Size(groups = { InvalidGroup1.class, InvalidGroup2.class })
+	private String string4;
+
+	@Size(groups = { Group1.class, InvalidGroup1.class, InvalidGroup2.class })
+	private String string5;
+
+	@Size.List(
+			{
+					@Size(groups = {
+							Group1.class,
+							InvalidGroup1.class,
+							InvalidGroup2.class
+					}),
+					@Size(groups = {
+							InvalidGroup1.class,
+							InvalidGroup2.class
+					}),
+					@Size(groups = {
+							Group1.class,
+							Group2.class
+					})
+			}
+	)
+	private String string6;
+
+
+	public interface Group1 {
+	}
+
+	public interface Group2 {
+	}
+
+	public class InvalidGroup1 {
+	}
+
+	public class InvalidGroup2 {
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-455

added check for groups parameter to verify that groups are represented by interfaces.

One more for annotation processor :)