### PR TITLE
Documentation: add group inheritance chapter

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -109,6 +109,12 @@
                 </execution>
               </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Duser.language=en</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/documentation/src/main/asciidoc/ch05.asciidoc
+++ b/documentation/src/main/asciidoc/ch05.asciidoc
@@ -40,7 +40,7 @@ is just a simple tagging interface.
 [TIP]
 ====
 Using interfaces makes the usage of groups type-safe and allows for easy refactoring. It also means
-that groups can inherit from each other via class inheritance.
+that groups can inherit from each other via class inheritance. See <<section-group-inheritance>>.
 ====
 
 [[example-driver]]
@@ -105,6 +105,47 @@ due to the fact that the driver has not yet passed the driving test. Only after 
 
 The last `validate()` call finally shows that all constraints are passing by validating against all
 defined groups.
+
+[[section-group-inheritance]]
+=== Group inheritance
+
+In <<example-drive-away>>, we need to call `validate()` for each validation group, or specify all of them one by one.
+In some situations, you may want to define a group of constraints which includes another group.
+You can do that using group inheritance.
+
+In <<example-supercar>>, we define a `SuperCar` and a group `RaceCarChecks` that extends the `Default` group.
+A `SuperCar` must have safety belts to be allowed to run in races.
+
+[[example-supercar]]
+.SuperCar
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter05/groupinheritance/SuperCar.java[tags=include]
+----
+
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter05/groupinheritance/RaceCarChecks.java[]
+----
+====
+
+Now we will check if a `SuperCar` with one seat and no security belt is a valid car and a valid race-car.
+
+[[example-group-inheritance]]
+.Using group inheritance
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter05/GroupTest.java[tags=testGroupInheritance]
+----
+====
+
+On the first call to `validate()`, we do not specify a group. There is one validation error because a car must have at least one seat.
+It's a constraint from the `Default` group.
+
+On the second call, we specify only the group `RaceCarChecks`. There are two validation errors: one about the seat from the `Default` group,
+another one about safety belt from the `RaceCarChecks` group.
 
 [[section-defining-group-sequences]]
 === Defining group sequences

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter05/GroupTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter05/GroupTest.java
@@ -1,5 +1,6 @@
 package org.hibernate.validator.referenceguide.chapter05;
 
+import java.util.Iterator;
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -9,6 +10,9 @@ import javax.validation.groups.Default;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import org.hibernate.validator.referenceguide.chapter05.groupinheritance.RaceCarChecks;
+import org.hibernate.validator.referenceguide.chapter05.groupinheritance.SuperCar;
 
 import static org.junit.Assert.assertEquals;
 
@@ -67,6 +71,20 @@ public class GroupTest {
 		).size()
 		);
 		//end::driveAway[]
+	}
+
+	@Test
+	public void testGroupInheritance() {
+		//tag::testGroupInheritance[]
+		// create a supercar and check that it's valid as a generic Car
+		SuperCar superCar = new SuperCar( "Morris", "DD-AB-123", 1  );
+		assertEquals( "must be greater than or equal to 2", validator.validate( superCar ).iterator().next().getMessage() );
+
+		// check that this supercar is valid as generic car and also as race car
+		Iterator<ConstraintViolation<SuperCar>> iterator = validator.validate( superCar, RaceCarChecks.class ).iterator();
+		assertEquals( "Race car must have a safety belt", iterator.next().getMessage() );
+		assertEquals( "must be greater than or equal to 2", iterator.next().getMessage() );
+		//end::testGroupInheritance[]
 	}
 
 	@Test

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter05/groupinheritance/RaceCarChecks.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter05/groupinheritance/RaceCarChecks.java
@@ -1,0 +1,6 @@
+package org.hibernate.validator.referenceguide.chapter05.groupinheritance;
+
+import javax.validation.groups.Default;
+
+public interface RaceCarChecks extends Default {
+}

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter05/groupinheritance/SuperCar.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter05/groupinheritance/SuperCar.java
@@ -1,0 +1,36 @@
+//tag::include[]
+package org.hibernate.validator.referenceguide.chapter05.groupinheritance;
+
+//end::include[]
+import javax.validation.constraints.AssertTrue;
+
+import org.hibernate.validator.referenceguide.chapter05.Car;
+
+//tag::include[]
+public class SuperCar extends Car {
+
+	@AssertTrue(
+			message = "Race car must have a safety belt",
+			groups = RaceCarChecks.class
+	)
+	private boolean safetyBelt;
+
+	// getters and setters ...
+
+	//end::include[]
+
+	public SuperCar(String manufacturer, String licencePlate, int seatCount) {
+		super( manufacturer, licencePlate, seatCount );
+	}
+
+	public boolean isSafetyBelt() {
+		return safetyBelt;
+	}
+
+	public void setSafetyBelt(boolean safetyBelt) {
+		this.safetyBelt = safetyBelt;
+	}
+
+//tag::include[]
+}
+//end::include[]


### PR DESCRIPTION
Hibernate-validator documentation do not mention the possibility to declare constraints group inheriting from other groups or from Default group, as describe in [bean-validation 1.1 spec](http://beanvalidation.org/1.1/spec/#constraintdeclarationvalidationprocess-groupsequence-groupinheritance).
This PR proposes a chapter about group inheritance with examples based on Car class.