### PR TITLE
HV-1002 Fix collectMetaConstraintsForPath logic in the iterable case

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/util/ReflectionHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/ReflectionHelper.java
@@ -299,6 +299,22 @@ public final class ReflectionHelper {
 	}
 
 	/**
+	 * Converts the given <code>Type</code> to a <code>Class</code>.
+	 *
+	 * @param type the type to convert
+	 * @return the class corresponding to the type
+	 */
+	public static Class<?> getClassFromType(Type type) {
+		if ( type instanceof Class ) {
+			return (Class<?>) type;
+		}
+		if ( type instanceof ParameterizedType ) {
+			return getClassFromType( ( (ParameterizedType) type ).getRawType() );
+		}
+		throw log.getUnableToConvertTypeToClassException( type );
+	}
+
+	/**
 	 * @param type the type to check.
 	 *
 	 * @return Returns <code>true</code> if <code>type</code> is a iterable type, <code>false</code> otherwise.

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -186,8 +186,8 @@ public interface Log extends BasicLogger {
 	@Message(id = 38, value = "Invalid property path.")
 	IllegalArgumentException getInvalidPropertyPathException();
 
-	@Message(id = 39, value = "Invalid property path. Either there is no property %1$s in entity %2$s or it is not possible to cascade to the property.")
-	IllegalArgumentException getInvalidPropertyPathException(String propertyName, @FormatWith(ClassObjectFormatter.class) Class<?> beanClass);
+	@Message(id = 39, value = "Invalid property path. Either there is no property %2$s in entity %1$s or it is not possible to cascade to the property.")
+	IllegalArgumentException getInvalidPropertyPathException(@FormatWith(ClassObjectFormatter.class) Class<?> beanClass, String propertyName);
 
 	@Message(id = 40, value = "Property path must provide index or map key.")
 	IllegalArgumentException getPropertyPathMustProvideIndexOrMapKeyException();

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -186,7 +186,7 @@ public interface Log extends BasicLogger {
 	@Message(id = 38, value = "Invalid property path.")
 	IllegalArgumentException getInvalidPropertyPathException();
 
-	@Message(id = 39, value = "Invalid property path. There is no property %1$s in entity %2$s.")
+	@Message(id = 39, value = "Invalid property path. Either there is no property %1$s in entity %2$s or it is not possible to cascade to the property.")
 	IllegalArgumentException getInvalidPropertyPathException(String propertyName, @FormatWith(ClassObjectFormatter.class) Class<?> beanClass);
 
 	@Message(id = 40, value = "Property path must provide index or map key.")
@@ -684,4 +684,10 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 194, value = "An empty element is only supported when a CharSequence is expected.")
 	ValidationException getEmptyElementOnlySupportedWhenCharSequenceIsExpectedExpection();
+
+	@Message(id = 195, value = "Unable to reach the property to validate for the bean %s and the property path %s. A property is null along the way.")
+	ValidationException getUnableToReachPropertyToValidateException(Object bean, Path path);
+
+	@Message(id = 196, value = "Unable to convert the Type %s to a Class.")
+	ValidationException getUnableToConvertTypeToClassException(Type type);
 }


### PR DESCRIPTION
Here is the second attempt at fixing HV-1002. I separated the `collectMetaConstraintsForPath` in 2 as it was becoming unreadable to manage both cases in the very same method. They are not recursive anymore.

It should also return better errors.

I added a second commit to rename the `getValue` methods.