### PR TITLE
HV-1155 Backport for 5.3

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/ElTermResolver.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/ElTermResolver.java
@@ -59,7 +59,7 @@ public class ElTermResolver implements TermResolver {
 	@Override
 	public String interpolate(MessageInterpolator.Context context, String expression) {
 		String resolvedExpression = expression;
-		SimpleELContext elContext = new SimpleELContext();
+		SimpleELContext elContext = new SimpleELContext( expressionFactory );
 		try {
 			ValueExpression valueExpression = bindContextValues( expression, context, elContext );
 			resolvedExpression = (String) valueExpression.getValue( elContext );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/el/SimpleELContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/el/SimpleELContext.java
@@ -7,11 +7,13 @@
 package org.hibernate.validator.internal.engine.messageinterpolation.el;
 
 import java.lang.reflect.Method;
+
 import javax.el.ArrayELResolver;
 import javax.el.BeanELResolver;
 import javax.el.CompositeELResolver;
 import javax.el.ELContext;
 import javax.el.ELResolver;
+import javax.el.ExpressionFactory;
 import javax.el.ListELResolver;
 import javax.el.MapELResolver;
 import javax.el.ResourceBundleELResolver;
@@ -37,7 +39,14 @@ public class SimpleELContext extends ELContext {
 	private final VariableMapper variableMapper;
 	private final ELResolver resolver;
 
-	public SimpleELContext() {
+	public SimpleELContext(ExpressionFactory expressionFactory) {
+		// In javax.el.ELContext, the ExpressionFactory is extracted from the context map. If it is not found, it
+		// defaults to ELUtil.getExpressionFactory() which, if we provided the ExpressionFactory to the
+		// ResourceBundleMessageInterpolator, might not be the same, thus potentially instantiating another
+		// ExpressionFactory outside of the boundaries of the class loader safe loading mechanism of
+		// ResourceBundleMessageInterpolator.
+		putContext( ExpressionFactory.class, expressionFactory );
+
 		functions = new MapBasedFunctionMapper();
 		variableMapper = new MapBasedVariableMapper();
 		resolver = DEFAULT_RESOLVER;

--- a/engine/src/main/java/org/hibernate/validator/internal/util/privilegedactions/SetContextClassLoader.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/privilegedactions/SetContextClassLoader.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.util.privilegedactions;
+
+import java.security.PrivilegedAction;
+
+import org.hibernate.validator.internal.util.Contracts;
+
+/**
+ * Privileged action used to set the Thread context class loader.
+ *
+ * @author Guillaume Smet
+ */
+public final class SetContextClassLoader implements PrivilegedAction<Void> {
+	private final ClassLoader classLoader;
+
+	public static SetContextClassLoader action(ClassLoader classLoader) {
+		Contracts.assertNotNull( classLoader, "class loader must not be null" );
+		return new SetContextClassLoader( classLoader );
+	}
+
+	private SetContextClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
+
+	@Override
+	public Void run() {
+		Thread.currentThread().setContextClassLoader( classLoader );
+		return null;
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.messageinterpolation;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Locale;
 
 import javax.el.ExpressionFactory;
@@ -13,6 +15,8 @@ import javax.el.ExpressionFactory;
 import org.hibernate.validator.internal.engine.messageinterpolation.InterpolationTerm;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
+import org.hibernate.validator.internal.util.privilegedactions.GetClassLoader;
+import org.hibernate.validator.internal.util.privilegedactions.SetContextClassLoader;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
 
 /**
@@ -70,13 +74,45 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 		return expression.interpolate( context );
 	}
 
+	/**
+	 * The javax.el FactoryFinder uses the TCCL to load the {@link ExpressionFactory} implementation so we need to be
+	 * extra careful when initializing it.
+	 *
+	 * @return the {@link ExpressionFactory}
+	 */
 	private static ExpressionFactory buildExpressionFactory() {
+		// First, we try to load the instance from the TCCL.
 		try {
+			return ExpressionFactory.newInstance();
+		}
+		catch (Throwable e) {
+			// we ignore the error in this case as we will try the Hibernate Validator class loader.
+		}
+
+		// Then we try the Hibernate Validator class loader. In a fully-functional modular environment such as
+		// WildFly or Jigsaw, it is the way to go.
+		final ClassLoader originalContextClassLoader = run( GetClassLoader.fromContext() );
+
+		try {
+			run( SetContextClassLoader.action( ResourceBundleMessageInterpolator.class.getClassLoader() ) );
 			return ExpressionFactory.newInstance();
 		}
 		catch (Throwable e) {
 			// HV-793 - We fail eagerly in case we have no EL dependencies on the classpath
 			throw LOG.getUnableToInitializeELExpressionFactoryException( e );
 		}
+		finally {
+			run( SetContextClassLoader.action( originalContextClassLoader ) );
+		}
+	}
+
+	/**
+	 * Runs the given privileged action, using a privileged block if required.
+	 * <p>
+	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
+	 * privileged actions within HV's protection domain.
+	 */
+	private static <T> T run(PrivilegedAction<T> action) {
+		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}
 }

--- a/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/OsgiIntegrationTest.java
+++ b/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/OsgiIntegrationTest.java
@@ -108,23 +108,28 @@ public class OsgiIntegrationTest {
 
 	@Test
 	public void canObtainValidatorFactoryAndPerformValidation() {
-		Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
+		ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
 
-		Set<ConstraintViolation<Customer>> constraintViolations = Validation.byDefaultProvider()
-				.providerResolver( new MyValidationProviderResolver() )
-				.configure()
-				.buildValidatorFactory()
-				.getValidator()
-				.validate( new Customer() );
+		try {
+			Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
 
-		assertEquals( 1, constraintViolations.size() );
-		assertEquals( "must be greater than or equal to 2", constraintViolations.iterator().next().getMessage() );
+			Set<ConstraintViolation<Customer>> constraintViolations = Validation.byDefaultProvider()
+					.providerResolver( new MyValidationProviderResolver() )
+					.configure()
+					.buildValidatorFactory()
+					.getValidator()
+					.validate( new Customer() );
+
+			assertEquals( 1, constraintViolations.size() );
+			assertEquals( "must be greater than or equal to 2", constraintViolations.iterator().next().getMessage() );
+		}
+		finally {
+			Thread.currentThread().setContextClassLoader( originalClassLoader );
+		}
 	}
 
 	@Test
 	public void canConfigureCustomConstraintValidatorFactoryViaValidationXml() {
-		Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
-
 		ExampleConstraintValidatorFactory.invocationCounter.set( 0 );
 
 		HibernateValidatorConfiguration configuration = Validation.byProvider( HibernateValidator.class )
@@ -150,8 +155,6 @@ public class OsgiIntegrationTest {
 
 	@Test
 	public void canConfigureConstraintViaXmlMapping() {
-		Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
-
 		Set<ConstraintViolation<Customer>> constraintViolations = Validation.byProvider( HibernateValidator.class )
 				.providerResolver( new MyValidationProviderResolver() )
 				.configure()
@@ -166,8 +169,6 @@ public class OsgiIntegrationTest {
 
 	@Test
 	public void canConfigureCustomConstraintViaXmlMapping() {
-		Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
-
 		Set<ConstraintViolation<Order>> constraintViolations = Validation.byProvider( HibernateValidator.class )
 				.providerResolver( new MyValidationProviderResolver() )
 				.configure()
@@ -182,8 +183,6 @@ public class OsgiIntegrationTest {
 
 	@Test
 	public void canObtainValuesFromValidationMessages() {
-		Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
-
 		Set<ConstraintViolation<RetailOrder>> constraintViolations = Validation.byProvider( HibernateValidator.class )
 				.providerResolver( new MyValidationProviderResolver() )
 				.configure()

--- a/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/OsgiIntegrationTest.java
+++ b/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/OsgiIntegrationTest.java
@@ -108,6 +108,8 @@ public class OsgiIntegrationTest {
 
 	@Test
 	public void canObtainValidatorFactoryAndPerformValidation() {
+		Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
+
 		Set<ConstraintViolation<Customer>> constraintViolations = Validation.byDefaultProvider()
 				.providerResolver( new MyValidationProviderResolver() )
 				.configure()
@@ -116,11 +118,13 @@ public class OsgiIntegrationTest {
 				.validate( new Customer() );
 
 		assertEquals( 1, constraintViolations.size() );
-		assertEquals( "must be greater than or equal to 1", constraintViolations.iterator().next().getMessage() );
+		assertEquals( "must be greater than or equal to 2", constraintViolations.iterator().next().getMessage() );
 	}
 
 	@Test
 	public void canConfigureCustomConstraintValidatorFactoryViaValidationXml() {
+		Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
+
 		ExampleConstraintValidatorFactory.invocationCounter.set( 0 );
 
 		HibernateValidatorConfiguration configuration = Validation.byProvider( HibernateValidator.class )
@@ -146,6 +150,8 @@ public class OsgiIntegrationTest {
 
 	@Test
 	public void canConfigureConstraintViaXmlMapping() {
+		Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
+
 		Set<ConstraintViolation<Customer>> constraintViolations = Validation.byProvider( HibernateValidator.class )
 				.providerResolver( new MyValidationProviderResolver() )
 				.configure()
@@ -160,6 +166,8 @@ public class OsgiIntegrationTest {
 
 	@Test
 	public void canConfigureCustomConstraintViaXmlMapping() {
+		Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
+
 		Set<ConstraintViolation<Order>> constraintViolations = Validation.byProvider( HibernateValidator.class )
 				.providerResolver( new MyValidationProviderResolver() )
 				.configure()
@@ -174,6 +182,8 @@ public class OsgiIntegrationTest {
 
 	@Test
 	public void canObtainValuesFromValidationMessages() {
+		Thread.currentThread().setContextClassLoader( getClass().getClassLoader() );
+
 		Set<ConstraintViolation<RetailOrder>> constraintViolations = Validation.byProvider( HibernateValidator.class )
 				.providerResolver( new MyValidationProviderResolver() )
 				.configure()

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <arquillian.version>1.1.11.Final</arquillian.version>
 
         <!-- OSGi dependencies -->
-        <pax.exam.version>4.8.0</pax.exam.version>
+        <pax.exam.version>4.9.2</pax.exam.version>
         <pax.url.version>2.4.7</pax.url.version>
         <apache.karaf.version>3.0.6</apache.karaf.version>
         <osgi-core.version>6.0.0</osgi-core.version>


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1155

Note: this is not perfect as there is still an `ExpressionFactory` initialized outside of the class loader safe portion in the `BeanELResolver` class of the 2.4 version of javax.el-api...

WildFly 10.1+ (and maybe before) is using the 3.0.1-b8 version which is not affected by this issue but it's there.

We should definitely move to 3.0.1-b8 for HV 5.4.