### PR TITLE
HV-1216 Avoid usage of tables in reference docs where feasible

### DIFF
--- a/documentation/src/main/asciidoc/ch02.asciidoc
+++ b/documentation/src/main/asciidoc/ch02.asciidoc
@@ -419,23 +419,33 @@ determined. <<table-constraint-violation>> gives an overview of these methods. T
 
 [[table-constraint-violation]]
 .The various `ConstraintViolation` methods
-[options="header"]
-|===============
-|Method|Usage|Example
-|`getMessage()`|The interpolated error message|"may not be null"
-|`getMessageTemplate()`|The non-interpolated error message|"{... NotNull.message}"
-|`getRootBean()`|The root bean being validated|car
-|`getRootBeanClass()`|The class of the root bean being validated|`Car.class`
-|`getLeafBean()`|If a bean constraint, the bean instance the constraint is
-              applied on; If a property constraint, the bean instance hosting
-              the property the constraint is applied on|`car`
-|`getPropertyPath()`|The property path to the validated value from root
-              bean|contains one node with kind
-              `PROPERTY` and name "manufacturer"
-|`getInvalidValue()`|The value failing to pass the constraint|`null`
-|`getConstraintDescriptor()`|Constraint metadata reported to fail|descriptor for `@NotNull`
-
-|===============
+//[horizontal]
+`getMessage()`::
+	Usage::: The interpolated error message
+	Example::: "may not be null"
+`getMessageTemplate()`::
+	Usage::: The non-interpolated error message
+	Example::: "{... NotNull.message}"
+`getRootBean()`::
+	Usage::: The root bean being validated
+	Example::: car
+`getRootBeanClass()`::
+	Usage::: The class of the root bean being validated
+	Example::: `Car.class`
+`getLeafBean()`::
+	Usage::: If a bean constraint, the bean instance the constraint is
+             applied on; If a property constraint, the bean instance hosting
+             the property the constraint is applied on
+	Example::: `car`
+`getPropertyPath()`::
+	Usage::: The property path to the validated value from root bean
+	Example::: contains one node with kind `PROPERTY` and name "manufacturer"
+`getInvalidValue()`::
+	Usage::: The value failing to pass the constraint
+	Example::: `null`
+`getConstraintDescriptor()`::
+	Usage::: Constraint metadata reported to fail
+	Example::: descriptor for `@NotNull`
 
 
 [[section-builtin-constraints]]
@@ -466,129 +476,64 @@ impact portability of your application between Bean Validation providers.
 
 [[table-spec-constraints]]
 .Bean Validation constraints
