### PR TITLE
HV-1131 Deferring retrieval of default MI

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
@@ -72,7 +72,13 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 	private static final Log log = LoggerFactory.make();
 
 	private final ResourceBundleLocator defaultResourceBundleLocator;
-	private final MessageInterpolator defaultMessageInterpolator;
+
+	/**
+	 * Built lazily so RBMI and its dependency on EL is only initialized if actually needed
+	 */
+	private MessageInterpolator defaultMessageInterpolator;
+	private MessageInterpolator messageInterpolator;
+
 	private final TraversableResolver defaultTraversableResolver;
 	private final ConstraintValidatorFactory defaultConstraintValidatorFactory;
 	private final ParameterNameProvider defaultParameterNameProvider;
@@ -125,7 +131,6 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 		this.defaultTraversableResolver = new DefaultTraversableResolver();
 		this.defaultConstraintValidatorFactory = new ConstraintValidatorFactoryImpl();
 		this.defaultParameterNameProvider = new DefaultParameterNameProvider();
-		this.defaultMessageInterpolator = new ResourceBundleMessageInterpolator( defaultResourceBundleLocator );
 		this.serviceLoaderBasedConstraintMappingContributor = new ServiceLoaderBasedConstraintMappingContributor(
 				typeResolutionHelper
 		);
@@ -346,7 +351,18 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 
 	@Override
 	public final MessageInterpolator getMessageInterpolator() {
-		return validationBootstrapParameters.getMessageInterpolator();
+		if ( messageInterpolator == null ) {
+			// apply explicitly given MI, otherwise use default one
+			MessageInterpolator interpolator = validationBootstrapParameters.getMessageInterpolator();
+			if ( interpolator != null ) {
+				messageInterpolator = interpolator;
+			}
+			else {
+				messageInterpolator = getDefaultMessageInterpolatorConfiguredWithClassLoader();
+			}
+		}
+
+		return messageInterpolator;
 	}
 
 	@Override
@@ -400,6 +416,10 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 
 	@Override
 	public final MessageInterpolator getDefaultMessageInterpolator() {
+		if ( defaultMessageInterpolator == null ) {
+			defaultMessageInterpolator = new ResourceBundleMessageInterpolator( defaultResourceBundleLocator );
+		}
+
 		return defaultMessageInterpolator;
 	}
 
@@ -427,7 +447,6 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 		return programmaticMappings;
 	}
 
-
 	private boolean isSpecificProvider() {
 		return validationBootstrapParameters.getProvider() != null;
 	}
@@ -439,12 +458,6 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 		if ( ignoreXmlConfiguration ) {
 			log.ignoringXmlConfiguration();
 
-			// make sure we use the defaults in case they haven't been provided yet
-			if ( validationBootstrapParameters.getMessageInterpolator() == null ) {
-				validationBootstrapParameters.setMessageInterpolator(
-						getDefaultMessageInterpolatorConfiguredWithClassLoader()
-				);
-			}
 			if ( validationBootstrapParameters.getTraversableResolver() == null ) {
 				validationBootstrapParameters.setTraversableResolver( defaultTraversableResolver );
 			}
@@ -469,11 +482,6 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 		if ( validationBootstrapParameters.getMessageInterpolator() == null ) {
 			if ( xmlParameters.getMessageInterpolator() != null ) {
 				validationBootstrapParameters.setMessageInterpolator( xmlParameters.getMessageInterpolator() );
-			}
-			else {
-				validationBootstrapParameters.setMessageInterpolator(
-						getDefaultMessageInterpolatorConfiguredWithClassLoader()
-				);
 			}
 		}
 
@@ -546,7 +554,7 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 								true
 						)
 				) :
-				defaultMessageInterpolator;
+				getDefaultMessageInterpolator();
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
@@ -8,6 +8,7 @@ package org.hibernate.validator.internal.engine;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.MessageInterpolator;
 import javax.validation.ParameterNameProvider;
@@ -36,7 +37,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 	private boolean failFast;
 	private final List<ValidatedValueUnwrapper<?>> validatedValueHandlers;
 	private TimeProvider timeProvider;
