### PR TITLE
Fixing mentioning wrong annotations in JavaDoc for annotation Lists (EAN, Currency)

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/constraints/Currency.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/Currency.java
@@ -52,7 +52,7 @@ public @interface Currency {
 	String[] value();
 
 	/**
-	 * Defines several {@code @Email} annotations on the same element.
+	 * Defines several {@code @Currency} annotations on the same element.
 	 */
 	@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 	@Retention(RUNTIME)

--- a/engine/src/main/java/org/hibernate/validator/constraints/EAN.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/EAN.java
@@ -53,7 +53,7 @@ public @interface EAN {
 	Type type() default Type.EAN13;
 
 	/**
-	 * Defines several {@code @NotBlank} annotations on the same element.
+	 * Defines several {@code @EAN} annotations on the same element.
 	 */
 	@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 	@Retention(RUNTIME)


### PR DESCRIPTION
As in the title. The others seems to be OK. 

I was just making the same 'typo' while copying an annotation for DurationMin :) 