-[options="header"]
-|===============
-|Annotation|Supported data types|Use|Hibernate metadata impact
-|`@AssertFalse`|`Boolean`,
-              `boolean`|Checks that the annotated element is
-              false|None
-|`@AssertTrue`|`Boolean`,
-              `boolean`|Checks that the annotated element is
-              true|None
-|`@DecimalMax(value=,inclusive=)`|`BigDecimal`,
-              `BigInteger`,
-              `CharSequence`,
-              `byte`, `short`,
-              `int`, `long` and the
-              respective wrappers of the primitive types; Additionally
-              supported by HV: any sub-type of
-              `Number` and `javax.money.MonetaryAmount` (if the https://jcp.org/en/jsr/detail?id=354[JSR 354 API] and an implementation is on the class path)|Checks whether the annotated value is less than the
-              specified maximum, when inclusive=false.
-              Otherwise whether the value is less than or equal to the
-              specified maximum. The parameter value is
-              the string representation of the max value according to the
-              `BigDecimal` string representation.|None
-|`@DecimalMin(value=,inclusive=)`|`BigDecimal`,
-              `BigInteger`,
-              `CharSequence`,
-              `byte`, `short`,
-              `int`, `long` and the
-              respective wrappers of the primitive types; Additionally
-              supported by HV: any sub-type of
-              `Number` and `javax.money.MonetaryAmount`|Checks whether the annotated value is larger than the
-              specified minimum, when inclusive=false.
-              Otherwise whether the value is larger than or equal to the
-              specified minimum. The parameter value is
-              the string representation of the min value according to the
-              `BigDecimal` string representation.|None
-|`@Digits(integer=,fraction=)`|BigDecimal,
-              `BigInteger`,
-              `CharSequence`,
-              `byte`, `short`,
-              `int`, `long` and the
-              respective wrappers of the primitive types; Additionally
-              supported by HV: any sub-type of
-              `Number`|Checks whether the annotated value is a number having up to
-              `integer` digits and
-              `fraction` fractional digits|Defines column precision and scale
-|`@Future`|`java.util.Date`,
-              `java.util.Calendar`,
-              `java.time.Instant`,
-              `java.time.LocalDate`,
-              `java.time.LocalDateTime`,
-              `java.time.LocalTime`,
-              `java.time.MonthDay`,
-              `java.time.OffsetDateTime`,
-              `java.time.OffsetTime`,
-              `java.time.Year`,
-              `java.time.YearMonth`,
-              `java.time.ZonedDateTime`,
-              `java.time.chrono.HijrahDate`,
-              `java.time.chrono.JapaneseDate`,
-              `java.time.chrono.MinguoDate`,
-              `java.time.chrono.ThaiBuddhistDate`; Additionally
-              supported by HV, if the http://www.joda.org/joda-time/[Joda Time]
-              date/time API is on the classpath: any implementations of
-              `ReadablePartial` and
-              `ReadableInstant`|Checks whether the annotated date is in the
-              future|None
-|`@Max(value=)`|`BigDecimal`,
-              `BigInteger`, `byte`,
-              `short`, `int`,
-              `long` and the respective wrappers of the
-              primitive types; Additionally supported by HV: any sub-type of
-              `CharSequence` (the numeric value
-              represented by the character sequence is evaluated), any
-              sub-type of `Number` and `javax.money.MonetaryAmount`|Checks whether the annotated value is less than or equal
-              to the specified maximum|Adds a check constraint on the column
-|`@Min(value=)`|`BigDecimal`,
-              `BigInteger`, `byte`,
-              `short`, `int`,
-              `long` and the respective wrappers of the
-              primitive types; Additionally supported by HV: any sub-type of
-              `CharSequence` (the numeric value
-              represented by the char sequence is evaluated), any sub-type of
-              `Number` and `javax.money.MonetaryAmount`|Checks whether the annotated value is higher than or
-              equal to the specified minimum|Adds a check constraint on the column
-|`@NotNull`|Any type|Checks that the annotated value is not
-              `null`.|Column(s) are not nullable
-|`@Null`|Any type|Checks that the annotated value is
-              `null`|None
-|`@Past`|`java.util.Date`,
-              `java.util.Calendar`,
-              `java.time.Instant`,
-              `java.time.LocalDate`,
-              `java.time.LocalDateTime`,
-              `java.time.LocalTime`,
-              `java.time.MonthDay`,
-              `java.time.OffsetDateTime`,
-              `java.time.OffsetTime`,
-              `java.time.Year`,
-              `java.time.YearMonth`,
-              `java.time.ZonedDateTime`,
-              `java.time.chrono.HijrahDate`,
-              `java.time.chrono.JapaneseDate`,
-              `java.time.chrono.MinguoDate`,
-              `java.time.chrono.ThaiBuddhistDate`; Additionally
-              supported by HV, if the http://www.joda.org/joda-time/[Joda Time]
-              date/time API is on the classpath: any implementations of
-              `ReadablePartial` and
-              `ReadableInstant`|Checks whether the annotated date is in the
-              past|None
-|`@Pattern(regex=,flags=)`|`CharSequence`|Checks if the annotated string matches the regular
-              expression `regex` considering the given
-              flag `match`|None
-|`@Size(min=, max=)`|`CharSequence`,
-              `Collection`, `Map`
-              and arrays|Checks if the annotated element's size is between `min` and
-              `max` (inclusive)|Column length will be set to
-              `max`
-|`@Valid`|Any non-primitive type|Performs validation recursively on the associated object.
-              If the object is a collection or an array, the elements are
-              validated recursively. If the object is a map, the value
-              elements are validated recursively.|None
 
-|===============
+//[horizontal]
+`@AssertFalse`::
+	*Supported data types*::: `Boolean`, `boolean`
+	*Use*::: Checks that the annotated element is false
+	*Hibernate metadata impact*::: None
+`@AssertTrue`::
+	*Supported data types*::: `Boolean`, `boolean`
+	*Use*::: Checks that the annotated element is true
+	*Hibernate metadata impact*::: None
+`@DecimalMax(value=,inclusive=)`::
+	*Supported data types*::: `BigDecimal`, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types; Additionally supported by HV: any sub-type of `Number` and `javax.money.MonetaryAmount` (if the https://jcp.org/en/jsr/detail?id=354[JSR 354 API] and an implementation is on the class path)
+	*Use*::: Checks whether the annotated value is less than the specified maximum, when `inclusive`=false. Otherwise whether the value is less than or equal to the specified maximum. The parameter value is the string representation of the max value according to the `BigDecimal` string representation.
+	*Hibernate metadata impact*::: None
+`@DecimalMin(value=,inclusive=)`::
+	*Supported data types*::: `BigDecimal`, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types; Additionally supported by HV: any sub-type of `Number` and `javax.money.MonetaryAmount`
+	*Use*::: Checks whether the annotated value is larger than the specified minimum, when `inclusive`=false. Otherwise whether the value is larger than or equal to the specified minimum. The parameter value is the string representation of the min value according to the `BigDecimal` string representation.
+	*Hibernate metadata impact*::: None
+`@Digits(integer=,fraction=)`::
+	*Supported data types*::: BigDecimal, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types; Additionally supported by HV: any sub-type of `Number`
+	*Use*::: Checks whether the annotated value is a number having up to `integer` digits and `fraction` fractional digits
+	*Hibernate metadata impact*::: Defines column precision and scale
+`@Future`::
+	*Supported data types*::: `java.util.Date`, `java.util.Calendar`, `java.time.Instant`, `java.time.LocalDate`, `java.time.LocalDateTime`, `java.time.LocalTime`, `java.time.MonthDay`, `java.time.OffsetDateTime`, `java.time.OffsetTime`, `java.time.Year`, `java.time.YearMonth`, `java.time.ZonedDateTime`, `java.time.chrono.HijrahDate`, `java.time.chrono.JapaneseDate`, `java.time.chrono.MinguoDate`, `java.time.chrono.ThaiBuddhistDate`; Additionally supported by HV, if the http://www.joda.org/joda-time/[Joda Time] date/time API is on the classpath: any implementations of `ReadablePartial` and `ReadableInstant`
+	*Use*::: Checks whether the annotated date is in the future
+	*Hibernate metadata impact*::: None
+`@Max(value=)`::
+	*Supported data types*::: `BigDecimal`, `BigInteger`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types; Additionally supported by HV: any sub-type of `CharSequence` (the numeric value represented by the character sequence is evaluated), any sub-type of `Number` and `javax.money.MonetaryAmount`
+	*Use*::: Checks whether the annotated value is less than or equal to the specified maximum
+	*Hibernate metadata impact*::: Adds a check constraint on the column
+`@Min(value=)`::
+	*Supported data types*::: `BigDecimal`, `BigInteger`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types; Additionally supported by HV: any sub-type of `CharSequence` (the numeric value represented by the character sequence is evaluated), any sub-type of `Number` and `javax.money.MonetaryAmount`
+	*Use*::: Checks whether the annotated value is higher than or equal to the specified minimum
+	*Hibernate metadata impact*::: Adds a check constraint on the column
+`@NotNull`::
+	*Supported data types*::: Any type
+	*Use*::: hecks that the annotated value is not `null`
+	*Hibernate metadata impact*::: Column(s) are not nullable
+`@Null`::
+	*Supported data types*::: Any type
+	*Use*::: hecks that the annotated value is `null`
+	*Hibernate metadata impact*::: None
+`@Past`::
+	*Supported data types*::: `java.util.Date`,`java.util.Calendar`, `java.time.Instant`, `java.time.LocalDate`, `java.time.LocalDateTime`, `java.time.LocalTime`, `java.time.MonthDay`, `java.time.OffsetDateTime`, `java.time.OffsetTime`, `java.time.Year`, `java.time.YearMonth`, `java.time.ZonedDateTime`, `java.time.chrono.HijrahDate`, `java.time.chrono.JapaneseDate`, `java.time.chrono.MinguoDate`, `java.time.chrono.ThaiBuddhistDate`; Additionally supported by HV, if the http://www.joda.org/joda-time/[Joda Time] date/time API is on the classpath: any implementations of `ReadablePartial` and `ReadableInstant`
+	*Use*::: Checks whether the annotated date is in the past
+	*Hibernate metadata impact*::: None
+`@Pattern(regex=,flags=)`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks if the annotated string matches the regular expression `regex` considering the given flag `match`
+	*Hibernate metadata impact*::: None
+`@Size(min=, max=)`::
+	*Supported data types*::: `CharSequence`, `Collection`, `Map` and arrays
+	*Use*::: Checks if the annotated element's size is between `min` and `max` (inclusive)
+	*Hibernate metadata impact*::: Column length will be set to `max`
+`@Valid`::
+	*Supported data types*::: Any non-primitive type
+	*Use*::: Performs validation recursively on the associated object. If the object is a collection or an array, the elements are validated recursively. If the object is a map, the value elements are validated recursively.
+	*Hibernate metadata impact*::: None
 
 
 
@@ -609,185 +554,64 @@ level constraint.
 
 [[table-custom-constraints]]
 .Custom constraints
-[cols="4*", options="header"]
-|===============
-|Annotation
-|Supported data types
-|Use
-|Hibernate metadata impact
 
-|`@CreditCardNumber(ignoreNonDigitCharacters=)`
-|`CharSequence`
-|Checks that the annotated character sequence passes the
- Luhn checksum test. Note, this validation aims to check for user
- mistakes, not credit card validity! See also
- http://www.merriampark.com/anatomycc.htm[Anatomy of Credit Card Numbers]. `ignoreNonDigitCharacters`
- allows to ignore non digit characters. The default is `false`.
-|None
-
-|`@Currency(value=)`
-|any sub-type of `javax.money.MonetaryAmount` (if the https://jcp.org/en/jsr/detail?id=354[JSR 354 API] and an implementation is on the class path)
-|Checks that the annotated `javax.money.MonetaryAmount` currency unit is part of the specified currency units.
-|None
-
-|`@EAN`
-|`CharSequence`
-|Checks that the annotated character sequence is a valid
-link:$$http://en.wikipedia.org/wiki/International_Article_Number_%28EAN%29$$[EAN] barcode.
-type determines the type of barcode. The default is EAN-13.
-|None
-
-|`@Email`
-|`CharSequence`
-|Checks whether the specified character sequence is a valid email address. The optional parameters
-`regexp` and `flags` allow to specify an additional regular expression (including regular expression
-flags) which the email must match.
-|None
-
-|`@Length(min=, +
-         max=)`
-|`CharSequence`
-|Validates that the annotated character sequence is
-              between `min` and
-              `max` included
-|Column length will be set to max
-
-|`@LuhnCheck(startIndex= , +
-            endIndex=, +
-            checkDigitIndex=, +
-            ignoreNonDigitCharacters=)`
-|`CharSequence`
-|Checks that the digits within the annotated character
-sequence pass the Luhn checksum algorithm (see also
-link:$$http://en.wikipedia.org/wiki/Luhn_algorithm$$[Luhn algorithm]). `startIndex` and
-`endIndex` allow to only run the algorithm on
-the specified sub-string. `checkDigitIndex`
-allows to use an arbitrary digit within the character sequence
-as the check digit. If not specified it is assumed that the
-check digit is part of the specified range. Last but not least,
-`ignoreNonDigitCharacters` allows to ignore
-non digit characters.
-|None
-
-|`@Mod10Check(multiplier=, +
-             weight=, +
-             startIndex=, +
-             endIndex=, +
-             checkDigitIndex=, +
-             ignoreNonDigitCharacters=)`
-|`CharSequence`
-|Checks that the digits within the annotated character
-sequence pass the generic mod 10 checksum algorithm.
-`multiplier` determines the multiplier for
-odd numbers (defaults to 3), `weight` the
-weight for even numbers (defaults to 1).
-`startIndex` and
-`endIndex` allow to only run the algorithm on
-the specified sub-string. `checkDigitIndex`
-allows to use an arbitrary digit within the character sequence
-as the check digit. If not specified it is assumed that the
-check digit is part of the specified range. Last but not least,
-`ignoreNonDigitCharacters` allows to ignore
-non digit characters.
-|None
-
-|`@Mod11Check(threshold=, +
-             startIndex=, +
-             endIndex=, +
-             checkDigitIndex=, +
-             ignoreNonDigitCharacters=, +
-             treatCheck10As=, +
-             treatCheck11As=)`
-|`CharSequence`
-|Checks that the digits within the annotated character
-sequence pass the mod 11 checksum algorithm.
-`threshold` specifies the threshold for the
-mod11 multiplier growth; if no value is specified the multiplier
-will grow indefinitely. `treatCheck10As`
-and `treatCheck11As` specify the check
-digits to be used when the mod 11 checksum equals 10 or 11,
-respectively. Default to X and 0, respectively.
-`startIndex`, `endIndex`
-`checkDigitIndex` and
-`ignoreNonDigitCharacters` carry the same
-semantics as in `@Mod10Check`.
-|None
-
-|`@NotBlank`
-|`CharSequence`
-|Checks that the annotated character sequence is not null
-and the trimmed length is greater than 0. The difference to
-`@NotEmpty` is that this constraint can
-only be applied on strings and that trailing white-spaces are
-ignored.
-|None
-
-|`@NotEmpty`
-|`CharSequence`, `Collection`, `Map` and arrays
-|Checks whether the annotated element is not null nor empty
-|None
-
-|`@Range(min=, +
-        max=)`
-|`BigDecimal`, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the
-primitive types
-|Checks whether the annotated value lies between (inclusive) the specified minimum and maximum
-|None
-
-|`@SafeHtml(whitelistType= , +
-           additionalTags=, +
-           additionalTagsWithAttributes=)`
-|`CharSequence`
-|Checks whether the annotated value
-contains potentially malicious fragments such as `<script/>`. In order to use this
-constraint, the
-link:$$http://jsoup.org/$$[jsoup] library must be part of the class path.
-With the `whitelistType` attribute a predefined whitelist type can be chosen which can
-be refined via `additionalTags` or `additionalTagsWithAttributes`. The former allows to
-add tags without any attributes, whereas the latter allows to specify tags and
-optionally allowed attributes using the annotation `@SafeHtml.Tag`.
-|None
-
-|`@ScriptAssert(lang=, +
-              script=, +
-              alias=, +
-              reportOn=)`
-|Any type
-|Checks whether the given script can successfully be
-evaluated against the annotated element. In order to use this
-constraint, an implementation of the Java Scripting API as
-defined by JSR 223 ("Scripting for the
-Java^TM^ Platform") must be a part of the
-class path. The expressions to be evaluated can be written in
-any scripting or expression language, for which a JSR 223
-compatible engine can be found in the class path. Even though
-this is a class-level constraint, one can use the `reportOn` attribute
-to report a constraint violation on a specific property
-rather than the whole object.
-|None
-
-|`@URL(protocol=, +
-      host=, +
-      port=, +
-      regexp=, +
-      flags=)`
-|`CharSequence`
-|Checks if the annotated character sequence is a valid URL
-according to RFC2396. If any of the optional parameters
-`protocol`, `host` or
-`port` are specified, the corresponding URL
-fragments must match the specified values. The optional
-parameters `regexp` and
-`flags` allow to specify an additional
-regular expression (including regular expression flags) which
-the URL must match. Per default this constraint used the `java.net.URL` constructor to
-verify whether a given string represents a valid URL. A regular expression based version is also
-available - `RegexpURLValidator` - which can be configured via XML
-(see <<section-mapping-xml-constraints>>) or the programmatic API
-(see <<section-programmatic-constraint-definition>>).
-|None
-
-|===============
+//[horizontal]
+`@CreditCardNumber(ignoreNonDigitCharacters=)`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the annotated character sequence passes the Luhn checksum test. Note, this validation aims to check for user mistakes, not credit card validity! See also http://www.merriampark.com/anatomycc.htm[Anatomy of Credit Card Numbers]. `ignoreNonDigitCharacters` allows to ignore non digit characters. The default is `false`.
+	*Hibernate metadata impact*::: None
+`@Currency(value=)`::
+	*Supported data types*::: any sub-type of `javax.money.MonetaryAmount` (if the https://jcp.org/en/jsr/detail?id=354[JSR 354 API] and an implementation is on the class path)
+	*Use*::: Checks that the annotated `javax.money.MonetaryAmount` currency unit is part of the specified currency units.
+	*Hibernate metadata impact*::: None
+`@EAN`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the annotated character sequence is a valid link:$$http://en.wikipedia.org/wiki/International_Article_Number_%28EAN%29$$[EAN] barcode. type determines the type of barcode. The default is EAN-13.
+	*Hibernate metadata impact*::: None
+`@Email`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks whether the specified character sequence is a valid email address. The optional parameters `regexp` and `flags` allow to specify an additional regular expression (including regular expression flags) which the email must match.
+	*Hibernate metadata impact*::: None
+`@Length(min=, max=)`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Validates that the annotated character sequence is between `min` and `max` included
+	*Hibernate metadata impact*::: Column length will be set to max
+`@LuhnCheck(startIndex= , endIndex=, checkDigitIndex=, ignoreNonDigitCharacters=)`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the digits within the annotated character sequence pass the Luhn checksum algorithm (see also link:$$http://en.wikipedia.org/wiki/Luhn_algorithm$$[Luhn algorithm]). `startIndex` and `endIndex` allow to only run the algorithm on the specified sub-string. `checkDigitIndex` allows to use an arbitrary digit within the character sequence as the check digit. If not specified it is assumed that the check digit is part of the specified range. Last but not least, `ignoreNonDigitCharacters` allows to ignore non digit characters.
+	*Hibernate metadata impact*::: None
+`@Mod10Check(multiplier=, weight=, startIndex=, endIndex=, checkDigitIndex=, ignoreNonDigitCharacters=)`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the digits within the annotated character sequence pass the generic mod 10 checksum algorithm. `multiplier` determines the multiplier for odd numbers (defaults to 3), `weight` the weight for even numbers (defaults to 1). `startIndex` and `endIndex` allow to only run the algorithm on the specified sub-string. `checkDigitIndex` allows to use an arbitrary digit within the character sequence as the check digit. If not specified it is assumed that the check digit is part of the specified range. Last but not least, `ignoreNonDigitCharacters` allows to ignore non digit characters.
+	*Hibernate metadata impact*::: None
+`@Mod11Check(threshold=, startIndex=, endIndex=, checkDigitIndex=, ignoreNonDigitCharacters=, treatCheck10As=, treatCheck11As=)`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the digits within the annotated character sequence pass the mod 11 checksum algorithm. `threshold` specifies the threshold for the mod11 multiplier growth; if no value is specified the multiplier will grow indefinitely. `treatCheck10As` and `treatCheck11As` specify the check digits to be used when the mod 11 checksum equals 10 or 11, respectively. Default to X and 0, respectively. `startIndex`, `endIndex` `checkDigitIndex` and `ignoreNonDigitCharacters` carry the same semantics as in `@Mod10Check`.
+	*Hibernate metadata impact*::: None
+`@NotBlank`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the annotated character sequence is not null and the trimmed length is greater than 0. The difference to `@NotEmpty` is that this constraint can only be applied on strings and that trailing white-spaces are ignored.
+	*Hibernate metadata impact*::: None
+`@NotEmpty`::
+	*Supported data types*::: `CharSequence`, `Collection`, `Map` and arrays
+	*Use*::: Checks whether the annotated element is not null nor empty
+	*Hibernate metadata impact*::: None
+`@Range(min=, max=)`::
+	*Supported data types*::: `BigDecimal`, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types
+	*Use*::: Checks whether the annotated value lies between (inclusive) the specified minimum and maximum
+	*Hibernate metadata impact*::: None
+`@SafeHtml(whitelistType= , additionalTags=, additionalTagsWithAttributes=)`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks whether the annotated value contains potentially malicious fragments such as `<script/>`. In order to use this constraint, the link:$$http://jsoup.org/$$[jsoup] library must be part of the class path. With the `whitelistType` attribute a predefined whitelist type can be chosen which can be refined via `additionalTags` or `additionalTagsWithAttributes`. The former allows to add tags without any attributes, whereas the latter allows to specify tags and optionally allowed attributes using the annotation `@SafeHtml.Tag`.
+	*Hibernate metadata impact*::: None
+`@ScriptAssert(lang=, script=, alias=, reportOn=)`::
+	*Supported data types*::: Any type
+	*Use*::: Checks whether the given script can successfully be evaluated against the annotated element. In order to use this constraint, an implementation of the Java Scripting API as defined by JSR 223 ("Scripting for the Java^TM^ Platform") must be a part of the class path. The expressions to be evaluated can be written in any scripting or expression language, for which a JSR 223 compatible engine can be found in the class path. Even though this is a class-level constraint, one can use the `reportOn` attribute to report a constraint violation on a specific property rather than the whole object.
+	*Hibernate metadata impact*::: None
+`@URL(protocol=, host=, port=, regexp=, flags=)`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks if the annotated character sequence is a valid URL according to RFC2396. If any of the optional parameters `protocol`, `host` or `port` are specified, the corresponding URL fragments must match the specified values. The optional parameters `regexp` and `flags` allow to specify an additional regular expression (including regular expression flags) which the URL must match. Per default this constraint used the `java.net.URL` constructor to verify whether a given string represents a valid URL. A regular expression based version is also available - `RegexpURLValidator` - which can be configured via XML (see <<section-mapping-xml-constraints>>) or the programmatic API (see <<section-programmatic-constraint-definition>>).
+	*Hibernate metadata impact*::: None
 
 
 
@@ -806,27 +630,42 @@ Hibernate Validator!
 
 [[table-custom-country-constraints]]
 .Custom country specific constraints
-[options="header"]
-|===============
-|Annotation|Supported data types|Use|Country|Hibernate metadata impact
-|`@CNPJ`|`CharSequence`|Checks that the annotated character sequence represents
-                a Brazilian corporate tax payer registry number (Cadastro de
-                Pessoa Juríeddica)|Brazil|None
-|`@CPF`|`CharSequence`|Checks that the annotated character sequence represents
-                a Brazilian individual taxpayer registry number (Cadastro de
-                Pessoa Fídsica)|Brazil|None
-|`@TituloEleitoral`|`CharSequence`|Checks that the annotated character sequence represents
-                a Brazilian voter ID card number (http://www.exceldoseujeito.com.br/2008/12/19/validar-cpf-cnpj-e-titulo-de-eleitor-parte-ii/[Título Eleitoral])|Brazil|None
-|`@NIP`|`CharSequence`|Checks that the annotated character sequence represents a Polish VAT identification
- 				number (https://pl.wikipedia.org/wiki/NIP[NIP])|Poland|None
-|`@PESEL`|`CharSequence`|Checks that the annotated character sequence represents a Polish national identification
-				number (https://pl.wikipedia.org/wiki/PESEL[PESEL])|Poland|None
-|`@REGON`|`CharSequence`|Checks that the annotated character sequence represents a Polish taxpayer identification
-				number (https://pl.wikipedia.org/wiki/REGON[REGON]). Can be applied to both 9 and 14 digits versions of REGON|Poland|None
 
-|===============
+//[horizontal]
+`@CNPJ`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the annotated character sequence represents a Brazilian corporate tax payer registry number (Cadastro de Pessoa Juríeddica)
+	*Hibernate metadata impact*::: None
+	*Country*::: Brazil
 
+`@CPF`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the annotated character sequence represents a Brazilian individual taxpayer registry number (Cadastro de Pessoa Fídsica)
+	*Hibernate metadata impact*::: None
+	*Country*::: Brazil
 
+`@TituloEleitoral`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the annotated character sequence represents a Brazilian voter ID card number (http://www.exceldoseujeito.com.br/2008/12/19/validar-cpf-cnpj-e-titulo-de-eleitor-parte-ii/[Título Eleitoral])
+	*Hibernate metadata impact*::: None
+	*Country*::: Brazil
+`@NIP`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: hecks that the annotated character sequence represents a Polish VAT identification number (https://pl.wikipedia.org/wiki/NIP[NIP])
+	*Hibernate metadata impact*::: None
+	*Country*::: Poland
+
+`@PESEL`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the annotated character sequence represents a Polish national identification number (https://pl.wikipedia.org/wiki/PESEL[PESEL])
+	*Hibernate metadata impact*::: None
+	*Country*::: Poland
+
+`@REGON`::
+	*Supported data types*::: `CharSequence`
+	*Use*::: Checks that the annotated character sequence represents a Polish taxpayer identification number (https://pl.wikipedia.org/wiki/REGON[REGON]). Can be applied to both 9 and 14 digits versions of REGON
+	*Hibernate metadata impact*::: None
+	*Country*::: Poland
 
 [TIP]
 ====

--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -27,51 +27,25 @@ part of the public this is not necessarily true for its sub-packages.
 
 [[validator-public-api]]
 .Hibernate Validator public API
-[options="header"]
-|===============
-|Packages|Description
-|`org.hibernate.validator`|Classes used by the Bean Validation bootstrap mechanism
-            (eg. validation provider, configuration class); For more details
-            see <<chapter-bootstrapping>>.
-|`org.hibernate.validator.cfg`,
-            `org.hibernate.validator.cfg.context`,
-            `org.hibernate.validator.cfg.defs`,
-            `org.hibernate.validator.spi.cfg`|Hibernate Validator's fluent API for constraint
-            declaration; In `org.hibernate.validator.cfg` you
-            will find the `ConstraintMapping` interface,
-            in `org.hibernate.validator.cfg.defs` all
-            constraint definitions and in `org.hibernate.validator.spi.cfg` a
-            callback for using the API for configuring the default validator factory.
-            Refer to <<section-programmatic-api>> for the details.
-|`org.hibernate.validator.constraints`,
-            `org.hibernate.validator.constraints.br`|Some useful custom constraints provided by Hibernate
-            Validator in addition to the built-in constraints defined by the
-            Bean Validation specification; The constraints are described in
-            detail in <<validator-defineconstraints-hv-constraints>>.
-|`org.hibernate.validator.constraintvalidation`|Extended constraint validator context which allows to set
-            custom attributes for message interpolation. <<section-hibernateconstraintvalidatorcontext>> describes
-            how to make use of that feature.
-|`org.hibernate.validator.group`,
-            `org.hibernate.validator.spi.group`|The group sequence provider feature which allows you to
-            define dynamic default group sequences in function of the
-            validated object state; The specifics can be found in <<section-default-group-class>>.
-|`org.hibernate.validator.messageinterpolation`,
-            `org.hibernate.validator.resourceloading`,
-            `org.hibernate.validator.spi.resourceloading`|Classes related to constraint message interpolation; The
-            first package contains Hibernate Validator's default message
-            interpolator,
-            `ResourceBundleMessageInterpolator`. The
-            latter two packages provide the
-            `ResourceBundleLocator` SPI for the loading of resource
-            bundles (see <<section-resource-bundle-locator>>)
-            and its default implementation.
-|`org.hibernate.validator.parameternameprovider`|A `ParameterNameProvider` based on the
-            ParaNamer library, see <<section-paranamer-parameternameprovider>>.
-|`org.hibernate.validator.propertypath`|Extensions to the `javax.validation.Path` API,
-            see <<section-extensions-path-api>>.
-|`org.hibernate.validator.spi.constraintdefinition`|An SPI for registering additional constraint validators programmatically,
-            see <<section-constraint-definition-contribution>>.
-|===============
+//|Packages|Description
+//[horizontal]
+`org.hibernate.validator`::
+			Classes used by the Bean Validation bootstrap mechanism (eg. validation provider, configuration class); For more details see <<chapter-bootstrapping>>.
+`org.hibernate.validator.cfg`, `org.hibernate.validator.cfg.context`, `org.hibernate.validator.cfg.defs`, `org.hibernate.validator.spi.cfg`::
+			Hibernate Validator's fluent API for constraint declaration; In `org.hibernate.validator.cfg` you will find the `ConstraintMapping` interface, in `org.hibernate.validator.cfg.defs` all constraint definitions and in `org.hibernate.validator.spi.cfg` a callback for using the API for configuring the default validator factory. Refer to <<section-programmatic-api>> for the details.
+`org.hibernate.validator.constraints`, `org.hibernate.validator.constraints.br`::
+			Some useful custom constraints provided by Hibernate Validator in addition to the built-in constraints defined by the Bean Validation specification; The constraints are described in detail in <<validator-defineconstraints-hv-constraints>>.
+`org.hibernate.validator.constraintvalidation`::
+			Extended constraint validator context which allows to set custom attributes for message interpolation. <<section-hibernateconstraintvalidatorcontext>> describes how to make use of that feature.
+`org.hibernate.validator.group`, `org.hibernate.validator.spi.group`:: The group sequence provider feature which allows you to define dynamic default group sequences in function of the validated object state; The specifics can be found in <<section-default-group-class>>.
+`org.hibernate.validator.messageinterpolation`, `org.hibernate.validator.resourceloading`, `org.hibernate.validator.spi.resourceloading`::
+			Classes related to constraint message interpolation; The first package contains Hibernate Validator's default message interpolator, `ResourceBundleMessageInterpolator`. The latter two packages provide the `ResourceBundleLocator` SPI for the loading of resource bundles (see <<section-resource-bundle-locator>>) and its default implementation.
+`org.hibernate.validator.parameternameprovider`::
+			A `ParameterNameProvider` based on the ParaNamer library, see <<section-paranamer-parameternameprovider>>.
+`org.hibernate.validator.propertypath`::
+			Extensions to the `javax.validation.Path` API, see <<section-extensions-path-api>>.
+`org.hibernate.validator.spi.constraintdefinition`::
+			An SPI for registering additional constraint validators programmatically, see <<section-constraint-definition-contribution>>.
 
 [NOTE]
 ====

--- a/documentation/src/main/asciidoc/ch12.asciidoc
+++ b/documentation/src/main/asciidoc/ch12.asciidoc
@@ -52,22 +52,20 @@ listed in table <<table_processor_options>>:
 
 [[table_processor_options]]
 .Hibernate Validator Annotation Processor options
-[options="header"]
-|===============
-|Option|Explanation
-|`diagnosticKind`|Controls how constraint problems are reported. Must be the
+//|Option|Explanation
+//[horizontal]
+`diagnosticKind`:: Controls how constraint problems are reported. Must be the
             string representation of one of the values from the enum `javax.tools.Diagnostic.Kind`,
             e.g. `WARNING`. A value of `ERROR` will cause compilation to halt whenever the AP detects
             a constraint problem. Defaults to `ERROR`.
-|`methodConstraintsSupported`|Controls whether constraints are allowed at methods of any
+`methodConstraintsSupported`:: Controls whether constraints are allowed at methods of any
             kind. Must be set to `true` when working with method level constraints as supported by
             Hibernate Validator. Can be set to `false` to allow constraints only at
             JavaBeans getter methods as defined by the Bean Validation API. Defaults to `true`.
-|`verbose`|Controls whether detailed processing information shall be
+`verbose`:: Controls whether detailed processing information shall be
             displayed or not, useful for debugging purposes. Must be either
             `true` or `false`. Defaults to `false`.
 
-|===============
 
 
 [[validator-annotationprocessor-usage]]


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1216

migrated tables to labeled lists in documentation. Resulting pdf file is attached to the JIRA.