### PR TITLE
HV-1198 Avoid epoch conversion overflow in @Past/@Future validators

### DIFF
--- a/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/TypeAnnotationConstraintTest.java
+++ b/engine-jdk8-tests/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/TypeAnnotationConstraintTest.java
@@ -35,7 +35,6 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.apache.log4j.Logger;
-import org.hibernate.validator.constraints.NotBlank;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.testutil.MessageLoggedAssertionLogger;
 import org.hibernate.validator.testutil.TestForIssue;

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/future/FutureValidatorForChronoZonedDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/future/FutureValidatorForChronoZonedDateTime.java
@@ -6,7 +6,10 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.future;
 
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.time.chrono.ChronoZonedDateTime;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.constraints.Future;
@@ -19,6 +22,7 @@ import org.hibernate.validator.spi.time.TimeProvider;
  * Check that the {@code java.time.chrono.ChronoZonedDateTime} passed is in the future.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 @IgnoreJava6Requirement
 public class FutureValidatorForChronoZonedDateTime implements ConstraintValidator<Future, ChronoZonedDateTime<?>> {
@@ -37,8 +41,8 @@ public class FutureValidatorForChronoZonedDateTime implements ConstraintValidato
 
 		TimeProvider timeProvider = context.unwrap( HibernateConstraintValidatorContext.class )
 				.getTimeProvider();
-		long now = timeProvider.getCurrentTime();
+		ZonedDateTime reference = ZonedDateTime.ofInstant( Instant.ofEpochMilli( timeProvider.getCurrentTime() ), value.getZone() );
 
-		return value.toInstant().toEpochMilli() > now;
+		return value.compareTo( reference ) > 0;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/future/FutureValidatorForInstant.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/future/FutureValidatorForInstant.java
@@ -19,6 +19,7 @@ import org.hibernate.validator.spi.time.TimeProvider;
  * Check that the {@code java.time.Instant} passed is in the future.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 @IgnoreJava6Requirement
 public class FutureValidatorForInstant implements ConstraintValidator<Future, Instant> {
@@ -37,8 +38,8 @@ public class FutureValidatorForInstant implements ConstraintValidator<Future, In
 
 		TimeProvider timeProvider = context.unwrap( HibernateConstraintValidatorContext.class )
 				.getTimeProvider();
-		long now = timeProvider.getCurrentTime();
+		Instant reference = Instant.ofEpochMilli( timeProvider.getCurrentTime() );
 
-		return value.toEpochMilli() > now;
+		return value.compareTo( reference ) > 0;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/future/FutureValidatorForOffsetDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/future/FutureValidatorForOffsetDateTime.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.future;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
+
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.constraints.Future;
@@ -37,8 +39,8 @@ public class FutureValidatorForOffsetDateTime implements ConstraintValidator<Fut
 
 		TimeProvider timeProvider = context.unwrap( HibernateConstraintValidatorContext.class )
 				.getTimeProvider();
-		long now = timeProvider.getCurrentTime();
+		OffsetDateTime reference = OffsetDateTime.ofInstant( Instant.ofEpochMilli( timeProvider.getCurrentTime() ), value.getOffset() );
 
-		return value.toInstant().toEpochMilli() > now;
+		return value.compareTo( reference ) > 0;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/past/PastValidatorForChronoZonedDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/past/PastValidatorForChronoZonedDateTime.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.past;
 
+import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.time.chrono.ChronoZonedDateTime;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -19,6 +21,7 @@ import org.hibernate.validator.spi.time.TimeProvider;
  * Check that the {@code java.time.chrono.ChronoZonedDateTime} passed is in the past.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 @IgnoreJava6Requirement
 public class PastValidatorForChronoZonedDateTime implements ConstraintValidator<Past, ChronoZonedDateTime<?>> {
@@ -37,8 +40,8 @@ public class PastValidatorForChronoZonedDateTime implements ConstraintValidator<
 
 		TimeProvider timeProvider = context.unwrap( HibernateConstraintValidatorContext.class )
 				.getTimeProvider();
-		long now = timeProvider.getCurrentTime();
+		ZonedDateTime reference = ZonedDateTime.ofInstant( Instant.ofEpochMilli( timeProvider.getCurrentTime() ), value.getZone() );
 
-		return value.toInstant().toEpochMilli() < now;
+		return value.compareTo( reference ) < 0;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/past/PastValidatorForInstant.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/past/PastValidatorForInstant.java
@@ -19,6 +19,7 @@ import org.hibernate.validator.spi.time.TimeProvider;
  * Check that the {@code java.time.Instant} passed is in the past.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 @IgnoreJava6Requirement
 public class PastValidatorForInstant implements ConstraintValidator<Past, Instant> {
@@ -37,8 +38,8 @@ public class PastValidatorForInstant implements ConstraintValidator<Past, Instan
 
 		TimeProvider timeProvider = context.unwrap( HibernateConstraintValidatorContext.class )
 				.getTimeProvider();
-		long now = timeProvider.getCurrentTime();
+		Instant reference = Instant.ofEpochMilli( timeProvider.getCurrentTime() );
 
-		return value.toEpochMilli() < now;
+		return value.compareTo( reference ) < 0;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/past/PastValidatorForOffsetDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/past/PastValidatorForOffsetDateTime.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.past;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
@@ -19,6 +20,7 @@ import org.hibernate.validator.spi.time.TimeProvider;
  * Check that the {@code java.time.OffsetDateTime} passed is in the past.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 @IgnoreJava6Requirement
 public class PastValidatorForOffsetDateTime implements ConstraintValidator<Past, OffsetDateTime> {
@@ -37,8 +39,8 @@ public class PastValidatorForOffsetDateTime implements ConstraintValidator<Past,
 
 		TimeProvider timeProvider = context.unwrap( HibernateConstraintValidatorContext.class )
 				.getTimeProvider();
-		long now = timeProvider.getCurrentTime();
+		OffsetDateTime reference = OffsetDateTime.ofInstant( Instant.ofEpochMilli( timeProvider.getCurrentTime() ), value.getOffset() );
 
-		return value.toInstant().toEpochMilli() < now;
+		return value.compareTo( reference ) < 0;
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/FutureValidatorForChronoZonedDateTimeTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/FutureValidatorForChronoZonedDateTimeTest.java
@@ -6,22 +6,26 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv.future;
 
+import static org.hibernate.validator.testutils.ValidatorUtil.getConstraintValidatorContext;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
+import org.hibernate.validator.internal.constraintvalidators.bv.future.FutureValidatorForChronoZonedDateTime;
+import org.hibernate.validator.testutil.TestForIssue;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.hibernate.validator.internal.constraintvalidators.bv.future.FutureValidatorForChronoZonedDateTime;
-
-import static org.hibernate.validator.testutils.ValidatorUtil.getConstraintValidatorContext;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 /**
  * Tests for {@link org.hibernate.validator.internal.constraintvalidators.bv.future.FutureValidatorForChronoZonedDateTime}.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 public class FutureValidatorForChronoZonedDateTimeTest {
 
@@ -44,5 +48,13 @@ public class FutureValidatorForChronoZonedDateTimeTest {
 			assertTrue( constraint.isValid( future, getConstraintValidatorContext() ), "Future ZonedDateTime '" + future + "' fails validation." );
 			assertFalse( constraint.isValid( past, getConstraintValidatorContext() ), "Past ZonedDateTime '" + past + "' validated as future." );
 		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1198")
+	public void testEpochOverflow() {
+		ZonedDateTime future = ZonedDateTime.of( LocalDate.MAX, LocalTime.MAX, ZoneId.of( "GMT" ) );
+
+		assertTrue( constraint.isValid( future, getConstraintValidatorContext() ), "Future ZonedDateTime '" + future + "' fails validation." );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/FutureValidatorForInstantTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/FutureValidatorForInstantTest.java
@@ -6,20 +6,22 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv.future;
 
-import java.time.Instant;
-
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-import org.hibernate.validator.internal.constraintvalidators.bv.future.FutureValidatorForInstant;
-
 import static org.hibernate.validator.testutils.ValidatorUtil.getConstraintValidatorContext;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+
+import java.time.Instant;
+
+import org.hibernate.validator.internal.constraintvalidators.bv.future.FutureValidatorForInstant;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 /**
  * Tests for {@link org.hibernate.validator.internal.constraintvalidators.bv.future.FutureValidatorForInstant}.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 public class FutureValidatorForInstantTest {
 
@@ -38,5 +40,13 @@ public class FutureValidatorForInstantTest {
 		assertTrue( constraint.isValid( null, null ), "null fails validation." );
 		assertTrue( constraint.isValid( future, getConstraintValidatorContext() ), "Future Instant '" + future + "' fails validation." );
 		assertFalse( constraint.isValid( past, getConstraintValidatorContext() ), "Past Instant '" + past + "' validated as future." );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1198")
+	public void testEpochOverflow() {
+		Instant future = Instant.MAX;
+
+		assertTrue( constraint.isValid( future, getConstraintValidatorContext() ), "Future Instant '" + future + "' fails validation." );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/FutureValidatorForOffsetDateTimeTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/future/FutureValidatorForOffsetDateTimeTest.java
@@ -6,21 +6,23 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv.future;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-import org.hibernate.validator.internal.constraintvalidators.bv.future.FutureValidatorForOffsetDateTime;
-
 import static org.hibernate.validator.testutils.ValidatorUtil.getConstraintValidatorContext;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import org.hibernate.validator.internal.constraintvalidators.bv.future.FutureValidatorForOffsetDateTime;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 /**
  * Tests for {@link org.hibernate.validator.internal.constraintvalidators.bv.future.FutureValidatorForOffsetDateTime}.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 public class FutureValidatorForOffsetDateTimeTest {
 
@@ -43,5 +45,13 @@ public class FutureValidatorForOffsetDateTimeTest {
 			assertTrue( constraint.isValid( future, getConstraintValidatorContext() ), "Future OffsetDateTime '" + future + "' fails validation." );
 			assertFalse( constraint.isValid( past, getConstraintValidatorContext() ), "Past OffsetDateTime '" + past + "' validated as future." );
 		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1198")
+	public void testEpochOverflow() {
+		OffsetDateTime future = OffsetDateTime.MAX;
+
+		assertTrue( constraint.isValid( future, getConstraintValidatorContext() ), "Future OffsetDateTime '" + future + "' fails validation." );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForChronoZonedDateTimeTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForChronoZonedDateTimeTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv.past;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -13,6 +15,7 @@ import java.time.ZonedDateTime;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.hibernate.validator.internal.constraintvalidators.bv.past.PastValidatorForChronoZonedDateTime;
+import org.hibernate.validator.testutil.TestForIssue;
 
 import static org.hibernate.validator.testutils.ValidatorUtil.getConstraintValidatorContext;
 import static org.testng.Assert.assertFalse;
@@ -22,6 +25,7 @@ import static org.testng.Assert.assertTrue;
  * Tests for {@link org.hibernate.validator.internal.constraintvalidators.bv.past.PastValidatorForChronoZonedDateTime}.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 public class PastValidatorForChronoZonedDateTimeTest {
 
@@ -44,5 +48,13 @@ public class PastValidatorForChronoZonedDateTimeTest {
 			assertTrue( constraint.isValid( past, getConstraintValidatorContext() ), "Past ZonedDateTime '" + past + "' fails validation." );
 			assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future ZonedDateTime '" + future + "' validated as past." );
 		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1198")
+	public void testEpochOverflow() {
+		ZonedDateTime future = ZonedDateTime.of( LocalDate.MAX, LocalTime.MAX, ZoneId.of( "GMT" ) );
+
+		assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future ZonedDateTime '" + future + "' fails validation." );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForInstantTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForInstantTest.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.hibernate.validator.internal.constraintvalidators.bv.past.PastValidatorForInstant;
+import org.hibernate.validator.testutil.TestForIssue;
 
 import static org.hibernate.validator.testutils.ValidatorUtil.getConstraintValidatorContext;
 import static org.testng.Assert.assertFalse;
@@ -20,6 +21,7 @@ import static org.testng.Assert.assertTrue;
  * Tests for {@link org.hibernate.validator.internal.constraintvalidators.bv.past.PastValidatorForInstant}.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 public class PastValidatorForInstantTest {
 
@@ -38,5 +40,13 @@ public class PastValidatorForInstantTest {
 		assertTrue( constraint.isValid( null, null ), "null fails validation." );
 		assertTrue( constraint.isValid( past, getConstraintValidatorContext() ), "Past Instant '" + past + "' fails validation." );
 		assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future Instant '" + future + "' validated as past." );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1198")
+	public void testEpochOverflow() {
+		Instant past = Instant.MAX;
+
+		assertFalse( constraint.isValid( past, getConstraintValidatorContext() ), "Future Instant '" + past + "' fails validation." );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForOffsetDateTimeTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/past/PastValidatorForOffsetDateTimeTest.java
@@ -6,21 +6,23 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv.past;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
-
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
-import org.hibernate.validator.internal.constraintvalidators.bv.past.PastValidatorForOffsetDateTime;
-
 import static org.hibernate.validator.testutils.ValidatorUtil.getConstraintValidatorContext;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import org.hibernate.validator.internal.constraintvalidators.bv.past.PastValidatorForOffsetDateTime;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 /**
  * Tests for {@link org.hibernate.validator.internal.constraintvalidators.bv.past.PastValidatorForOffsetDateTime}.
  *
  * @author Khalid Alqinyah
+ * @author Guillaume Smet
  */
 public class PastValidatorForOffsetDateTimeTest {
 
@@ -43,5 +45,13 @@ public class PastValidatorForOffsetDateTimeTest {
 			assertTrue( constraint.isValid( past, getConstraintValidatorContext() ), "Past OffsetDateTime '" + past + "' fails validation." );
 			assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future OffsetDateTime '" + future + "' validated as past." );
 		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1198")
+	public void testEpochOverflow() {
+		OffsetDateTime future = OffsetDateTime.MAX;
+
+		assertFalse( constraint.isValid( future, getConstraintValidatorContext() ), "Future OffsetDateTime '" + future + "' fails validation." );
 	}
 }


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1198

This is for 5.4.

master is not concerned by this issue but I'll forward port the tests once we have merged this one.