### PR TITLE
HV-1161 Use the correct checkstyle conf for OSGi integration tests

### DIFF
--- a/osgi/integrationtest/pom.xml
+++ b/osgi/integrationtest/pom.xml
@@ -138,7 +138,7 @@
             <plugin>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <configuration>
-                    <configLocation>checkstyle-documentation.xml</configLocation>
+                    <configLocation>checkstyle-junit.xml</configLocation>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1161

Should be backported to 5.4.