### PR TITLE
HV-966 ParameterNameProvider is called on methods with no parameter as well as Object methods

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ExecutableConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ExecutableConstraintMappingContextImpl.java
@@ -125,6 +125,7 @@ abstract class ExecutableConstraintMappingContextImpl {
 	private List<ConstrainedParameter> getParameters(ConstraintHelper constraintHelper, TypeResolutionHelper typeResolutionHelper,
 			ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager) {
 		List<ConstrainedParameter> constrainedParameters = newArrayList();
+		List<String> parameterNames = parameterNameProvider.getParameterNames( executable );
 
 		for ( int i = 0; i < parameterContexts.length; i++ ) {
 			ParameterConstraintMappingContextImpl parameter = parameterContexts[i];
@@ -138,7 +139,7 @@ abstract class ExecutableConstraintMappingContextImpl {
 								executable,
 								ReflectionHelper.typeOf( executable, i ),
 								i,
-								parameterNameProvider.getParameterNames( executable ).get( i )
+								parameterNames.get( i )
 						)
 				);
 			}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -259,11 +259,6 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 	}
 
 	private <T> Set<ConstraintViolation<T>> validateParameters(T object, Executable executable, Object[] parameterValues, Class<?>... groups) {
-		//this might be the case for parameterless methods
-		if ( parameterValues == null ) {
-			return Collections.emptySet();
-		}
-
 		ValidationOrder validationOrder = determineGroupValidationOrder( groups );
 
 		ValidationContext<T> context = getValidationContext().forValidateParameters(

--- a/engine/src/main/java/org/hibernate/validator/internal/util/ExecutableParameterNameProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/ExecutableParameterNameProvider.java
@@ -9,6 +9,7 @@ package org.hibernate.validator.internal.util;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 
 import javax.validation.ParameterNameProvider;
@@ -28,6 +29,10 @@ public class ExecutableParameterNameProvider {
 	}
 
 	public List<String> getParameterNames(Executable executable) {
+		//skip parameterless methods
+		if ( executable.getParameterCount() == 0 ) {
+			return Collections.emptyList();
+		}
 		if ( executable instanceof Method ) {
 			return delegate.getParameterNames( (Method) executable );
 		}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/ParameterlessMethodValidationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/ParameterlessMethodValidationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.methodvalidation;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.testng.Assert.fail;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import javax.validation.ParameterNameProvider;
+import javax.validation.Validation;
+import javax.validation.Validator;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.testutil.TestForIssue;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+@Test
+public class ParameterlessMethodValidationTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HV-966")
+	public void testEmptyParameters() throws NoSuchMethodException {
+		HibernateValidatorConfiguration config = Validation.byProvider( HibernateValidator.class ).configure();
+
+		ParameterNameProvider providerMock = new ParameterNameProvider() {
+
+			@Override
+			public List<String> getParameterNames(Constructor<?> constructor) {
+				throw new IllegalStateException( "this method shouldn't be invoked" );
+			}
+
+			@Override
+			public List<String> getParameterNames(Method method) {
+				if ( method.getName().equals( "getString" ) ) {
+					throw new IllegalStateException( "this method shouldn't be invoked" + method.getName() );
+				}
+				return Arrays.asList( new String[method.getParameterCount()] );
+			}
+		};
+
+		Validator validator = config
+				.parameterNameProvider( providerMock )
+				.buildValidatorFactory()
+				.getValidator();
+
+		Bar bar = new Bar();
+
+		try {
+			assertNumberOfViolations( validator.forExecutables().validateParameters( bar, bar.getClass().getMethod( "getString" ), new Object[]{} ), 0 );
+		}
+		catch (IllegalStateException e) {
+			fail( "ParameterNameProvider#getParameterNames() shouldn't be invoked for getString" );
+		}
+	}
+
+	private static class Bar {
+
+		private String string;
+
+		public String getString() {
+			return string;
+		}
+
+	}
+
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-966

So obviously that approach that I've mentioned in JIRA didn't work out :). The reason for that is that if we exit from validation that fast some of the checks will never be performed and no exceptions will be thrown. For example:
```
Log#getMethodOrConstructorNotDefinedByValidatedTypeException
Log#getInvalidParameterCountForExecutableException // for the case when no parameters are passed
```

So the place where I found that method call could be skipped is in `ExecutableParameterNameProvider`. 
I also made some other changes related to this - I'll comment inline to explain why the change was made. 

Another thing that came to my mind is that maybe we should throw an exception (`IllegalArgumentException`) if a parameterless method is passed for parameter method validation, WDYT?