### PR TITLE
HV-1241 Use a proper LRU cache in ConstraintValidatorManager

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/util/LRUCache.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/LRUCache.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.util;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * LRU cache implementation based on {@link LinkedHashMap} and it's {@code accessOrder=true} parameter.
+ *
+ * @author Marko Bekhta
+ */
+public class LRUCache<K,V> extends LinkedHashMap<K,V> {
+
+	/**
+	 * Same load factor as used in {@link java.util.HashMap}
+	 */
+	private static final float LOAD_FACTOR = 0.75f;
+	/**
+	 * Same initial capacity as used in {@link java.util.HashMap}
+	 */
+	private static final int INITIAL_CAPACITY = 16;
+
+	private final int maxCapacity;
+
+	private LRUCache(int initialCapacity, int maxCapacity) {
+		super( initialCapacity, LOAD_FACTOR, true );
+		this.maxCapacity = maxCapacity;
+	}
+
+	@Override protected boolean removeEldestEntry(Map.Entry eldest) {
+		return size() > maxCapacity;
+	}
+
+	public static <K,V> Map<K,V> getInstance(int maxCapacity) {
+		return Collections.synchronizedMap( new LRUCache<>( INITIAL_CAPACITY, maxCapacity ) );
+	}
+
+	public static <K,V> Map<K,V> getInstance(int initialCapacity, int maxCapacity) {
+		return Collections.synchronizedMap( new LRUCache<>( initialCapacity, maxCapacity ) );
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
@@ -15,7 +15,6 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import java.util.Set;
-
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.Validator;
@@ -30,6 +29,7 @@ import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintVa
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 import org.hibernate.validator.testutil.TestForIssue;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -147,7 +147,7 @@ public class ConstraintValidatorManagerTest {
 	}
 
 	@Test
-	public void testOnlyTheInstancesForTheLeastRecentlyUsedCustomFactoryAreCached() {
+	public void testAllInstancesForDifferentCustomFactoriesAreCached() {
 		ConstraintDescriptorImpl<?> constraintDescriptor = getConstraintDescriptorForProperty( "s1" );
 
 		for ( int i = 0; i < 10; i++ ) {
@@ -158,7 +158,7 @@ public class ConstraintValidatorManagerTest {
 			);
 
 			assertEquals(
-					constraintValidatorManager.numberOfCachedConstraintValidatorInstances(), 1,
+					constraintValidatorManager.numberOfCachedConstraintValidatorInstances(), i + 1,
 					"There should be only one instance cached"
 			);
 		}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1241

Created LRU cache based on LinkedHashMap and replaced cache in ConstraintValidatorManager with it.

Will such `LinkedHashMap` based cache be a proper one ? and what should be a max capacity for this cache ?