### PR TITLE
HV-1193 Avoid systematic resizing of collections when we provide a size

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/util/CollectionHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/CollectionHelper.java
@@ -34,7 +34,7 @@ public final class CollectionHelper {
 	}
 
 	public static <K, V> HashMap<K, V> newHashMap(int size) {
-		return new HashMap<K, V>( size );
+		return new HashMap<K, V>( getInitialCapacityFromExpectedSize( size ) );
 	}
 
 	public static <K, V> HashMap<K, V> newHashMap(Map<K, V> map) {
@@ -50,7 +50,7 @@ public final class CollectionHelper {
 	}
 
 	public static <T> HashSet<T> newHashSet(int size) {
-		return new HashSet<T>( size );
+		return new HashSet<T>( getInitialCapacityFromExpectedSize( size ) );
 	}
 
 	public static <T> HashSet<T> newHashSet(Collection<? extends T> c) {
@@ -76,7 +76,7 @@ public final class CollectionHelper {
 	}
 
 	public static <T> ArrayList<T> newArrayList(int size) {
-		return new ArrayList<T>( size );
+		return new ArrayList<T>( getInitialCapacityFromExpectedSize( size ) );
 	}
 
 	@SafeVarargs
@@ -134,6 +134,21 @@ public final class CollectionHelper {
 			throw new IllegalArgumentException( "Provided object " + object + " is not a supported array type" );
 		}
 		return iterator;
+	}
+
+	/**
+	 * As the default loadFactor is of 0.75, we need to calculate the initial capacity from the expected size to avoid
+	 * resizing the collection when we populate the collection with all the initial elements. We use a calculation
+	 * similar to what is done in {@link HashMap#putAll(Map)}.
+	 *
+	 * @param expectedSize the expected size of the collection
+	 * @return the initial capacity of the collection
+	 */
+	private static int getInitialCapacityFromExpectedSize(int expectedSize) {
+		if ( expectedSize < 3 ) {
+			return expectedSize + 1;
+		}
+		return (int) ( (float) expectedSize / 0.75f + 1.0f );
 	}
 
 	private static class ObjectArrayIterator implements Iterator<Object> {

--- a/engine/src/main/java/org/hibernate/validator/internal/util/CollectionHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/CollectionHelper.java
@@ -57,12 +57,6 @@ public final class CollectionHelper {
 		return new HashSet<T>( c );
 	}
 
-	public static <T> HashSet<T> newHashSet(Collection<? extends T> s1, Collection<? extends T> s2) {
-		HashSet<T> set = CollectionHelper.<T>newHashSet( s1 );
-		set.addAll( s2 );
-		return set;
-	}
-
 	public static <T> HashSet<T> newHashSet(Iterable<? extends T> iterable) {
 		HashSet<T> set = newHashSet();
 		for ( T t : iterable ) {
@@ -76,7 +70,7 @@ public final class CollectionHelper {
 	}
 
 	public static <T> ArrayList<T> newArrayList(int size) {
-		return new ArrayList<T>( getInitialCapacityFromExpectedSize( size ) );
+		return new ArrayList<T>( size );
 	}
 
 	@SafeVarargs


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1193

Even if it's just to stop having this conversation over and over again, I think it's worth it. I expect the calculation to be inlined so it shouldn't cost a lot.

Having a systematic resizing when we provide a size is definitely something we should avoid.