### PR TITLE
HV-1188 Switch to LinkedHashSet to preserve order of constraints and messages

### DIFF
--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/AbstractElementVisitor.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/AbstractElementVisitor.java
@@ -46,8 +46,8 @@ public class AbstractElementVisitor<T, V> extends ElementKindVisitor6<T, V> {
 	 * @param foundIssues a collection of issues to be reported
 	 */
 	protected void reportIssues(Collection<ConstraintCheckIssue> foundIssues) {
-		Set<ConstraintCheckIssue> warnings = CollectionHelper.newHashSet();
-		Set<ConstraintCheckIssue> errors = CollectionHelper.newHashSet();
+		Set<ConstraintCheckIssue> warnings = CollectionHelper.newLinkedHashSet();
+		Set<ConstraintCheckIssue> errors = CollectionHelper.newLinkedHashSet();
 
 		for ( ConstraintCheckIssue issue : foundIssues ) {
 			if ( issue.isError() ) {

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/ClassVisitor.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/ClassVisitor.java
@@ -108,7 +108,7 @@ public class ClassVisitor extends AbstractElementVisitor<Void, Void> {
 
 	private void processClassChecks(Element element) {
 		try {
-			Set<ConstraintCheckIssue> allIssues = CollectionHelper.newHashSet();
+			Set<ConstraintCheckIssue> allIssues = CollectionHelper.newLinkedHashSet();
 			Collection<ClassCheck> classChecks = factory.getClassChecks( element );
 			for ( ClassCheck classCheck : classChecks ) {
 				allIssues.addAll( classCheck.execute( element ) );

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/AnnotationTypeMemberCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/AnnotationTypeMemberCheck.java
@@ -48,7 +48,7 @@ public class AnnotationTypeMemberCheck extends AbstractConstraintCheck {
 	@Override
 	public Set<ConstraintCheckIssue> checkAnnotationType(TypeElement element, AnnotationMirror annotation) {
 
-		Set<ConstraintCheckIssue> theValue = CollectionHelper.newHashSet();
+		Set<ConstraintCheckIssue> theValue = CollectionHelper.newLinkedHashSet();
 
 		theValue.addAll( checkMessageAttribute( element ) );
 		theValue.addAll( checkGroupsAttribute( element ) );

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/GroupSequenceProviderCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/GroupSequenceProviderCheck.java
@@ -59,7 +59,7 @@ public class GroupSequenceProviderCheck extends AbstractConstraintCheck {
 
 	@Override
 	public Set<ConstraintCheckIssue> checkNonAnnotationType(TypeElement element, AnnotationMirror annotation) {
-		Set<ConstraintCheckIssue> errors = CollectionHelper.newHashSet();
+		Set<ConstraintCheckIssue> errors = CollectionHelper.newLinkedHashSet();
 
 		errors.addAll( checkHostingElement( element, annotation ) );
 		errors.addAll( checkAnnotationValue( element, annotation ) );
@@ -94,7 +94,7 @@ public class GroupSequenceProviderCheck extends AbstractConstraintCheck {
 	}
 
 	private Set<ConstraintCheckIssue> checkAnnotationValue(TypeElement element, AnnotationMirror annotation) {
-		Set<ConstraintCheckIssue> errors = CollectionHelper.newHashSet();
+		Set<ConstraintCheckIssue> errors = CollectionHelper.newLinkedHashSet();
 		AnnotationValue value = annotationApiHelper.getAnnotationValue( annotation, "value" );
 		TypeMirror valueType = (TypeMirror) value.getValue();
 		TypeElement valueElement = (TypeElement) typeUtils.asElement( valueType );

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/MultiValuedChecks.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/MultiValuedChecks.java
@@ -40,7 +40,7 @@ public class MultiValuedChecks implements ConstraintChecks {
 
 	@Override
 	public Set<ConstraintCheckIssue> execute(Element element, AnnotationMirror annotation) {
-		Set<ConstraintCheckIssue> theValue = CollectionHelper.newHashSet();
+		Set<ConstraintCheckIssue> theValue = CollectionHelper.newLinkedHashSet();
 
 		//execute the checks on each element of the multi-valued constraint
 		for ( AnnotationMirror onePartOfMultiValuedConstraint :

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/SingleValuedChecks.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/SingleValuedChecks.java
@@ -48,7 +48,7 @@ public class SingleValuedChecks implements ConstraintChecks {
 
 	@Override
 	public Set<ConstraintCheckIssue> execute(Element element, AnnotationMirror annotation) {
-		Set<ConstraintCheckIssue> theValue = CollectionHelper.newHashSet();
+		Set<ConstraintCheckIssue> theValue = CollectionHelper.newLinkedHashSet();
 
 		//for each check execute the check method appropriate for the kind of
 		//the given element

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/AnnotationParametersAbstractCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/AnnotationParametersAbstractCheck.java
@@ -17,7 +17,7 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -33,7 +33,7 @@ public abstract class AnnotationParametersAbstractCheck extends AbstractConstrai
 
 	public AnnotationParametersAbstractCheck(AnnotationApiHelper annotationApiHelper, String... annotationClass) {
 		this.annotationApiHelper = annotationApiHelper;
-		this.annotationClasses = new HashSet<>( Arrays.asList( annotationClass ) );
+		this.annotationClasses = new LinkedHashSet<>( Arrays.asList( annotationClass ) );
 	}
 
 	@Override

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/AnnotationParametersGroupsCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/AnnotationParametersGroupsCheck.java
@@ -36,7 +36,7 @@ public class AnnotationParametersGroupsCheck extends AnnotationParametersAbstrac
 	@Override
 	protected Set<ConstraintCheckIssue> doCheck(Element element, AnnotationMirror annotation) {
 		List<? extends AnnotationValue> annotationValue = annotationApiHelper.getAnnotationArrayValue( annotation, "groups" );
-		Set<ConstraintCheckIssue> issues = CollectionHelper.newHashSet();
+		Set<ConstraintCheckIssue> issues = CollectionHelper.newLinkedHashSet();
 
 		for ( AnnotationValue value : annotationValue ) {
 			if ( !annotationApiHelper.isInterface( (TypeMirror) value.getValue() ) ) {

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/GroupSequenceCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/checks/annotationparameters/GroupSequenceCheck.java
@@ -54,9 +54,9 @@ public class GroupSequenceCheck extends AnnotationParametersAbstractCheck {
 
 		boolean isDefaultGroupSequenceRedefinition = false;
 
-		Set<String> qualifiedNames = CollectionHelper.newHashSet();
+		Set<String> qualifiedNames = CollectionHelper.newLinkedHashSet();
 
-		Set<ConstraintCheckIssue> issues = CollectionHelper.newHashSet();
+		Set<ConstraintCheckIssue> issues = CollectionHelper.newLinkedHashSet();
 
 		for ( AnnotationValue value : annotationValue ) {
 			TypeMirror typeMirror = (TypeMirror) value.getValue();
@@ -99,7 +99,7 @@ public class GroupSequenceCheck extends AnnotationParametersAbstractCheck {
 		}
 
 		// 5. the defined group sequence is expandable (no cyclic definition)
-		ConstraintCheckIssue cyclicDefinitionIssue = checkForCyclicDefinition( CollectionHelper.newHashSet(), annotatedElement.asType(), annotatedElement, annotation );
+		ConstraintCheckIssue cyclicDefinitionIssue = checkForCyclicDefinition( CollectionHelper.newLinkedHashSet(), annotatedElement.asType(), annotatedElement, annotation );
 		if ( cyclicDefinitionIssue != null ) {
 			issues.add( cyclicDefinitionIssue );
 		}

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/classchecks/MethodInheritanceTree.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/classchecks/MethodInheritanceTree.java
@@ -90,7 +90,7 @@ public class MethodInheritanceTree {
 	}
 
 	private Set<ExecutableElement> buildOverriddenMethodSet() {
-		Set<ExecutableElement> overriddenMethods = CollectionHelper.newHashSet();
+		Set<ExecutableElement> overriddenMethods = CollectionHelper.newLinkedHashSet();
 		for ( ExecutableElement method : methodNodeMapping.keySet() ) {
 			if ( !rootMethodNode.getMethod().equals( method ) ) {
 				overriddenMethods.add( method );
@@ -100,7 +100,7 @@ public class MethodInheritanceTree {
 	}
 
 	private Set<ExecutableElement> buildTopLevelMethodSet() {
-		Set<ExecutableElement> methods = CollectionHelper.newHashSet();
+		Set<ExecutableElement> methods = CollectionHelper.newLinkedHashSet();
 		for ( MethodNode methodNode : methodNodeMapping.values() ) {
 			if ( !methodNode.isOverriding() ) {
 				methods.add( methodNode.getMethod() );
@@ -150,7 +150,7 @@ public class MethodInheritanceTree {
 
 		private MethodNode(ExecutableElement method) {
 			this.method = method;
-			this.overriddenMethodNodes = CollectionHelper.newHashSet();
+			this.overriddenMethodNodes = CollectionHelper.newLinkedHashSet();
 		}
 
 		private boolean isOverriding() {

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/classchecks/ParametersMethodOverrideCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/classchecks/ParametersMethodOverrideCheck.java
@@ -50,7 +50,7 @@ public class ParametersMethodOverrideCheck extends AbstractMethodOverrideCheck {
 		// you can't define a parameter constraint at all for this method (anywhere in the hierarchy, not even once)
 		if ( methodInheritanceTree.hasParallelDefinitions() ) {
 			// it means we have more than one top level method and as a result there cannot be any annotations present in the hierarchy
-			Set<ConstraintCheckIssue> issues = CollectionHelper.newHashSet();
+			Set<ConstraintCheckIssue> issues = CollectionHelper.newLinkedHashSet();
 			for ( ExecutableElement method : methodInheritanceTree.getAllMethods() ) {
 				if ( hasAnnotationsOnParameters( method ) ) {
 					issues.add( ConstraintCheckIssue.error(

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/classchecks/ReturnValueMethodOverrideCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/classchecks/ReturnValueMethodOverrideCheck.java
@@ -40,7 +40,7 @@ public class ReturnValueMethodOverrideCheck extends AbstractMethodOverrideCheck 
 	protected Set<ConstraintCheckIssue> checkMethodInternal(ExecutableElement currentMethod, MethodInheritanceTree methodInheritanceTree) {
 		// if this method gets executed it means that the current method has a @Valid annotation and we
 		// need to check that there is no other @Valid annotations in the hierarchy of this method
-		Set<ConstraintCheckIssue> issues = CollectionHelper.newHashSet();
+		Set<ConstraintCheckIssue> issues = CollectionHelper.newLinkedHashSet();
 		for ( ExecutableElement overriddenMethod : methodInheritanceTree.getOverriddenMethods() ) {
 			if ( methodIsAnnotatedWithValid( overriddenMethod ) ) {
 				issues.add( ConstraintCheckIssue.error(

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/util/AnnotationApiHelper.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/util/AnnotationApiHelper.java
@@ -311,7 +311,7 @@ public class AnnotationApiHelper {
 			return null;
 		}
 
-		Set<TypeMirror> theValue = CollectionHelper.newHashSet();
+		Set<TypeMirror> theValue = CollectionHelper.newLinkedHashSet();
 
 		for ( TypeMirror typeMirror1 : types ) {
 			boolean foundSubType = false;

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/util/CollectionHelper.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/util/CollectionHelper.java
@@ -9,7 +9,7 @@ package org.hibernate.validator.ap.util;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -28,8 +28,8 @@ public class CollectionHelper {
 		return new HashMap<K, V>();
 	}
 
-	public static <T> HashSet<T> newHashSet() {
-		return new HashSet<T>();
+	public static <T> LinkedHashSet<T> newLinkedHashSet() {
+		return new LinkedHashSet<T>();
 	}
 
 	public static <T> TreeSet<T> newTreeSet() {
@@ -42,7 +42,7 @@ public class CollectionHelper {
 
 	public static <T> Set<T> asSet(T... ts) {
 
-		return new HashSet<T>( Arrays.asList( ts ) );
+		return new LinkedHashSet<T>( Arrays.asList( ts ) );
 	}
 
 	public static <T> Set<T> asTreeSet(T... ts) {

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/util/ConstraintHelper.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/util/ConstraintHelper.java
@@ -11,7 +11,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.EnumSet;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -788,7 +788,7 @@ public class ConstraintHelper {
 				constraintMetaAnnotation
 		);
 
-		Set<TypeMirror> supportedTypes = CollectionHelper.newHashSet();
+		Set<TypeMirror> supportedTypes = CollectionHelper.newLinkedHashSet();
 
 		for ( AnnotationValue oneValidatorClassReference : validatorClassReferences ) {
 
@@ -972,7 +972,7 @@ public class ConstraintHelper {
 	 */
 	private Set<TypeMirror> getAssignableTypes(Set<TypeMirror> types, TypeMirror type) {
 
-		Set<TypeMirror> theValue = CollectionHelper.newHashSet();
+		Set<TypeMirror> theValue = CollectionHelper.newLinkedHashSet();
 
 		for ( TypeMirror supportedType : types ) {
 			if ( typeUtils.isAssignable( type, supportedType ) ) {
@@ -1002,7 +1002,7 @@ public class ConstraintHelper {
 		Set<TypeMirror> types = supportedTypesByConstraint.get( key );
 
 		if ( types == null ) {
-			supportedTypesByConstraint.put( key, new HashSet<TypeMirror>( supportedTypes ) );
+			supportedTypesByConstraint.put( key, new LinkedHashSet<TypeMirror>( supportedTypes ) );
 		}
 		else {
 			types.addAll( supportedTypes );
@@ -1032,7 +1032,7 @@ public class ConstraintHelper {
 			return composingConstraints;
 		}
 
-		composingConstraints = CollectionHelper.newHashSet();
+		composingConstraints = CollectionHelper.newLinkedHashSet();
 
 		List<? extends AnnotationMirror> annotationMirrors = constraintAnnotationType.asElement()
 				.getAnnotationMirrors();

--- a/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidationExtension.java
+++ b/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidationExtension.java
@@ -54,7 +54,7 @@ import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * A CDI portable extension which integrates Bean Validation with CDI. It registers the following objects:
@@ -237,7 +237,7 @@ public class ValidationExtension implements Extension {
 	}
 
 	private <T> Set<AnnotatedCallable<? super T>> determineConstrainedCallables(AnnotatedType<T> type) {
-		Set<AnnotatedCallable<? super T>> callables = newHashSet();
+		Set<AnnotatedCallable<? super T>> callables = newLinkedHashSet();
 		BeanDescriptor beanDescriptor = validator.getConstraintsForClass( type.getJavaClass() );
 
 		determineConstrainedConstructors( type, beanDescriptor, callables );

--- a/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidationProviderHelper.java
+++ b/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidationProviderHelper.java
@@ -8,7 +8,7 @@ package org.hibernate.validator.internal.cdi;
 
 import java.lang.annotation.Annotation;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
@@ -21,7 +21,7 @@ import org.hibernate.validator.cdi.HibernateValidator;
 import org.hibernate.validator.internal.engine.ValidatorFactoryImpl;
 import org.hibernate.validator.internal.engine.ValidatorImpl;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * Provides functionality for dealing with validation provider types.
@@ -110,7 +110,7 @@ public class ValidationProviderHelper {
 	@SuppressWarnings("serial")
 	private static Set<Annotation> determineRequiredQualifiers(boolean isDefaultProvider,
 			boolean isHibernateValidator) {
-		HashSet<Annotation> qualifiers = newHashSet( 3 );
+		LinkedHashSet<Annotation> qualifiers = newLinkedHashSet( 3 );
 
 		if ( isDefaultProvider ) {
 			qualifiers.add(

--- a/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidatorBean.java
+++ b/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidatorBean.java
@@ -42,7 +42,7 @@ public class ValidatorBean implements Bean<Validator>, PassivationCapable {
 		this.validatorFactoryBean = validatorFactoryBean;
 		this.validationProviderHelper = validationProviderHelper;
 		this.types = Collections.unmodifiableSet(
-				CollectionHelper.<Type>newHashSet(
+				CollectionHelper.<Type>newLinkedHashSet(
 						ClassHierarchyHelper.getHierarchy( validationProviderHelper.getValidatorBeanClass() )
 				)
 		);

--- a/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidatorFactoryBean.java
+++ b/cdi/src/main/java/org/hibernate/validator/internal/cdi/ValidatorFactoryBean.java
@@ -32,7 +32,7 @@ import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
 import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * A {@link Bean} representing a {@link ValidatorFactory}. There is one instance of this type representing the default
@@ -51,10 +51,10 @@ public class ValidatorFactoryBean implements Bean<ValidatorFactory>, Passivation
 
 	public ValidatorFactoryBean(BeanManager beanManager, ValidationProviderHelper validationProviderHelper) {
 		this.beanManager = beanManager;
-		this.destructibleResources = newHashSet( 4 );
+		this.destructibleResources = newLinkedHashSet( 4 );
 		this.validationProviderHelper = validationProviderHelper;
 		this.types = Collections.unmodifiableSet(
-				CollectionHelper.<Type>newHashSet(
+				CollectionHelper.<Type>newLinkedHashSet(
 						ClassHierarchyHelper.getHierarchy( validationProviderHelper.getValidatorFactoryBeanClass() )
 				)
 		);

--- a/cdi/src/main/java/org/hibernate/validator/internal/cdi/interceptor/ValidationEnabledAnnotatedCallable.java
+++ b/cdi/src/main/java/org/hibernate/validator/internal/cdi/interceptor/ValidationEnabledAnnotatedCallable.java
@@ -8,7 +8,7 @@ package org.hibernate.validator.internal.cdi.interceptor;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.enterprise.inject.spi.AnnotatedCallable;
@@ -68,7 +68,7 @@ public abstract class ValidationEnabledAnnotatedCallable<T> implements Annotated
 
 	@Override
 	public Set<Annotation> getAnnotations() {
-		Set<Annotation> annotations = new HashSet<Annotation>( wrappedCallable.getAnnotations() );
+		Set<Annotation> annotations = new LinkedHashSet<Annotation>( wrappedCallable.getAnnotations() );
 		annotations.add( methodValidationAnnotation );
 		return annotations;
 	}

--- a/cdi/src/main/java/org/hibernate/validator/internal/cdi/interceptor/ValidationEnabledAnnotatedType.java
+++ b/cdi/src/main/java/org/hibernate/validator/internal/cdi/interceptor/ValidationEnabledAnnotatedType.java
@@ -27,8 +27,8 @@ public class ValidationEnabledAnnotatedType<T> implements AnnotatedType<T> {
 
 	public ValidationEnabledAnnotatedType(AnnotatedType<T> type, Set<AnnotatedCallable<? super T>> constrainedCallables) {
 		this.wrappedType = type;
-		this.wrappedMethods = CollectionHelper.newHashSet();
-		this.wrappedConstructors = CollectionHelper.newHashSet();
+		this.wrappedMethods = CollectionHelper.newLinkedHashSet();
+		this.wrappedConstructors = CollectionHelper.newLinkedHashSet();
 		buildWrappedCallable( constrainedCallables );
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConstraintDefinitionContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConstraintDefinitionContextImpl.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.cfg.context;
 
 import java.lang.annotation.Annotation;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import javax.validation.ConstraintValidator;
@@ -32,7 +32,7 @@ class ConstraintDefinitionContextImpl<A extends Annotation>
 
 	private boolean includeExistingValidators = true;
 
-	private final Set<ConstraintValidatorDescriptor<A>> validatorDescriptors = new HashSet<>();
+	private final Set<ConstraintValidatorDescriptor<A>> validatorDescriptors = new LinkedHashSet<>();
 
 	ConstraintDefinitionContextImpl(DefaultConstraintMapping mapping, Class<A> annotationType) {
 		super( mapping );

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConstraintMappingContextImplBase.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConstraintMappingContextImplBase.java
@@ -15,7 +15,7 @@ import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl.ConstraintType;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * Base class for implementations of constraint mapping creational context types.
@@ -28,7 +28,7 @@ abstract class ConstraintMappingContextImplBase extends ConstraintContextImplBas
 
 	ConstraintMappingContextImplBase(DefaultConstraintMapping mapping) {
 		super( mapping );
-		this.constraints = newHashSet();
+		this.constraints = newLinkedHashSet();
 	}
 
 	/**
@@ -63,7 +63,7 @@ abstract class ConstraintMappingContextImplBase extends ConstraintContextImplBas
 			return Collections.emptySet();
 		}
 
-		Set<MetaConstraint<?>> metaConstraints = newHashSet();
+		Set<MetaConstraint<?>> metaConstraints = newLinkedHashSet();
 
 		for ( ConfiguredConstraint<?> configuredConstraint : constraints ) {
 			metaConstraints.add( asMetaConstraint( configuredConstraint, constraintHelper ) );

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/DefaultConstraintMapping.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/DefaultConstraintMapping.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.internal.cfg.context;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
 
 import java.lang.annotation.Annotation;
@@ -45,10 +45,10 @@ public class DefaultConstraintMapping implements ConstraintMapping {
 
 	public DefaultConstraintMapping() {
 		this.annotationProcessingOptions = new AnnotationProcessingOptionsImpl();
-		this.configuredTypes = newHashSet();
-		this.typeContexts = newHashSet();
-		this.definedConstraints = newHashSet();
-		this.constraintContexts = newHashSet();
+		this.configuredTypes = newLinkedHashSet();
+		this.typeContexts = newLinkedHashSet();
+		this.definedConstraints = newLinkedHashSet();
+		this.constraintContexts = newLinkedHashSet();
 	}
 
 	@Override
@@ -83,7 +83,7 @@ public class DefaultConstraintMapping implements ConstraintMapping {
 	 * @return a set of {@link BeanConfiguration}s with an element for each type configured through this mapping
 	 */
 	public Set<BeanConfiguration<?>> getBeanConfigurations(ConstraintHelper constraintHelper, ExecutableParameterNameProvider parameterNameProvider) {
-		Set<BeanConfiguration<?>> configurations = newHashSet();
+		Set<BeanConfiguration<?>> configurations = newLinkedHashSet();
 
 		for ( TypeConstraintMappingContextImpl<?> typeContext : typeContexts ) {
 			configurations.add( typeContext.build( constraintHelper, parameterNameProvider ) );
@@ -111,7 +111,7 @@ public class DefaultConstraintMapping implements ConstraintMapping {
 	}
 
 	public Set<ConstraintDefinitionContribution<?>> getConstraintDefinitionContributions() {
-		Set<ConstraintDefinitionContribution<?>> contributions = newHashSet();
+		Set<ConstraintDefinitionContribution<?>> contributions = newLinkedHashSet();
 
 		for ( ConstraintDefinitionContextImpl<?> constraintContext : constraintContexts ) {
 			contributions.add( constraintContext.build() );

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/TypeConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/TypeConstraintMappingContextImpl.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.internal.cfg.context;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
 
 import java.lang.annotation.ElementType;
@@ -59,9 +59,9 @@ public final class TypeConstraintMappingContextImpl<C> extends ConstraintMapping
 
 	private final Class<C> beanClass;
 
-	private final Set<ExecutableConstraintMappingContextImpl> executableContexts = newHashSet();
-	private final Set<PropertyConstraintMappingContextImpl> propertyContexts = newHashSet();
-	private final Set<Member> configuredMembers = newHashSet();
+	private final Set<ExecutableConstraintMappingContextImpl> executableContexts = newLinkedHashSet();
+	private final Set<PropertyConstraintMappingContextImpl> propertyContexts = newLinkedHashSet();
+	private final Set<Member> configuredMembers = newLinkedHashSet();
 
 	private List<Class<?>> defaultGroupSequence;
 	private Class<? extends DefaultGroupSequenceProvider<? super C>> defaultGroupSequenceProviderClass;
@@ -193,7 +193,7 @@ public final class TypeConstraintMappingContextImpl<C> extends ConstraintMapping
 	}
 
 	private Set<ConstrainedElement> buildConstraintElements(ConstraintHelper constraintHelper, ExecutableParameterNameProvider parameterNameProvider) {
-		Set<ConstrainedElement> elements = newHashSet();
+		Set<ConstrainedElement> elements = newLinkedHashSet();
 
 		//class-level configuration
 		elements.add(

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.engine;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
 
 import java.io.BufferedInputStream;
@@ -89,11 +89,11 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 	private ValidationProviderResolver providerResolver;
 	private final ValidationBootstrapParameters validationBootstrapParameters;
 	private boolean ignoreXmlConfiguration = false;
-	private final Set<InputStream> configurationStreams = newHashSet();
+	private final Set<InputStream> configurationStreams = newLinkedHashSet();
 	private BootstrapConfiguration bootstrapConfiguration;
 
 	// HV-specific options
-	private final Set<DefaultConstraintMapping> programmaticMappings = newHashSet();
+	private final Set<DefaultConstraintMapping> programmaticMappings = newLinkedHashSet();
 	private boolean failFast;
 	private final List<ValidatedValueUnwrapper<?>> validatedValueHandlers = newArrayList();
 	private ClassLoader externalClassLoader;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/MethodValidationConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/MethodValidationConfiguration.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.engine;
 
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import org.hibernate.validator.internal.metadata.aggregated.rule.MethodConfigurationRule;
@@ -17,7 +17,7 @@ import org.hibernate.validator.internal.metadata.aggregated.rule.ParallelMethods
 import org.hibernate.validator.internal.metadata.aggregated.rule.ReturnValueMayOnlyBeMarkedOnceAsCascadedPerHierarchyLine;
 import org.hibernate.validator.internal.metadata.aggregated.rule.VoidMethodsMustNotBeReturnValueConstrained;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * These properties modify the behavior of the {@code }Validator} with respect to the Bean Validation
@@ -127,7 +127,7 @@ public class MethodValidationConfiguration {
 	 * @return a set of method configuration rules based on this configuration state
 	 */
 	public Set<MethodConfigurationRule> getConfiguredRuleSet() {
-		HashSet<MethodConfigurationRule> result = newHashSet();
+		LinkedHashSet<MethodConfigurationRule> result = newLinkedHashSet();
 
 		if ( !this.isAllowOverridingMethodAlterParameterConstraint() ) {
 			result.add( new OverridingMethodMustNotAlterParameterConstraints() );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
@@ -7,12 +7,12 @@
 package org.hibernate.validator.internal.engine;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Type;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -185,7 +185,7 @@ public class ValidationContext<T> {
 		this.processedBeansPerGroup = newHashMap();
 		this.processedPathsPerBean = new IdentityHashMap<>();
 		this.processedMetaConstraints = newHashMap();
-		this.failingConstraintViolations = newHashSet();
+		this.failingConstraintViolations = newLinkedHashSet();
 	}
 
 	public static ValidationContextBuilder getValidationContext(
@@ -255,7 +255,7 @@ public class ValidationContext<T> {
 
 	public Set<ConstraintViolation<T>> createConstraintViolations(ValueContext<?, ?> localContext,
 			ConstraintValidatorContextImpl constraintValidatorContext) {
-		Set<ConstraintViolation<T>> constraintViolations = newHashSet();
+		Set<ConstraintViolation<T>> constraintViolations = newLinkedHashSet();
 		for ( ConstraintViolationCreationContext constraintViolationCreationContext : constraintValidatorContext.getConstraintViolationCreationContexts() ) {
 			ConstraintViolation<T> violation = createConstraintViolation(
 					localContext,
@@ -487,7 +487,7 @@ public class ValidationContext<T> {
 			processedPathsPerBean.get( value ).add( path );
 		}
 		else {
-			Set<PathImpl> set = new HashSet<>();
+			Set<PathImpl> set = new LinkedHashSet<>();
 			set.add( path );
 			processedPathsPerBean.put( value, set );
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.engine;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.annotation.Annotation;
 import java.security.AccessController;
@@ -247,7 +247,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 	}
 
 	private static Set<DefaultConstraintMapping> getConstraintMappings(ConfigurationState configurationState, ClassLoader externalClassLoader) {
-		Set<DefaultConstraintMapping> constraintMappings = newHashSet();
+		Set<DefaultConstraintMapping> constraintMappings = newLinkedHashSet();
 
 		if ( configurationState instanceof ConfigurationImpl ) {
 			ConfigurationImpl hibernateConfiguration = (ConfigurationImpl) configurationState;
@@ -509,7 +509,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 
 	private static void registerCustomConstraintValidators(Set<DefaultConstraintMapping> constraintMappings,
 			ConstraintHelper constraintHelper) {
-		Set<Class<?>> definedConstraints = newHashSet();
+		Set<Class<?>> definedConstraints = newLinkedHashSet();
 		for ( DefaultConstraintMapping constraintMapping : constraintMappings ) {
 			for ( ConstraintDefinitionContribution<?> contribution : constraintMapping.getConstraintDefinitionContributions() ) {
 				processConstraintDefinitionContribution( contribution, constraintHelper, definedConstraints );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
@@ -10,7 +10,7 @@ import static org.hibernate.validator.constraints.CompositionType.ALL_FALSE;
 import static org.hibernate.validator.constraints.CompositionType.AND;
 import static org.hibernate.validator.constraints.CompositionType.OR;
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
@@ -83,7 +83,7 @@ public class ConstraintTree<A extends Annotation> {
 
 	public final <T> boolean validateConstraints(ValidationContext<T> executionContext,
 			ValueContext<?, ?> valueContext) {
-		Set<ConstraintViolation<T>> constraintViolations = newHashSet();
+		Set<ConstraintViolation<T>> constraintViolations = newLinkedHashSet();
 		validateConstraints( executionContext, valueContext, constraintViolations );
 		if ( !constraintViolations.isEmpty() ) {
 			executionContext.addConstraintFailures( constraintViolations );
@@ -392,7 +392,7 @@ public class ConstraintTree<A extends Annotation> {
 		CompositionResult compositionResult = new CompositionResult( true, false );
 		List<ConstraintTree<?>> children = getChildren();
 		for ( ConstraintTree<?> tree : children ) {
-			Set<ConstraintViolation<T>> tmpViolations = newHashSet();
+			Set<ConstraintViolation<T>> tmpViolations = newLinkedHashSet();
 			tree.validateConstraints( executionContext, valueContext, tmpViolations );
 			constraintViolations.addAll( tmpViolations );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/groups/Sequence.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/groups/Sequence.java
@@ -8,7 +8,7 @@ package org.hibernate.validator.internal.engine.groups;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -67,7 +67,7 @@ public class Sequence implements Iterable<GroupWithInheritance> {
 		ArrayList<Group> tmpGroups = new ArrayList<Group>();
 
 		for ( Group group : groups ) {
-			HashSet<Group> groupsOfGroup = new HashSet<Group>();
+			LinkedHashSet<Group> groupsOfGroup = new LinkedHashSet<Group>();
 
 			groupsOfGroup.add( group );
 			addInheritedGroups( group, groupsOfGroup );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/AbstractConstraintMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/AbstractConstraintMetaData.java
@@ -16,7 +16,7 @@ import org.hibernate.validator.internal.engine.valuehandling.UnwrapMode;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * Base implementation for {@link ConstraintMetaData} with attributes common
@@ -130,7 +130,7 @@ public abstract class AbstractConstraintMetaData implements ConstraintMetaData {
 	}
 
 	protected Set<ConstraintDescriptorImpl<?>> asDescriptors(Set<MetaConstraint<?>> constraints) {
-		Set<ConstraintDescriptorImpl<?>> theValue = newHashSet();
+		Set<ConstraintDescriptorImpl<?>> theValue = newLinkedHashSet();
 
 		for ( MetaConstraint<?> oneConstraint : constraints ) {
 			theValue.add( oneConstraint.getDescriptor() );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.metadata.aggregated;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.annotation.ElementType;
 import java.lang.reflect.Executable;
@@ -157,8 +157,8 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 		this.beanClass = beanClass;
 		this.propertyMetaDataMap = newHashMap();
 
-		Set<PropertyMetaData> propertyMetaDataSet = newHashSet();
-		Set<ExecutableMetaData> executableMetaDataSet = newHashSet();
+		Set<PropertyMetaData> propertyMetaDataSet = newLinkedHashSet();
+		Set<ExecutableMetaData> executableMetaDataSet = newLinkedHashSet();
 
 		for ( ConstraintMetaData constraintMetaData : constraintMetaDataSet ) {
 			if ( constraintMetaData.getKind() == ElementKind.PROPERTY ) {
@@ -169,8 +169,8 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 			}
 		}
 
-		Set<Cascadable> cascadedProperties = newHashSet();
-		Set<MetaConstraint<?>> allMetaConstraints = newHashSet();
+		Set<Cascadable> cascadedProperties = newLinkedHashSet();
+		Set<MetaConstraint<?>> allMetaConstraints = newLinkedHashSet();
 
 		for ( PropertyMetaData propertyMetaData : propertyMetaDataSet ) {
 			propertyMetaDataMap.put( propertyMetaData.getName(), propertyMetaData );
@@ -427,9 +427,9 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	}
 
 	private Set<MetaConstraint<?>> getDirectConstraints() {
-		Set<MetaConstraint<?>> constraints = newHashSet();
+		Set<MetaConstraint<?>> constraints = newLinkedHashSet();
 
-		Set<Class<?>> classAndInterfaces = newHashSet();
+		Set<Class<?>> classAndInterfaces = newLinkedHashSet();
 		classAndInterfaces.add( beanClass );
 		classAndInterfaces.addAll( ClassHierarchyHelper.getDirectlyImplementedInterfaces( beanClass ) );
 
@@ -527,7 +527,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 
 		private final Class<T> beanClass;
 
-		private final Set<BuilderDelegate> builders = newHashSet();
+		private final Set<BuilderDelegate> builders = newLinkedHashSet();
 
 		private final ExecutableHelper executableHelper;
 
@@ -613,7 +613,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 		}
 
 		public BeanMetaDataImpl<T> build() {
-			Set<ConstraintMetaData> aggregatedElements = newHashSet();
+			Set<ConstraintMetaData> aggregatedElements = newLinkedHashSet();
 
 			for ( BuilderDelegate builder : builders ) {
 				aggregatedElements.addAll( builder.build() );
@@ -724,7 +724,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 		}
 
 		public Set<ConstraintMetaData> build() {
-			Set<ConstraintMetaData> metaDataSet = newHashSet();
+			Set<ConstraintMetaData> metaDataSet = newLinkedHashSet();
 
 			if ( propertyBuilder != null ) {
 				metaDataSet.add( propertyBuilder.build() );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
@@ -8,7 +8,7 @@ package org.hibernate.validator.internal.metadata.aggregated;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
@@ -18,7 +18,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -242,17 +242,17 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 	 * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
 	 */
 	public static class Builder extends MetaDataBuilder {
-		private final Set<String> signatures = newHashSet();
+		private final Set<String> signatures = newLinkedHashSet();
 
 		/**
 		 * Either CONSTRUCTOR or METHOD.
 		 */
 		private final ConstrainedElement.ConstrainedElementKind kind;
-		private final Set<ConstrainedExecutable> constrainedExecutables = newHashSet();
+		private final Set<ConstrainedExecutable> constrainedExecutables = newLinkedHashSet();
 		private Executable executable;
 		private final boolean isGetterMethod;
-		private final Set<MetaConstraint<?>> crossParameterConstraints = newHashSet();
-		private final Set<MetaConstraint<?>> typeArgumentsConstraints = newHashSet();
+		private final Set<MetaConstraint<?>> crossParameterConstraints = newLinkedHashSet();
+		private final Set<MetaConstraint<?>> typeArgumentsConstraints = newLinkedHashSet();
 		private final Set<MethodConfigurationRule> rules;
 		private boolean isConstrained = false;
 
@@ -287,7 +287,7 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 			this.executableHelper = executableHelper;
 			this.kind = constrainedExecutable.getKind();
 			this.executable = constrainedExecutable.getExecutable();
-			this.rules = new HashSet<>( methodValidationConfiguration.getConfiguredRuleSet() );
+			this.rules = new LinkedHashSet<>( methodValidationConfiguration.getConfiguredRuleSet() );
 			this.isGetterMethod = constrainedExecutable.isGetterMethod();
 
 			add( constrainedExecutable );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/GroupConversionHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/GroupConversionHelper.java
@@ -17,7 +17,7 @@ import org.hibernate.validator.internal.metadata.descriptor.GroupConversionDescr
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * Provides group conversion functionality to {@link org.hibernate.validator.cfg.context.Cascadable}s.
@@ -55,7 +55,7 @@ public class GroupConversionHelper {
 	 *         {@code null}.
 	 */
 	public Set<GroupConversionDescriptor> asDescriptors() {
-		Set<GroupConversionDescriptor> descriptors = newHashSet( groupConversions.size() );
+		Set<GroupConversionDescriptor> descriptors = newLinkedHashSet( groupConversions.size() );
 
 		for ( Entry<Class<?>, Class<?>> conversion : groupConversions.entrySet() ) {
 			descriptors.add(

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/MetaDataBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/MetaDataBuilder.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.metadata.aggregated;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.annotation.Annotation;
 import java.util.Map;
@@ -39,7 +39,7 @@ public abstract class MetaDataBuilder {
 	protected final ConstraintHelper constraintHelper;
 
 	private final Class<?> beanClass;
-	private final Set<MetaConstraint<?>> constraints = newHashSet();
+	private final Set<MetaConstraint<?>> constraints = newLinkedHashSet();
 	private final Map<Class<?>, Class<?>> groupConversions = newHashMap();
 	private boolean isCascading = false;
 	private UnwrapMode unwrapMode = UnwrapMode.AUTOMATIC;
@@ -137,7 +137,7 @@ public abstract class MetaDataBuilder {
 	 * @return A constraint adapted to the given bean type.
 	 */
 	protected Set<MetaConstraint<?>> adaptOriginsAndImplicitGroups(Set<MetaConstraint<?>> constraints) {
-		Set<MetaConstraint<?>> adaptedConstraints = newHashSet();
+		Set<MetaConstraint<?>> adaptedConstraints = newLinkedHashSet();
 
 		for ( MetaConstraint<?> oneConstraint : constraints ) {
 			adaptedConstraints.add( adaptOriginAndImplicitGroup( oneConstraint ) );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ParameterMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ParameterMetaData.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.internal.metadata.aggregated;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.annotation.ElementType;
 import java.lang.reflect.Type;
@@ -128,7 +128,7 @@ public class ParameterMetaData extends AbstractConstraintMetaData implements Cas
 		private final Type parameterType;
 		private final int parameterIndex;
 		private ConstrainedParameter constrainedParameter;
-		private final Set<MetaConstraint<?>> typeArgumentsConstraints = newHashSet();
+		private final Set<MetaConstraint<?>> typeArgumentsConstraints = newLinkedHashSet();
 
 		public Builder(Class<?> beanClass, ConstrainedParameter constrainedParameter, ConstraintHelper constraintHelper) {
 			super( beanClass, constraintHelper );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/PropertyMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/PropertyMetaData.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.internal.metadata.aggregated;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.annotation.ElementType;
 import java.lang.reflect.AccessibleObject;
@@ -237,7 +237,7 @@ public class PropertyMetaData extends AbstractConstraintMetaData implements Casc
 		private final String propertyName;
 		private final Type propertyType;
 		private Member cascadingMember;
-		private final Set<MetaConstraint<?>> typeArgumentsConstraints = newHashSet();
+		private final Set<MetaConstraint<?>> typeArgumentsConstraints = newLinkedHashSet();
 		private UnwrapMode unwrapMode = UnwrapMode.AUTOMATIC;
 		private boolean unwrapModeExplicitlyConfigured = false;
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/BeanDescriptorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/BeanDescriptorImpl.java
@@ -21,7 +21,7 @@ import javax.validation.metadata.PropertyDescriptor;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.ExecutableHelper;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
 
@@ -64,7 +64,7 @@ public class BeanDescriptorImpl extends ElementDescriptorImpl implements BeanDes
 
 	@Override
 	public final Set<PropertyDescriptor> getConstrainedProperties() {
-		return newHashSet( constrainedProperties.values() );
+		return newLinkedHashSet( constrainedProperties.values() );
 	}
 
 	@Override
@@ -74,7 +74,7 @@ public class BeanDescriptorImpl extends ElementDescriptorImpl implements BeanDes
 
 	@Override
 	public Set<ConstructorDescriptor> getConstrainedConstructors() {
-		return newHashSet( constrainedConstructors.values() );
+		return newLinkedHashSet( constrainedConstructors.values() );
 	}
 
 	@Override
@@ -92,7 +92,7 @@ public class BeanDescriptorImpl extends ElementDescriptorImpl implements BeanDes
 			}
 		}
 
-		Set<MethodDescriptor> matchingMethodDescriptors = newHashSet();
+		Set<MethodDescriptor> matchingMethodDescriptors = newLinkedHashSet();
 		for ( ExecutableDescriptorImpl constrainedMethod : constrainedMethods.values() ) {
 			boolean addToSet = false;
 			if ( ( constrainedMethod.isGetter() && includeGetters ) || ( !constrainedMethod.isGetter() && includeNonGetters ) ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ConstraintDescriptorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ConstraintDescriptorImpl.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.metadata.descriptor;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
@@ -516,7 +516,7 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 
 	@SuppressWarnings("unchecked")
 	private Set<Class<? extends Payload>> buildPayloadSet(T annotation) {
-		Set<Class<? extends Payload>> payloadSet = newHashSet();
+		Set<Class<? extends Payload>> payloadSet = newLinkedHashSet();
 		Class<Payload>[] payloadFromAnnotation;
 		try {
 			//TODO be extra safe and make sure this is an array of Payload
@@ -535,7 +535,7 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 	}
 
 	private Set<Class<?>> buildGroupSet(Class<?> implicitGroup) {
-		Set<Class<?>> groupSet = newHashSet();
+		Set<Class<?>> groupSet = newLinkedHashSet();
 		final Class<?>[] groupsFromAnnotation = run(
 				GetAnnotationParameter.action( annotation, ConstraintHelper.GROUPS, Class[].class )
 		);
@@ -615,7 +615,7 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 	}
 
 	private Set<ConstraintDescriptorImpl<?>> parseComposingConstraints(Member member, ConstraintHelper constraintHelper, ConstraintType constraintType) {
-		Set<ConstraintDescriptorImpl<?>> composingConstraintsSet = newHashSet();
+		Set<ConstraintDescriptorImpl<?>> composingConstraintsSet = newLinkedHashSet();
 		Map<ClassIndexWrapper, Map<String, Object>> overrideParameters = parseOverrideParameters();
 
 		for ( Annotation declaredAnnotation : annotationType.getDeclaredAnnotations() ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ElementDescriptorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ElementDescriptorImpl.java
@@ -11,7 +11,7 @@ import java.lang.annotation.ElementType;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -27,7 +27,7 @@ import org.hibernate.validator.internal.metadata.core.ConstraintOrigin;
 import org.hibernate.validator.internal.util.TypeHelper;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * Describes a validated element (class, field or property).
@@ -83,7 +83,7 @@ public abstract class ElementDescriptorImpl implements ElementDescriptor, Serial
 		private final Set<ElementType> elementTypes;
 
 		ConstraintFinderImpl() {
-			elementTypes = new HashSet<ElementType>();
+			elementTypes = new LinkedHashSet<ElementType>();
 			elementTypes.add( ElementType.TYPE );
 			elementTypes.add( ElementType.METHOD );
 			elementTypes.add( ElementType.CONSTRUCTOR );
@@ -92,7 +92,7 @@ public abstract class ElementDescriptorImpl implements ElementDescriptor, Serial
 			//for a bean descriptor there will be no parameter constraints, so we can safely add this element type here
 			elementTypes.add( ElementType.PARAMETER );
 
-			definedInSet = newHashSet();
+			definedInSet = newLinkedHashSet();
 			definedInSet.add( ConstraintOrigin.DEFINED_LOCALLY );
 			definedInSet.add( ConstraintOrigin.DEFINED_IN_HIERARCHY );
 			groups = Collections.emptyList();
@@ -129,7 +129,7 @@ public abstract class ElementDescriptorImpl implements ElementDescriptor, Serial
 
 		@Override
 		public Set<ConstraintDescriptor<?>> getConstraintDescriptors() {
-			Set<ConstraintDescriptor<?>> matchingDescriptors = new HashSet<ConstraintDescriptor<?>>();
+			Set<ConstraintDescriptor<?>> matchingDescriptors = new LinkedHashSet<ConstraintDescriptor<?>>();
 			findMatchingDescriptors( matchingDescriptors );
 			return Collections.unmodifiableSet( matchingDescriptors );
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
@@ -8,7 +8,7 @@ package org.hibernate.validator.internal.metadata.provider;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 import static org.hibernate.validator.internal.util.ConcurrentReferenceHashMap.ReferenceType.SOFT;
 import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
 
@@ -208,7 +208,7 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 			return Collections.emptySet();
 		}
 
-		Set<MetaConstraint<?>> classLevelConstraints = newHashSet();
+		Set<MetaConstraint<?>> classLevelConstraints = newLinkedHashSet();
 
 		// HV-262
 		List<ConstraintDescriptorImpl<?>> classMetaData = findClassLevelConstraints( clazz );
@@ -221,7 +221,7 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 	}
 
 	private Set<ConstrainedElement> getFieldMetaData(Class<?> beanClass) {
-		Set<ConstrainedElement> propertyMetaData = newHashSet();
+		Set<ConstrainedElement> propertyMetaData = newLinkedHashSet();
 
 		for ( Field field : run( GetDeclaredFields.action( beanClass ) ) ) {
 			// HV-172
@@ -278,7 +278,7 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 	}
 
 	private Set<MetaConstraint<?>> convertToMetaConstraints(List<ConstraintDescriptorImpl<?>> constraintDescriptors, Field field) {
-		Set<MetaConstraint<?>> constraints = newHashSet();
+		Set<MetaConstraint<?>> constraints = newLinkedHashSet();
 
 		for ( ConstraintDescriptorImpl<?> constraintDescription : constraintDescriptors ) {
 			constraints.add( createMetaConstraint( field, constraintDescription ) );
@@ -323,7 +323,7 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 	}
 
 	private Set<ConstrainedExecutable> getMetaData(Executable[] executableElements) {
-		Set<ConstrainedExecutable> executableMetaData = newHashSet();
+		Set<ConstrainedExecutable> executableMetaData = newLinkedHashSet();
 
 		for ( Executable executable : executableElements ) {
 			// HV-172; ignoring synthetic methods (inserted by the compiler), as they can't have any constraints
@@ -409,7 +409,7 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 			return Collections.emptySet();
 		}
 
-		Set<MetaConstraint<?>> constraints = newHashSet();
+		Set<MetaConstraint<?>> constraints = newLinkedHashSet();
 
 		for ( ConstraintDescriptorImpl<?> constraintDescriptor : constraintsDescriptors ) {
 			constraints.add(
@@ -448,8 +448,8 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 
 			boolean parameterIsCascading = false;
 			String parameterName = parameterNames.get( i );
-			Set<MetaConstraint<?>> parameterConstraints = newHashSet();
-			Set<MetaConstraint<?>> typeArgumentsConstraints = newHashSet();
+			Set<MetaConstraint<?>> parameterConstraints = newLinkedHashSet();
+			Set<MetaConstraint<?>> typeArgumentsConstraints = newLinkedHashSet();
 			ConvertGroup groupConversion = null;
 			ConvertGroup.List groupConversionList = null;
 
@@ -794,7 +794,7 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 	 * Creates meta constraints for type arguments constraints.
 	 */
 	private Set<MetaConstraint<?>> convertToTypeArgumentMetaConstraints(List<ConstraintDescriptorImpl<?>> constraintDescriptors, ConstraintLocation location, Type type) {
-		Set<MetaConstraint<?>> constraints = newHashSet( constraintDescriptors.size() );
+		Set<MetaConstraint<?>> constraints = newLinkedHashSet( constraintDescriptors.size() );
 		for ( ConstraintDescriptorImpl<?> constraintDescription : constraintDescriptors ) {
 			MetaConstraint<?> metaConstraint = createTypeArgumentMetaConstraint( location, constraintDescription, type );
 			constraints.add( metaConstraint );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/ProgrammaticMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/ProgrammaticMetaDataProvider.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.internal.metadata.provider;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,7 +44,7 @@ public class ProgrammaticMetaDataProvider extends MetaDataProviderKeyedByClassNa
 	}
 
 	private void assertUniquenessOfConfiguredTypes(Set<DefaultConstraintMapping> mappings) {
-		Set<Class<?>> allConfiguredTypes = newHashSet();
+		Set<Class<?>> allConfiguredTypes = newLinkedHashSet();
 
 		for ( DefaultConstraintMapping constraintMapping : mappings ) {
 			for ( Class<?> configuredType : constraintMapping.getConfiguredTypes() ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/BeanConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/BeanConfiguration.java
@@ -53,7 +53,7 @@ public class BeanConfiguration<T> {
 
 		this.source = source;
 		this.beanClass = beanClass;
-		this.constrainedElements = CollectionHelper.<ConstrainedElement>newHashSet( constrainedElements );
+		this.constrainedElements = CollectionHelper.<ConstrainedElement>newLinkedHashSet( constrainedElements );
 		this.defaultGroupSequence = defaultGroupSequence;
 		this.defaultGroupSequenceProvider = defaultGroupSequenceProvider;
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedExecutable.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedExecutable.java
@@ -8,7 +8,7 @@ package org.hibernate.validator.internal.metadata.raw;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
@@ -286,13 +286,13 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 			i++;
 		}
 
-		Set<MetaConstraint<?>> mergedCrossParameterConstraints = newHashSet( crossParameterConstraints );
+		Set<MetaConstraint<?>> mergedCrossParameterConstraints = newLinkedHashSet( crossParameterConstraints );
 		mergedCrossParameterConstraints.addAll( other.crossParameterConstraints );
 
-		Set<MetaConstraint<?>> mergedReturnValueConstraints = newHashSet( constraints );
+		Set<MetaConstraint<?>> mergedReturnValueConstraints = newLinkedHashSet( constraints );
 		mergedReturnValueConstraints.addAll( other.constraints );
 
-		Set<MetaConstraint<?>> mergedTypeArgumentsConstraints = newHashSet( typeArgumentsConstraints );
+		Set<MetaConstraint<?>> mergedTypeArgumentsConstraints = newLinkedHashSet( typeArgumentsConstraints );
 		mergedTypeArgumentsConstraints.addAll( other.typeArgumentsConstraints );
 
 		Map<Class<?>, Class<?>> mergedGroupConversions = newHashMap( groupConversions );
@@ -321,7 +321,7 @@ public class ConstrainedExecutable extends AbstractConstrainedElement {
 	}
 
 	private Set<ConstraintDescriptor<?>> getDescriptors(Iterable<MetaConstraint<?>> constraints) {
-		Set<ConstraintDescriptor<?>> descriptors = newHashSet();
+		Set<ConstraintDescriptor<?>> descriptors = newLinkedHashSet();
 
 		for ( MetaConstraint<?> constraint : constraints ) {
 			descriptors.add( constraint.getDescriptor() );

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedParameter.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedParameter.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.metadata.raw;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.reflect.Executable;
 import java.lang.reflect.Type;
@@ -149,10 +149,10 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 			mergedUnwrapMode = other.unwrapMode;
 		}
 
-		Set<MetaConstraint<?>> mergedConstraints = newHashSet( constraints );
+		Set<MetaConstraint<?>> mergedConstraints = newLinkedHashSet( constraints );
 		mergedConstraints.addAll( other.constraints );
 
-		Set<MetaConstraint<?>> mergedTypeArgumentsConstraints = newHashSet( typeArgumentsConstraints );
+		Set<MetaConstraint<?>> mergedTypeArgumentsConstraints = newLinkedHashSet( typeArgumentsConstraints );
 		mergedTypeArgumentsConstraints.addAll( other.typeArgumentsConstraints );
 
 		Map<Class<?>, Class<?>> mergedGroupConversions = newHashMap( groupConversions );

--- a/engine/src/main/java/org/hibernate/validator/internal/util/CollectionHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/CollectionHelper.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
@@ -45,26 +45,26 @@ public final class CollectionHelper {
 		return new ConcurrentHashMap<K, V>();
 	}
 
-	public static <T> HashSet<T> newHashSet() {
-		return new HashSet<T>();
+	public static <T> LinkedHashSet<T> newLinkedHashSet() {
+		return new LinkedHashSet<T>();
 	}
 
-	public static <T> HashSet<T> newHashSet(int size) {
-		return new HashSet<T>( size );
+	public static <T> LinkedHashSet<T> newLinkedHashSet(int size) {
+		return new LinkedHashSet<T>( size );
 	}
 
-	public static <T> HashSet<T> newHashSet(Collection<? extends T> c) {
-		return new HashSet<T>( c );
+	public static <T> LinkedHashSet<T> newLinkedHashSet(Collection<? extends T> c) {
+		return new LinkedHashSet<T>( c );
 	}
 
-	public static <T> HashSet<T> newHashSet(Collection<? extends T> s1, Collection<? extends T> s2) {
-		HashSet<T> set = CollectionHelper.<T>newHashSet( s1 );
+	public static <T> LinkedHashSet<T> newLinkedHashSet(Collection<? extends T> s1, Collection<? extends T> s2) {
+		LinkedHashSet<T> set = CollectionHelper.<T>newLinkedHashSet( s1 );
 		set.addAll( s2 );
 		return set;
 	}
 
-	public static <T> HashSet<T> newHashSet(Iterable<? extends T> iterable) {
-		HashSet<T> set = newHashSet();
+	public static <T> LinkedHashSet<T> newLinkedHashSet(Iterable<? extends T> iterable) {
+		LinkedHashSet<T> set = newLinkedHashSet();
 		for ( T t : iterable ) {
 			set.add( t );
 		}
@@ -92,7 +92,7 @@ public final class CollectionHelper {
 
 	@SafeVarargs
 	public static <T> Set<T> asSet(T... ts) {
-		return new HashSet<>( Arrays.asList( ts ) );
+		return new LinkedHashSet<>( Arrays.asList( ts ) );
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/util/TypeHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/TypeHelper.java
@@ -18,7 +18,7 @@
 package org.hibernate.validator.internal.util;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
@@ -391,7 +391,7 @@ public final class TypeHelper {
 
 	private static void putPrimitiveSubtypes(Map<Class<?>, Set<Class<?>>> subtypesByPrimitive, Class<?> primitiveType,
 											 Class<?>... directSubtypes) {
-		Set<Class<?>> subtypes = newHashSet();
+		Set<Class<?>> subtypes = newLinkedHashSet();
 
 		for ( Class<?> directSubtype : directSubtypes ) {
 			subtypes.add( directSubtype );

--- a/engine/src/main/java/org/hibernate/validator/internal/util/classhierarchy/ClassHierarchyHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/classhierarchy/ClassHierarchyHelper.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import org.hibernate.validator.internal.util.Contracts;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * Helper class for dealing with inheritance hierarchies of given types which
@@ -108,7 +108,7 @@ public class ClassHierarchyHelper {
 	public static <T> Set<Class<? super T>> getDirectlyImplementedInterfaces(Class<T> clazz) {
 		Contracts.assertNotNull( clazz );
 
-		Set<Class<? super T>> classes = newHashSet();
+		Set<Class<? super T>> classes = newLinkedHashSet();
 		getImplementedInterfaces( clazz, classes );
 		return classes;
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/BootstrapConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/BootstrapConfigurationImpl.java
@@ -14,7 +14,7 @@ import javax.validation.BootstrapConfiguration;
 import javax.validation.executable.ExecutableType;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * Wrapper class for the bootstrap parameters defined in <i>validation.xml</i>
@@ -65,7 +65,7 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 		this.parameterNameProviderClassName = null;
 		this.validatedExecutableTypes = DEFAULT_VALIDATED_EXECUTABLE_TYPES;
 		this.isExecutableValidationEnabled = true;
-		this.constraintMappingResourcePaths = newHashSet();
+		this.constraintMappingResourcePaths = newLinkedHashSet();
 		this.properties = newHashMap();
 	}
 
@@ -135,7 +135,7 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 
 	@Override
 	public Set<String> getConstraintMappingResourcePaths() {
-		return newHashSet( constraintMappingResourcePaths );
+		return newLinkedHashSet( constraintMappingResourcePaths );
 	}
 
 	@Override
@@ -145,7 +145,7 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 
 	@Override
 	public Set<ExecutableType> getDefaultValidatedExecutableTypes() {
-		return newHashSet( validatedExecutableTypes );
+		return newLinkedHashSet( validatedExecutableTypes );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedExecutableBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedExecutableBuilder.java
@@ -8,7 +8,7 @@ package org.hibernate.validator.internal.xml;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
@@ -76,7 +76,7 @@ class ConstrainedExecutableBuilder {
 	Set<ConstrainedExecutable> buildMethodConstrainedExecutable(List<MethodType> methods,
 																			  Class<?> beanClass,
 																			  String defaultPackage) {
-		Set<ConstrainedExecutable> constrainedExecutables = newHashSet();
+		Set<ConstrainedExecutable> constrainedExecutables = newLinkedHashSet();
 		List<Method> alreadyProcessedMethods = newArrayList();
 		for ( MethodType methodType : methods ) {
 			// parse the parameters
@@ -135,7 +135,7 @@ class ConstrainedExecutableBuilder {
 	Set<ConstrainedExecutable> buildConstructorConstrainedExecutable(List<ConstructorType> constructors,
 																				   Class<?> beanClass,
 																				   String defaultPackage) {
-		Set<ConstrainedExecutable> constrainedExecutables = newHashSet();
+		Set<ConstrainedExecutable> constrainedExecutables = newLinkedHashSet();
 		List<Constructor<?>> alreadyProcessedConstructors = newArrayList();
 		for ( ConstructorType constructorType : constructors ) {
 			// parse the parameters
@@ -206,7 +206,7 @@ class ConstrainedExecutableBuilder {
 		);
 
 		// parse the return value
-		Set<MetaConstraint<?>> returnValueConstraints = newHashSet();
+		Set<MetaConstraint<?>> returnValueConstraints = newLinkedHashSet();
 		Map<Class<?>, Class<?>> groupConversions = newHashMap();
 		boolean isCascaded = parseReturnValueType(
 				returnValueType,
@@ -235,7 +235,7 @@ class ConstrainedExecutableBuilder {
 																		 CrossParameterType crossParameterType,
 																		 Executable executable) {
 
-		Set<MetaConstraint<?>> crossParameterConstraints = newHashSet();
+		Set<MetaConstraint<?>> crossParameterConstraints = newLinkedHashSet();
 		if ( crossParameterType == null ) {
 			return crossParameterConstraints;
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedFieldBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedFieldBuilder.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.xml;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.reflect.Field;
 import java.security.AccessController;
@@ -51,12 +51,12 @@ class ConstrainedFieldBuilder {
 	Set<ConstrainedField> buildConstrainedFields(List<FieldType> fields,
 															   Class<?> beanClass,
 															   String defaultPackage) {
-		Set<ConstrainedField> constrainedFields = newHashSet();
+		Set<ConstrainedField> constrainedFields = newLinkedHashSet();
 		List<String> alreadyProcessedFieldNames = newArrayList();
 		for ( FieldType fieldType : fields ) {
 			Field field = findField( beanClass, fieldType.getName(), alreadyProcessedFieldNames );
 			ConstraintLocation constraintLocation = ConstraintLocation.forProperty( field );
-			Set<MetaConstraint<?>> metaConstraints = newHashSet();
+			Set<MetaConstraint<?>> metaConstraints = newLinkedHashSet();
 			for ( ConstraintType constraint : fieldType.getConstraint() ) {
 				MetaConstraint<?> metaConstraint = metaConstraintBuilder.buildMetaConstraint(
 						constraintLocation,

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedGetterBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedGetterBuilder.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.xml;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.reflect.Method;
 import java.security.AccessController;
@@ -52,14 +52,14 @@ class ConstrainedGetterBuilder {
 	Set<ConstrainedExecutable> buildConstrainedGetters(List<GetterType> getterList,
 																	 Class<?> beanClass,
 																	 String defaultPackage) {
-		Set<ConstrainedExecutable> constrainedExecutables = newHashSet();
+		Set<ConstrainedExecutable> constrainedExecutables = newLinkedHashSet();
 		List<String> alreadyProcessedGetterNames = newArrayList();
 		for ( GetterType getterType : getterList ) {
 			String getterName = getterType.getName();
 			Method getter = findGetter( beanClass, getterName, alreadyProcessedGetterNames );
 			ConstraintLocation constraintLocation = ConstraintLocation.forProperty( getter );
 
-			Set<MetaConstraint<?>> metaConstraints = newHashSet();
+			Set<MetaConstraint<?>> metaConstraints = newLinkedHashSet();
 			for ( ConstraintType constraint : getterType.getConstraint() ) {
 				MetaConstraint<?> metaConstraint = metaConstraintBuilder.buildMetaConstraint(
 						constraintLocation,

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedParameterBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedParameterBuilder.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.xml;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.lang.annotation.ElementType;
 import java.lang.reflect.Executable;
@@ -56,7 +56,7 @@ class ConstrainedParameterBuilder {
 		List<String> parameterNames = parameterNameProvider.getParameterNames( executable );
 		for ( ParameterType parameterType : parameterList ) {
 			ConstraintLocation constraintLocation = ConstraintLocation.forParameter( executable, i );
-			Set<MetaConstraint<?>> metaConstraints = newHashSet();
+			Set<MetaConstraint<?>> metaConstraints = newLinkedHashSet();
 			for ( ConstraintType constraint : parameterType.getConstraint() ) {
 				MetaConstraint<?> metaConstraint = metaConstraintBuilder.buildMetaConstraint(
 						constraintLocation,

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedTypeBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedTypeBuilder.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.xml;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.util.List;
 import java.util.Map;
@@ -57,7 +57,7 @@ class ConstrainedTypeBuilder {
 
 		// constraints
 		ConstraintLocation constraintLocation = ConstraintLocation.forClass( beanClass );
-		Set<MetaConstraint<?>> metaConstraints = newHashSet();
+		Set<MetaConstraint<?>> metaConstraints = newLinkedHashSet();
 		for ( ConstraintType constraint : classType.getConstraint() ) {
 			MetaConstraint<?> metaConstraint = metaConstraintBuilder.buildMetaConstraint(
 					constraintLocation,

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.internal.xml;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -60,7 +60,7 @@ public class MappingXmlParser {
 
 	private static final Log log = LoggerFactory.make();
 
-	private final Set<Class<?>> processedClasses = newHashSet();
+	private final Set<Class<?>> processedClasses = newLinkedHashSet();
 	private final ConstraintHelper constraintHelper;
 	private final AnnotationProcessingOptionsImpl annotationProcessingOptions;
 	private final Map<Class<?>, List<Class<?>>> defaultSequences;
@@ -136,7 +136,7 @@ public class MappingXmlParser {
 					annotationProcessingOptions
 			);
 
-			Set<String> alreadyProcessedConstraintDefinitions = newHashSet();
+			Set<String> alreadyProcessedConstraintDefinitions = newLinkedHashSet();
 			for ( InputStream in : mappingStreams ) {
 				// the InputStreams passed in parameters support mark and reset
 				in.mark( Integer.MAX_VALUE );
@@ -317,7 +317,7 @@ public class MappingXmlParser {
 			constrainedElements.get( beanClass ).add( constrainedElement );
 		}
 		else {
-			Set<ConstrainedElement> tmpList = newHashSet();
+			Set<ConstrainedElement> tmpList = newLinkedHashSet();
 			tmpList.add( constrainedElement );
 			constrainedElements.put( beanClass, tmpList );
 		}
@@ -339,7 +339,7 @@ public class MappingXmlParser {
 			existingConstrainedElements.addAll( newConstrainedElements );
 		}
 		else {
-			Set<ConstrainedElement> tmpSet = newHashSet();
+			Set<ConstrainedElement> tmpSet = newLinkedHashSet();
 			tmpSet.addAll( newConstrainedElements );
 			constrainedElements.put( beanClass, tmpSet );
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationBootstrapParameters.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationBootstrapParameters.java
@@ -27,7 +27,7 @@ import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
 import org.hibernate.validator.internal.util.privilegedactions.NewInstance;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 
 /**
  * @author Hardy Ferentschik
@@ -42,7 +42,7 @@ public class ValidationBootstrapParameters {
 	private ValidationProvider<?> provider;
 	private Class<? extends ValidationProvider<?>> providerClass = null;
 	private final Map<String, String> configProperties = newHashMap();
-	private final Set<InputStream> mappings = newHashSet();
+	private final Set<InputStream> mappings = newLinkedHashSet();
 
 	public ValidationBootstrapParameters() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationXmlParser.java
@@ -13,7 +13,7 @@ import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 import javax.validation.BootstrapConfiguration;
@@ -193,7 +193,7 @@ public class ValidationXmlParser {
 				config.getParameterNameProvider(),
 				defaultValidatedExecutableTypes,
 				executableValidationEnabled,
-				new HashSet<String>( config.getConstraintMapping() ),
+				new LinkedHashSet<String>( config.getConstraintMapping() ),
 				properties
 		);
 	}

--- a/engine/src/main/java/org/hibernate/validator/resourceloading/PlatformResourceBundleLocator.java
+++ b/engine/src/main/java/org/hibernate/validator/resourceloading/PlatformResourceBundleLocator.java
@@ -24,7 +24,7 @@ import org.hibernate.validator.internal.util.privilegedactions.GetResources;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
 import org.jboss.logging.Logger;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
 
 /**
@@ -204,7 +204,7 @@ public class PlatformResourceBundleLocator implements ResourceBundleLocator {
 
 		@Override
 		public Enumeration<String> getKeys() {
-			Set<String> keySet = newHashSet();
+			Set<String> keySet = newLinkedHashSet();
 			keySet.addAll( properties.stringPropertyNames() );
 			if ( parent != null ) {
 				keySet.addAll( Collections.list( parent.getKeys() ) );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/URLValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/URLValidatorTest.java
@@ -32,7 +32,7 @@ import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.ValidatorUtil;
 
 import static java.lang.annotation.ElementType.METHOD;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.testng.Assert.assertEquals;
@@ -391,7 +391,7 @@ public class URLValidatorTest {
 	}
 
 	private static class DelegatingConstraintValidatorFactory implements ConstraintValidatorFactory {
-		private final Set<Class<?>> requestedConstraintValidators = newHashSet();
+		private final Set<Class<?>> requestedConstraintValidators = newLinkedHashSet();
 		private final ConstraintValidatorFactory delegate;
 
 		private DelegatingConstraintValidatorFactory(ConstraintValidatorFactory delegate) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/BeanDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/BeanDescriptorTest.java
@@ -8,7 +8,7 @@ package org.hibernate.validator.test.internal.metadata.descriptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 import static org.hibernate.validator.testutils.ValidatorUtil.getBeanDescriptor;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -373,7 +373,7 @@ public class BeanDescriptorTest {
 	}
 
 	private Set<String> getMethodNames(Set<MethodDescriptor> descriptors) {
-		Set<String> methodNames = newHashSet();
+		Set<String> methodNames = newLinkedHashSet();
 
 		for ( MethodDescriptor methodDescriptor : descriptors ) {
 			methodNames.add( methodDescriptor.getName() );
@@ -383,7 +383,7 @@ public class BeanDescriptorTest {
 	}
 
 	private Set<List<Class<?>>> getSignatures(Set<ConstructorDescriptor> descriptors) {
-		Set<List<Class<?>>> signatures = newHashSet();
+		Set<List<Class<?>>> signatures = newLinkedHashSet();
 
 		for ( ConstructorDescriptor methodDescriptor : descriptors ) {
 			List<Class<?>> parameterTypes = newArrayList();

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/ConstraintDescriptorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/descriptor/ConstraintDescriptorTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.METHOD;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 import static org.hibernate.validator.testutils.ValidatorUtil.getBeanDescriptor;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -49,11 +49,11 @@ public class ConstraintDescriptorTest {
 		ConstraintDescriptor<?> constraintDescriptor = constraintDescriptors.iterator().next();
 		assertEquals( constraintDescriptor.getMessageTemplate(), "bar", "Wrong message" );
 
-		Set<Class<?>> groups = newHashSet();
+		Set<Class<?>> groups = newLinkedHashSet();
 		groups.add( SnafuGroup.class );
 		assertEquals( constraintDescriptor.getGroups(), groups, "Wrong groups" );
 
-		Set<Class<?>> payloads = newHashSet();
+		Set<Class<?>> payloads = newLinkedHashSet();
 		payloads.add( Payload22.class );
 		assertEquals( constraintDescriptor.getPayload(), payloads, "Wrong payload" );
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.xml;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+import static org.hibernate.validator.internal.util.CollectionHelper.newLinkedHashSet;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -54,7 +54,7 @@ public class MappingXmlParserTest {
 		assertFalse( validatorDescriptors.isEmpty(), "Wrong number of default validators" );
 		assertEquals( getIndex( validatorDescriptors, DecimalMinValidatorForFoo.class ), -1, "The custom validator must be absent" );
 
-		Set<InputStream> mappingStreams = newHashSet();
+		Set<InputStream> mappingStreams = newLinkedHashSet();
 		mappingStreams.add( MappingXmlParserTest.class.getResourceAsStream( "decimal-min-mapping-1.xml" ) );
 
 		xmlMappingParser.parse( mappingStreams );
@@ -82,7 +82,7 @@ public class MappingXmlParserTest {
 	@Test
 	@TestForIssue(jiraKey = "HV-782")
 	public void testOverridingOfConstraintValidatorsFromMultipleMappingFilesThrowsException() {
-		Set<InputStream> mappingStreams = newHashSet();
+		Set<InputStream> mappingStreams = newLinkedHashSet();
 		mappingStreams.add( MappingXmlParserTest.class.getResourceAsStream( "decimal-min-mapping-1.xml" ) );
 		mappingStreams.add( MappingXmlParserTest.class.getResourceAsStream( "decimal-min-mapping-2.xml" ) );
 


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1188

The only place where `new HashSet` or `import java.util.HashSet` is left is in the tests and in the `hibernate-validator-performance` and `hibernate-validator-test-utils` projects.
I think about to also replace this occurrences with `LinkedHashSet` - so it's obvious for everybody that no `HashSet` are used anymore...

PS: I signed the CLA already.