### PR TITLE
HV-1240 Don't call ValueExtractors on null values anymore

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -540,10 +540,12 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 
 			// constraint requiring a ValueExtractor
 			if ( metaConstraint.getValueExtractorDescriptor() != null ) {
-				TypeParameterValueReceiver receiver = new TypeParameterValueReceiver( validationContext, valueContext, metaConstraint );
-				( (ValueExtractor) metaConstraint.getValueExtractorDescriptor().getValueExtractor() ).extractValues( valueToValidate, receiver );
+				if ( valueToValidate != null ) {
+					TypeParameterValueReceiver receiver = new TypeParameterValueReceiver( validationContext, valueContext, metaConstraint );
+					( (ValueExtractor) metaConstraint.getValueExtractorDescriptor().getValueExtractor() ).extractValues( valueToValidate, receiver );
 
-				success = receiver.isSuccess();
+					success = receiver.isSuccess();
+				}
 			}
 			// regular constraint
 			else {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/MapKeyExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/MapKeyExtractor.java
@@ -20,10 +20,6 @@ class MapKeyExtractor implements ValueExtractor<Map<@ExtractedValue ?, ?>> {
 
 	@Override
 	public void extractValues(Map<?, ?> originalValue, ValueReceiver receiver) {
-		if ( originalValue == null ) {
-			return;
-		}
-
 		for ( Map.Entry<?, ?> entry : originalValue.entrySet() ) {
 			receiver.keyedValue( "<map key>", entry.getKey(), entry.getKey() );
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/MapValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/MapValueExtractor.java
@@ -20,10 +20,6 @@ class MapValueExtractor implements ValueExtractor<Map<?, @ExtractedValue ?>> {
 
 	@Override
 	public void extractValues(Map<?, ?> originalValue, ValueReceiver receiver) {
-		if ( originalValue == null ) {
-			return;
-		}
-
 		for ( Map.Entry<?, ?> entry : originalValue.entrySet() ) {
 			receiver.keyedValue( "<map value>", entry.getKey(), entry.getValue() );
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/OptionalValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/OptionalValueExtractor.java
@@ -23,6 +23,6 @@ public class OptionalValueExtractor implements ValueExtractor<Optional<@Extracte
 
 	@Override
 	public void extractValues(Optional<?> originalValue, ValueExtractor.ValueReceiver receiver) {
-		receiver.value( null, originalValue != null && originalValue.isPresent() ? originalValue.get() : null );
+		receiver.value( null, originalValue.isPresent() ? originalValue.get() : null );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/TypeAnnotationConstraintTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/TypeAnnotationConstraintTest.java
@@ -9,6 +9,7 @@ package org.hibernate.validator.test.internal.engine.typeannotationconstraint;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintTypes;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
@@ -56,6 +57,17 @@ public class TypeAnnotationConstraintTest {
 	@BeforeClass
 	public void setup() {
 		validator = getValidator();
+	}
+
+	// Validate value extractors are not called on null values
+
+	@Test
+	public void value_extractor_not_called_on_null_values() {
+		Set<ConstraintViolation<ModelWithNullValue>> constraintViolations = validator.validate( new ModelWithNullValue() );
+
+		assertCorrectPropertyPaths( constraintViolations, "nullValue" );
+		assertCorrectConstraintViolationMessages( constraintViolations, "container" );
+		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
 	}
 
 	// List
@@ -879,9 +891,9 @@ public class TypeAnnotationConstraintTest {
 		o = new TypeWithOptional4();
 		o.stringOptional = null;
 		constraintViolations = validator.validate( o );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectPropertyPaths( constraintViolations, "stringOptional", "stringOptional" );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotBlank.class );
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "stringOptional" );
+		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
 	}
 
 	@Test
@@ -985,6 +997,13 @@ public class TypeAnnotationConstraintTest {
 
 		assertingLogger.assertMessageLogged();
 		log4jRootLogger.removeAppender( assertingLogger );
+	}
+
+	// Validate value extractors are not called on null values
+
+	static class ModelWithNullValue {
+
+		private @NotNull(message = "container") Optional<@NotNull(message = "type") String> nullValue;
 	}
 
 	// List

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnConstructorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnConstructorTest.java
@@ -91,11 +91,11 @@ public class OptionalTypeAnnotationConstraintOnConstructorTest {
 				.forExecutables()
 				.validateConstructorParameters( constructor, values );
 
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectPropertyPaths( constraintViolations, "ModelB.valueWithNotNull", "ModelB.valueWithNotNull" );
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "ModelB.valueWithNotNull" );
 
-		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNull.class );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container" );
+		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
 	}
 
 	@Test
@@ -221,13 +221,13 @@ public class OptionalTypeAnnotationConstraintOnConstructorTest {
 
 	static class ModelA {
 
-		public ModelA(@NotNull(message = "container", payload = { Unwrapping.Skip.class }) Optional<String> valueWithoutTypeAnnotation) {
+		public ModelA(@NotNull(message = "container") Optional<String> valueWithoutTypeAnnotation) {
 		}
 	}
 
 	static class ModelB {
 
-		public ModelB(@NotNull(message = "container", payload = { Unwrapping.Skip.class }) Optional<@NotNull(message = "type") String> valueWithNotNull) {
+		public ModelB(@NotNull(message = "container") Optional<@NotNull(message = "type") String> valueWithNotNull) {
 		}
 	}
 
@@ -239,7 +239,7 @@ public class OptionalTypeAnnotationConstraintOnConstructorTest {
 
 	static class ModelD {
 
-		public ModelD(@NotNull(message = "container", payload = { Unwrapping.Skip.class }) Optional<@NullOrNotBlank(message = "type") String> valueWithNullOrNotBlank) {
+		public ModelD(@NotNull(message = "container") Optional<@NullOrNotBlank(message = "type") String> valueWithNullOrNotBlank) {
 		}
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnFieldTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnFieldTest.java
@@ -84,11 +84,10 @@ public class OptionalTypeAnnotationConstraintOnFieldTest {
 		model.valueWithNotNull = null;
 
 		Set<ConstraintViolation<ModelB>> constraintViolations = validator.validate( model );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNull", "valueWithNotNull" );
-		// TODO: We don't need to validate the type since the container already failed
-		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNull.class );
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNull" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container" );
+		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
 	}
 
 	@Test
@@ -197,14 +196,14 @@ public class OptionalTypeAnnotationConstraintOnFieldTest {
 
 	private static class ModelA {
 
-		@NotNull(message = "container", payload = { Unwrapping.Skip.class })
+		@NotNull(message = "container")
 		Optional<String> valueWithoutTypeAnnotation;
 
 	}
 
 	private static class ModelB {
 
-		@NotNull(message = "container", payload = { Unwrapping.Skip.class })
+		@NotNull(message = "container")
 		Optional<@NotNull(message = "type") String> valueWithNotNull;
 
 	}
@@ -217,7 +216,7 @@ public class OptionalTypeAnnotationConstraintOnFieldTest {
 
 	private static class ModelD {
 
-		@NotNull(message = "container", payload = { Unwrapping.Skip.class })
+		@NotNull(message = "container")
 		Optional<@NullOrNotBlank(message = "type") String> valueWithNullOrNotBlank;
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnGetterTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnGetterTest.java
@@ -84,11 +84,10 @@ public class OptionalTypeAnnotationConstraintOnGetterTest {
 		model.setValueWithNotNull( null );
 
 		Set<ConstraintViolation<ModelB>> constraintViolations = validator.validate( model );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNull", "valueWithNotNull" );
-		// TODO: We don't need to validate the type since the container already failed
-		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNull.class );
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNull" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container" );
+		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
 	}
 
 	@Test
@@ -199,7 +198,7 @@ public class OptionalTypeAnnotationConstraintOnGetterTest {
 
 		private Optional<String> valueWithoutTypeAnnotation;
 
-		@NotNull(message = "container", payload = { Unwrapping.Skip.class })
+		@NotNull(message = "container")
 		public Optional<String> getValueWithoutTypeAnnotation() {
 			return valueWithoutTypeAnnotation;
 		}
@@ -213,7 +212,7 @@ public class OptionalTypeAnnotationConstraintOnGetterTest {
 
 		private Optional<String> valueWithNotNull;
 
-		@NotNull(message = "container", payload = { Unwrapping.Skip.class })
+		@NotNull(message = "container")
 		public Optional<@NotNull(message = "type") String> getValueWithNotNull() {
 			return valueWithNotNull;
 		}
@@ -241,7 +240,7 @@ public class OptionalTypeAnnotationConstraintOnGetterTest {
 
 		private Optional<String> valueWithNullOrNotBlank;
 
-		@NotNull(message = "container", payload = { Unwrapping.Skip.class })
+		@NotNull(message = "container")
 		public Optional<@NullOrNotBlank(message = "type") String> getValueWithNullOrNotBlank() {
 			return valueWithNullOrNotBlank;
 		}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnMethodTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintOnMethodTest.java
@@ -91,10 +91,10 @@ public class OptionalTypeAnnotationConstraintOnMethodTest {
 				.forExecutables()
 				.validateParameters( new ModelB(), method, values );
 
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectPropertyPaths( constraintViolations, "method.valueWithNotNull", "method.valueWithNotNull" );
-		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNull.class );
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "method.valueWithNotNull" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container" );
+		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
 	}
 
 	@Test
@@ -244,13 +244,13 @@ public class OptionalTypeAnnotationConstraintOnMethodTest {
 
 	static class ModelA {
 
-		public void method(@NotNull(message = "container", payload = { Unwrapping.Skip.class }) Optional<String> valueWithoutTypeAnnotation) {
+		public void method(@NotNull(message = "container") Optional<String> valueWithoutTypeAnnotation) {
 		}
 	}
 
 	static class ModelB {
 
-		public void method(@NotNull(message = "container", payload = { Unwrapping.Skip.class }) Optional<@NotNull(message = "type") String> valueWithNotNull) {
+		public void method(@NotNull(message = "container") Optional<@NotNull(message = "type") String> valueWithNotNull) {
 		}
 	}
 
@@ -262,7 +262,7 @@ public class OptionalTypeAnnotationConstraintOnMethodTest {
 
 	static class ModelD {
 
-		public void method(@NotNull(message = "container", payload = { Unwrapping.Skip.class }) Optional<@NullOrNotBlank(message = "type") String> valueWithNullOrNotBlank) {
+		public void method(@NotNull(message = "container") Optional<@NullOrNotBlank(message = "type") String> valueWithNullOrNotBlank) {
 		}
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintUsingValidatePropertyTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/OptionalTypeAnnotationConstraintUsingValidatePropertyTest.java
@@ -90,10 +90,10 @@ public class OptionalTypeAnnotationConstraintUsingValidatePropertyTest {
 		model.valueWithNotNull = null;
 
 		Set<ConstraintViolation<Model>> constraintViolations = validator.validateProperty( model, "valueWithNotNull" );
-		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNull", "valueWithNotNull" );
-		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container", "type" );
-		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNull.class );
+		assertNumberOfViolations( constraintViolations, 1 );
+		assertCorrectPropertyPaths( constraintViolations, "valueWithNotNull" );
+		assertThat( constraintViolations ).extracting( "message" ).containsOnly( "container" );
+		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
 	}
 
 	@Test
@@ -214,16 +214,16 @@ public class OptionalTypeAnnotationConstraintUsingValidatePropertyTest {
 
 	private static class Model {
 
-		@NotNull(message = "container", payload = { Unwrapping.Skip.class })
+		@NotNull(message = "container")
 		Optional<String> valueWithoutTypeAnnotation;
 
-		@NotNull(message = "container", payload = { Unwrapping.Skip.class })
+		@NotNull(message = "container")
 		Optional<@NotNull(message = "type") String> valueWithNotNull;
 
 		@NotNull(message = "container", payload = { Unwrapping.Unwrap.class })
 		Optional<@NotBlank(message = "type") String> valueWithNotNullUnwrapped;
 
-		@NotNull(message = "container", payload = { Unwrapping.Skip.class })
+		@NotNull(message = "container")
 		Optional<@NullOrNotBlank(message = "type") String> valueWithNullOrNotBlank;
 
 		@NullOrNotBlank(message = "reference")


### PR DESCRIPTION
As a side effect, we only report 1 violation on Optionals when the
Optional is null and the wrapper and the wrapped value have a @NotNull
constraint.