### PR TITLE
HV-1223 Setting up jqAssistant

### DIFF
--- a/jqassistant/rules.xml
+++ b/jqassistant/rules.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.0">
+
+    <constraint id="my-rules:PublicTypesMayNotExtendInternalTypes">
+        <description>API/SPI types must not extend/implement internal types.</description>
+        <cypher><![CDATA[
+            MATCH
+                (class)-[:`EXTENDS`]->(supertype)
+            WHERE
+                NOT class.fqn =~ ".*\\.internal\\..*"
+                AND supertype.fqn =~ ".*\\.internal\\..*"
+            RETURN
+                class
+            UNION ALL
+            MATCH
+                (class)-[:`IMPLEMENTS`]->(supertype)
+            WHERE
+                NOT class.fqn =~ ".*\\.internal\\..*"
+                AND supertype.fqn =~ ".*\\.internal\\..*"
+            RETURN
+                class
+        ]]></cypher>
+    </constraint>
+
+    <constraint id="my-rules:PublicMethodsMayNotExposeInternalTypes">
+        <description>API/SPI methods must not expose internal types.</description>
+        <cypher><![CDATA[
+            // return values
+            MATCH
+                (class)-[:`DECLARES`]->(method)-[:`RETURNS`]->(returntype)
+            WHERE
+                NOT class.fqn =~ ".*\\.internal\\..*"
+                AND (method.visibility="public" OR method.visibility="protected")
+                AND returntype.fqn =~ ".*\\.internal\\..*"
+            RETURN
+                method
+
+            // parameters
+            UNION ALL
+            MATCH
+                (class)-[:`DECLARES`]->(method)-[:`HAS`]->(parameter)-[:`OF_TYPE`]->(parametertype)
+            WHERE
+                NOT class.fqn =~ ".*\\.internal\\..*"
+                AND (method.visibility="public" OR method.visibility="protected")
+                AND parametertype.fqn =~ ".*\\.internal\\..*"
+            RETURN
+                method
+        ]]></cypher>
+    </constraint>
+
+    <constraint id="my-rules:PublicFieldsMayNotExposeInternalTypes">
+        <description>API/SPI fields must not expose internal types.</description>
+        <cypher><![CDATA[
+            MATCH
+                (class)-[:`DECLARES`]->(field)-[:`OF_TYPE`]->(fieldtype)
+            WHERE
+                NOT class.fqn =~ ".*\\.internal\\..*"
+                AND (field.visibility="public" OR field.visibility="protected")
+                AND fieldtype.fqn =~ ".*\\.internal\\..*"
+            RETURN
+                field
+        ]]></cypher>
+    </constraint>
+
+    <group id="default">
+        <includeConstraint refId="my-rules:PublicTypesMayNotExtendInternalTypes" />
+        <includeConstraint refId="my-rules:PublicMethodsMayNotExposeInternalTypes" />
+        <includeConstraint refId="my-rules:PublicFieldsMayNotExposeInternalTypes" />
+    </group>
+
+</jqa:jqassistant-rules>

--- a/pom.xml
+++ b/pom.xml
@@ -1041,16 +1041,13 @@
                         <version>1.1.4</version>
                         <executions>
                             <execution>
-                                <id>scan</id>
                                 <goals>
                                     <goal>scan</goal>
-                                </goals>
-                            </execution>
-                            <execution>
-                                <id>analyze</id>
-                                <goals>
                                     <goal>analyze</goal>
                                 </goals>
+                                <configuration>
+                                    <failOnViolations>true</failOnViolations>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1031,5 +1031,31 @@
                 </pluginManagement>
             </build>
         </profile>
+        <profile>
+            <id>jqassistant</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.buschmais.jqassistant.scm</groupId>
+                        <artifactId>jqassistant-maven-plugin</artifactId>
+                        <version>1.1.4</version>
+                        <executions>
+                            <execution>
+                                <id>scan</id>
+                                <goals>
+                                    <goal>scan</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>analyze</id>
+                                <goals>
+                                    <goal>analyze</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
@gsmet That sets up the tooling we discussed.

Run it like this:

     mvn jqassistant:server -pl engine -Pjqassistant

For running the server, allowing to explore the project structure interactively (go to http://localhost:7474/browser/)

Run this to run the rule check:

    mvn clean install -pl engine -Pjqassistant -DskipTests=true

E.g. create a public constant exposing an internal type to see it in action.

I've put it into a separate profile as it takes some build time, but we can have job on CI executing it.