-	private MethodValidationConfiguration methodValidationConfiguration = new MethodValidationConfiguration();
+	private final MethodValidationConfiguration methodValidationConfiguration = new MethodValidationConfiguration();
 
 
 	public ValidatorContextImpl(ValidatorFactoryImpl validatorFactory) {
@@ -46,7 +47,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 		this.constraintValidatorFactory = validatorFactory.getConstraintValidatorFactory();
 		this.parameterNameProvider = validatorFactory.getParameterNameProvider();
 		this.failFast = validatorFactory.isFailFast();
-		this.validatedValueHandlers = new ArrayList<ValidatedValueUnwrapper<?>>(
+		this.validatedValueHandlers = new ArrayList<>(
 				validatorFactory.getValidatedValueHandlers()
 		);
 		this.timeProvider = validatorFactory.getTimeProvider();

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/ElTermResolver.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/ElTermResolver.java
@@ -53,11 +53,7 @@ public class ElTermResolver implements TermResolver {
      */
 	public ElTermResolver(Locale locale, ExpressionFactory expressionFactory) {
 		this.locale = locale;
-		/*
-		 * This call to newInstance might throw. Bad news; error is not until call to validate for case where
-		 * EL is nonfunctional. Good news; cases that don't need EL don't get any exception.
-		 */
-		this.expressionFactory = expressionFactory != null ? expressionFactory : ExpressionFactory.newInstance();
+		this.expressionFactory = expressionFactory;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
@@ -28,7 +28,7 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 
 	private static final Log LOG = LoggerFactory.make();
 
-	private ExpressionFactory expressionFactory;
+	private final ExpressionFactory expressionFactory;
 
 	// HV-793 - To fail eagerly in case we have no EL dependencies on the classpath we try to load the expression
 	// factory type eagerly
@@ -43,25 +43,30 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 
 	public ResourceBundleMessageInterpolator() {
 		super();
+		this.expressionFactory = buildExpressionFactory();
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator) {
 		super( userResourceBundleLocator );
+		this.expressionFactory = buildExpressionFactory();
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator) {
 		super( userResourceBundleLocator, contributorResourceBundleLocator );
+		this.expressionFactory = buildExpressionFactory();
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator,
 			boolean cachingEnabled) {
 		super( userResourceBundleLocator, contributorResourceBundleLocator, cachingEnabled );
+		this.expressionFactory = buildExpressionFactory();
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator, boolean cachingEnabled) {
 		super( userResourceBundleLocator, null, cachingEnabled );
+		this.expressionFactory = buildExpressionFactory();
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator, boolean cachingEnabled, ExpressionFactory expressionFactory) {
@@ -73,5 +78,15 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	public String interpolate(Context context, Locale locale, String term) {
 		InterpolationTerm expression = new InterpolationTerm( term, locale, expressionFactory );
 		return expression.interpolate( context );
+	}
+
+	private static ExpressionFactory buildExpressionFactory() {
+		try {
+			return ExpressionFactory.newInstance();
+		}
+		catch (NoClassDefFoundError e) {
+			// HV-793 - We fail eagerly in case we have no EL dependencies on the classpath
+			throw LOG.getMissingELDependenciesException();
+		}
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/ValidatorFactoryNoELBootstrapTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/ValidatorFactoryNoELBootstrapTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.test.internal.engine;
 
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -13,11 +15,14 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.util.Set;
 
+import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
-import javax.validation.bootstrap.GenericBootstrap;
+import javax.validation.Validator;
+import javax.validation.constraints.Min;
 
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.testng.annotations.Test;
 
@@ -29,38 +34,52 @@ public class ValidatorFactoryNoELBootstrapTest {
 
 	@Test
 	@TestForIssue(jiraKey = "HV-793")
-	public void testMissingELDependencyThrowsExceptionDuringFactoryBootstrap() throws Exception {
-		ClassLoader classLoader = new ELIgnoringClassLoader();
-		Class<?> clazz = classLoader.loadClass( Validation.class.getName() );
+	public void bootstrapFailsWhenUsingDefaultInterpolatorWithoutExpressionFactory() throws Throwable {
+		runWithoutElLibs( BootstrapFailsWhenUsingDefaultInterpolatorWithoutExpressionFactory.class );
+	}
 
-		Object validation = clazz.newInstance();
-		Method m = clazz.getMethod( "buildDefaultValidatorFactory" );
+	public static class BootstrapFailsWhenUsingDefaultInterpolatorWithoutExpressionFactory {
 
-		try {
-			m.invoke( validation );
-			fail( "An exception should have been thrown" );
-		}
-		catch (InvocationTargetException e) {
-			assertTrue(
-					getRootCause( e ).getMessage().startsWith( "HV000183" ),
-					"Bootstrapping in Validation should throw an unexpected exception: " + e.getMessage()
-			);
+		public void run() {
+			try {
+				Validation.buildDefaultValidatorFactory();
+				fail( "An exception should have been thrown" );
+			}
+			catch (Throwable e) {
+				assertTrue(
+						getRootCause( e ).getMessage().startsWith( "HV000183" ),
+						"Bootstrapping in Validation should throw an unexpected exception: " + e.getMessage()
+				);
+			}
 		}
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HV-1131")
-	public void testMissingELDependencyDontThrowExceptionDuringConfigurationInitialization() throws Exception {
-		ClassLoader classLoader = new ELIgnoringClassLoader();
+	public void canUseParameterInterpolatorWithoutExpressionFactory() throws Throwable {
+		runWithoutElLibs( CanUseParameterInterpolatorWithoutExpressionFactory.class );
+	}
 
-		Class<?> validationClass = classLoader.loadClass( Validation.class.getName() );
-		Method byDefaultProviderMethod = validationClass.getMethod( "byDefaultProvider" );
+	public static class CanUseParameterInterpolatorWithoutExpressionFactory {
 
-		Class<?> genericBootstrapClass = classLoader.loadClass( GenericBootstrap.class.getName() );
-		Method configureMethod = genericBootstrapClass.getMethod( "configure" );
+		public void run() {
+			Validator validator = Validation.byDefaultProvider()
+				.configure()
+				.messageInterpolator( new ParameterMessageInterpolator() )
+				.buildValidatorFactory()
+				.getValidator();
 
-		Object genericBootstrap = byDefaultProviderMethod.invoke( null );
-		configureMethod.invoke( genericBootstrap );
+			assertNotNull( validator );
+
+			Set<ConstraintViolation<SomeBean>> violations = validator.validate( new SomeBean() );
+			assertCorrectConstraintViolationMessages( violations, "must be greater than or equal to 42" );
+		}
+	}
+
+	public static class SomeBean {
+
+		@Min(42)
+		private final long myLong = 41;
 	}
 
 	/**
@@ -68,7 +87,7 @@ public class ValidatorFactoryNoELBootstrapTest {
 	 * To test what happens if the EL classes cannot be found, we need to somehow "remove" these classes from the
 	 * classpath.
 	 */
-	public class ELIgnoringClassLoader extends ClassLoader {
+	private static class ELIgnoringClassLoader extends ClassLoader {
 		private final String EL_PACKAGE_PREFIX = "javax.el";
 		private final String[] PASS_THROUGH_PACKAGE_PREFIXES = new String[] {
 				"java.",
@@ -124,39 +143,52 @@ public class ValidatorFactoryNoELBootstrapTest {
 
 			return clazz;
 		}
+
+		private String getPackageName(String className) {
+			int i = className.lastIndexOf( '.' );
+			if ( i > 0 ) {
+				return className.substring( 0, i );
+			}
+			else {
+				return null;
+			}
+		}
+
+		private byte[] loadClassData(String className) throws IOException, ClassNotFoundException {
+			String path = "/" + className.replace( ".", "/" ) + ".class";
+			InputStream in = ValidatorFactoryNoELBootstrapTest.class.getResourceAsStream( path );
+
+			if ( in == null ) {
+				throw new ClassNotFoundException();
+			}
+
+			ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+			int bytesRead;
+			byte[] data = new byte[16384];
+			while ( ( bytesRead = in.read( data, 0, data.length ) ) != -1 ) {
+				buffer.write( data, 0, bytesRead );
+			}
+
+			buffer.flush();
+			return buffer.toByteArray();
+		}
 	}
 
-	private static String getPackageName(String className) {
-		int i = className.lastIndexOf( '.' );
-		if ( i > 0 ) {
-			return className.substring( 0, i );
+	/**
+	 * Loads the given class using the EL-ignoring class loader and executes it.
+	 */
+	private void runWithoutElLibs(Class<?> delegateType) throws Throwable {
+		try {
+			Object test = new ELIgnoringClassLoader().loadClass( delegateType.getName() ).newInstance();
+			test.getClass().getMethod( "run" ).invoke( test );
 		}
-		else {
-			return null;
+		catch (InvocationTargetException ite) {
+			throw ite.getCause();
 		}
 	}
 
-	private byte[] loadClassData(String className) throws IOException, ClassNotFoundException {
-		String path = "/" + className.replace( ".", "/" ) + ".class";
-		InputStream in = ValidatorFactoryNoELBootstrapTest.class.getResourceAsStream( path );
-
-		if ( in == null ) {
-			throw new ClassNotFoundException();
-		}
-
-		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-
-		int bytesRead;
-		byte[] data = new byte[16384];
-		while ( ( bytesRead = in.read( data, 0, data.length ) ) != -1 ) {
-			buffer.write( data, 0, bytesRead );
-		}
-
-		buffer.flush();
-		return buffer.toByteArray();
-	}
-
-	private Throwable getRootCause(Throwable throwable) {
+	private static Throwable getRootCause(Throwable throwable) {
 		while ( true ) {
 			Throwable cause = throwable.getCause();
 			if ( cause == null ) {


### PR DESCRIPTION
@gsmet I've found an alternative approach for the EL issue. The idea is to defer the retrieval of the default message interpolator until it's actually needed (either by calling `getDefaultMessageInterpolator()` or when bootstrapping the VF and no other MI has been given). That way the instantiation of the expression factory can simply be done in the 'ctor of `ResourceBundleMessageInterpolator`, not requiring any synchronization.

I've also rewritten the test so it doesn't need reflection in the actual test routine. I've reworked your commit so it adds the new test and your fixes around the test class loader, but ommitted your original approach for fixing the issue for the sake of a clean history.