### PR TITLE
HV-1180 Detect cyclic definition of group sequence due to group inheritance in the annotation processor

### DIFF
--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/GroupSequenceValidationTest.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/GroupSequenceValidationTest.java
@@ -61,7 +61,9 @@ public class GroupSequenceValidationTest extends ConstraintValidationProcessorTe
 				new DiagnosticExpectation( Kind.ERROR, 113 ),
 				new DiagnosticExpectation( Kind.ERROR, 128 ),
 				new DiagnosticExpectation( Kind.ERROR, 132 ),
-				new DiagnosticExpectation( Kind.ERROR, 136 )
+				new DiagnosticExpectation( Kind.ERROR, 136 ),
+				new DiagnosticExpectation( Kind.ERROR, 151 ),
+				new DiagnosticExpectation( Kind.ERROR, 174 )
 		);
 	}
 

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/annotationparameters/InvalidGroupSequenceParameters.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/annotationparameters/InvalidGroupSequenceParameters.java
@@ -140,8 +140,6 @@ public class InvalidGroupSequenceParameters {
 
 	/**
 	 * Case 8: Cyclic definition due to group inheritance - incorrect
-	 *
-	 * XXX: currently, it does not throw an error
 	 */
 	public static class Case8 {
 		public interface Group1 extends Group2 {
@@ -152,6 +150,29 @@ public class InvalidGroupSequenceParameters {
 
 		@GroupSequence(value = { Group1.class, Group2.class })
 		public interface GroupSequence1 {
+		}
+	}
+
+	/**
+	 * Case 9: Cyclic definition due to group inheritance and group sequence inheritance - incorrect
+	 */
+	public static class Case9 {
+		public interface Group1 extends Group2 {
+		}
+
+		public interface Group2 {
+		}
+
+		@GroupSequence(value = Group1.class)
+		public interface GroupSequence1 {
+		}
+
+		@GroupSequence(value = GroupSequence1.class)
+		public interface GroupSequence2 {
+		}
+
+		@GroupSequence(value = { Group2.class, GroupSequence2.class })
+		public interface GroupSequence3 {
 		}
 
 	}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1180

added check of interface inheritance in group sequences, and also added one more case that uses interface inheritance and "GroupSequence inheritance"