### PR TITLE
HV-1258 Scoping BeanMetaDataManager per parameter name provider *and* method validation configuration

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/DefaultConstraintMapping.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/DefaultConstraintMapping.java
@@ -24,7 +24,6 @@ import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOption
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.util.Contracts;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -82,17 +81,16 @@ public class DefaultConstraintMapping implements ConstraintMapping {
 	 *
 	 * @param constraintHelper constraint helper required for building constraint descriptors
 	 * @param typeResolutionHelper type resolution helper
-	 * @param parameterNameProvider parameter name provider required for building parameter elements
 	 * @param valueExtractorManager the {@link ValueExtractor} manager
 	 *
 	 * @return a set of {@link BeanConfiguration}s with an element for each type configured through this mapping
 	 */
 	public Set<BeanConfiguration<?>> getBeanConfigurations(ConstraintHelper constraintHelper, TypeResolutionHelper typeResolutionHelper,
-			ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager) {
+			ValueExtractorManager valueExtractorManager) {
 		Set<BeanConfiguration<?>> configurations = newHashSet();
 
 		for ( TypeConstraintMappingContextImpl<?> typeContext : typeContexts ) {
-			configurations.add( typeContext.build( constraintHelper, typeResolutionHelper, parameterNameProvider, valueExtractorManager ) );
+			configurations.add( typeContext.build( constraintHelper, typeResolutionHelper, valueExtractorManager ) );
 		}
 
 		return configurations;

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ExecutableConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ExecutableConstraintMappingContextImpl.java
@@ -24,7 +24,6 @@ import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -106,12 +105,12 @@ abstract class ExecutableConstraintMappingContextImpl {
 	}
 
 	public ConstrainedElement build(ConstraintHelper constraintHelper, TypeResolutionHelper typeResolutionHelper,
-			ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager) {
+			ValueExtractorManager valueExtractorManager) {
 		// TODO HV-919 Support specification of type parameter constraints via XML and API
 		return new ConstrainedExecutable(
 				ConfigurationSource.API,
 				executable,
-				getParameters( constraintHelper, typeResolutionHelper, parameterNameProvider, valueExtractorManager ),
+				getParameters( constraintHelper, typeResolutionHelper, valueExtractorManager ),
 				crossParameterContext != null ? crossParameterContext.getConstraints( constraintHelper, typeResolutionHelper, valueExtractorManager ) : Collections.<MetaConstraint<?>>emptySet(),
 				returnValueContext != null ? returnValueContext.getConstraints( constraintHelper, typeResolutionHelper, valueExtractorManager ) : Collections.<MetaConstraint<?>>emptySet(),
 				Collections.emptySet(),
@@ -121,14 +120,13 @@ abstract class ExecutableConstraintMappingContextImpl {
 	}
 
 	private List<ConstrainedParameter> getParameters(ConstraintHelper constraintHelper, TypeResolutionHelper typeResolutionHelper,
-			ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager) {
+			ValueExtractorManager valueExtractorManager) {
 		List<ConstrainedParameter> constrainedParameters = newArrayList();
-		List<String> parameterNames = parameterNameProvider.getParameterNames( executable );
 
 		for ( int i = 0; i < parameterContexts.length; i++ ) {
 			ParameterConstraintMappingContextImpl parameter = parameterContexts[i];
 			if ( parameter != null ) {
-				constrainedParameters.add( parameter.build( constraintHelper, typeResolutionHelper, parameterNameProvider, valueExtractorManager ) );
+				constrainedParameters.add( parameter.build( constraintHelper, typeResolutionHelper, valueExtractorManager ) );
 			}
 			else {
 				constrainedParameters.add(
@@ -136,8 +134,7 @@ abstract class ExecutableConstraintMappingContextImpl {
 								ConfigurationSource.API,
 								executable,
 								ReflectionHelper.typeOf( executable, i ),
-								i,
-								parameterNames.get( i )
+								i
 						)
 				);
 			}

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ParameterConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ParameterConstraintMappingContextImpl.java
@@ -22,7 +22,6 @@ import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl.ConstraintType;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 
@@ -100,7 +99,7 @@ final class ParameterConstraintMappingContextImpl
 	}
 
 	public ConstrainedParameter build(ConstraintHelper constraintHelper, TypeResolutionHelper typeResolutionHelper,
-			ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager) {
+			ValueExtractorManager valueExtractorManager) {
 		// TODO HV-919 Support specification of type parameter constraints via XML and API
 		Type parameterType = ReflectionHelper.typeOf( executableContext.getExecutable(), parameterIndex );
 
@@ -109,7 +108,6 @@ final class ParameterConstraintMappingContextImpl
 				executableContext.getExecutable(),
 				parameterType,
 				parameterIndex,
-				parameterNameProvider.getParameterNames( executableContext.getExecutable() ).get( parameterIndex ),
 				getConstraints( constraintHelper, typeResolutionHelper, valueExtractorManager ),
 				Collections.emptySet(),
 				groupConversions,

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/TypeConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/TypeConstraintMappingContextImpl.java
@@ -33,7 +33,6 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.ExecutableHelper;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -185,18 +184,18 @@ public final class TypeConstraintMappingContextImpl<C> extends ConstraintMapping
 	}
 
 	BeanConfiguration<C> build(ConstraintHelper constraintHelper, TypeResolutionHelper typeResolutionHelper,
-			ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager) {
+			ValueExtractorManager valueExtractorManager) {
 		return new BeanConfiguration<>(
 				ConfigurationSource.API,
 				beanClass,
-				buildConstraintElements( constraintHelper, typeResolutionHelper, parameterNameProvider, valueExtractorManager ),
+				buildConstraintElements( constraintHelper, typeResolutionHelper, valueExtractorManager ),
 				defaultGroupSequence,
 				getDefaultGroupSequenceProvider()
 		);
 	}
 
 	private Set<ConstrainedElement> buildConstraintElements(ConstraintHelper constraintHelper, TypeResolutionHelper typeResolutionHelper,
-			ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager) {
+			ValueExtractorManager valueExtractorManager) {
 		Set<ConstrainedElement> elements = newHashSet();
 
 		//class-level configuration
@@ -210,7 +209,7 @@ public final class TypeConstraintMappingContextImpl<C> extends ConstraintMapping
 
 		//constructors/methods
 		for ( ExecutableConstraintMappingContextImpl executableContext : executableContexts ) {
-			elements.add( executableContext.build( constraintHelper, typeResolutionHelper, parameterNameProvider, valueExtractorManager ) );
+			elements.add( executableContext.build( constraintHelper, typeResolutionHelper, valueExtractorManager ) );
 		}
 
 		//properties

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
@@ -93,7 +93,7 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 	private boolean failFast;
 	private final List<ValueExtractor<?>> cascadedValueExtractors = new ArrayList<>();
 	private ClassLoader externalClassLoader;
-	private final MethodValidationConfiguration methodValidationConfiguration = new MethodValidationConfiguration();
+	private final MethodValidationConfiguration.Builder methodValidationConfigurationBuilder = new MethodValidationConfiguration.Builder();
 
 	public ConfigurationImpl(BootstrapState state) {
 		this();
@@ -213,36 +213,36 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 
 	@Override
 	public HibernateValidatorConfiguration allowOverridingMethodAlterParameterConstraint(boolean allow) {
-		this.methodValidationConfiguration.allowOverridingMethodAlterParameterConstraint( allow );
+		this.methodValidationConfigurationBuilder.allowOverridingMethodAlterParameterConstraint( allow );
 		return this;
 	}
 
 	public boolean isAllowOverridingMethodAlterParameterConstraint() {
-		return this.methodValidationConfiguration.isAllowOverridingMethodAlterParameterConstraint();
+		return this.methodValidationConfigurationBuilder.isAllowOverridingMethodAlterParameterConstraint();
 	}
 
 	@Override
 	public HibernateValidatorConfiguration allowMultipleCascadedValidationOnReturnValues(boolean allow) {
-		this.methodValidationConfiguration.allowMultipleCascadedValidationOnReturnValues( allow );
+		this.methodValidationConfigurationBuilder.allowMultipleCascadedValidationOnReturnValues( allow );
 		return this;
 	}
 
 	public boolean isAllowMultipleCascadedValidationOnReturnValues() {
-		return this.methodValidationConfiguration.isAllowMultipleCascadedValidationOnReturnValues();
+		return this.methodValidationConfigurationBuilder.isAllowMultipleCascadedValidationOnReturnValues();
 	}
 
 	@Override
 	public HibernateValidatorConfiguration allowParallelMethodsDefineParameterConstraints(boolean allow) {
-		this.methodValidationConfiguration.allowParallelMethodsDefineParameterConstraints( allow );
+		this.methodValidationConfigurationBuilder.allowParallelMethodsDefineParameterConstraints( allow );
 		return this;
 	}
 
 	public boolean isAllowParallelMethodsDefineParameterConstraints() {
-		return this.methodValidationConfiguration.isAllowParallelMethodsDefineParameterConstraints();
+		return this.methodValidationConfigurationBuilder.isAllowParallelMethodsDefineParameterConstraints();
 	}
 
 	public MethodValidationConfiguration getMethodValidationConfiguration() {
-		return this.methodValidationConfiguration;
+		return this.methodValidationConfigurationBuilder.build();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/MethodValidationConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/MethodValidationConfiguration.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -16,8 +18,6 @@ import org.hibernate.validator.internal.metadata.aggregated.rule.ParallelMethods
 import org.hibernate.validator.internal.metadata.aggregated.rule.ParallelMethodsMustNotDefineParameterConstraints;
 import org.hibernate.validator.internal.metadata.aggregated.rule.ReturnValueMayOnlyBeMarkedOnceAsCascadedPerHierarchyLine;
 import org.hibernate.validator.internal.metadata.aggregated.rule.VoidMethodsMustNotBeReturnValueConstrained;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 
 /**
  * These properties modify the behavior of the {@code }Validator} with respect to the Bean Validation
@@ -35,66 +35,16 @@ import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
  * @author Chris Beckey &lt;cbeckey@paypal.com&gt;
  */
 public class MethodValidationConfiguration {
+
 	private boolean allowOverridingMethodAlterParameterConstraint = false;
 	private boolean allowMultipleCascadedValidationOnReturnValues = false;
 	private boolean allowParallelMethodsDefineParameterConstraints = false;
 
-	/**
-	 * Define whether overriding methods that override constraints should throw a {@code ConstraintDefinitionException}.
-	 * The default value is {@code false}, i.e. do not allow.
-	 *
-	 * See Section 4.5.5 of JSR-380 Specification, specifically
-	 * <pre>
-	 * "In sub types (be it sub classes/interfaces or interface implementations), no parameter constraints may
-	 * be declared on overridden or implemented methods, nor may parameters be marked for cascaded validation.
-	 * This would pose a strengthening of preconditions to be fulfilled by the caller."
-	 * </pre>
-	 *
-	 * @param allow flag determining whether validation will allow overriding to alter parameter constraints.
-	 *
-	 * @return {@code this} following the chaining method pattern
-	 */
-	public MethodValidationConfiguration allowOverridingMethodAlterParameterConstraint(boolean allow) {
-		this.allowOverridingMethodAlterParameterConstraint = allow;
-		return this;
-	}
-
-	/**
-	 * Define whether more than one constraint on a return value may be marked for cascading validation are allowed.
-	 * The default value is {@code false}, i.e. do not allow.
-	 *
-	 * "One must not mark a method return value for cascaded validation more than once in a line of a class hierarchy.
-	 * In other words, overriding methods on sub types (be it sub classes/interfaces or interface implementations)
-	 * cannot mark the return value for cascaded validation if the return value has already been marked on the
-	 * overridden method of the super type or interface."
-	 *
-	 * @param allow flag determining whether validation will allow multiple cascaded validation on return values.
-	 *
-	 * @return {@code this} following the chaining method pattern
-	 */
-	public MethodValidationConfiguration allowMultipleCascadedValidationOnReturnValues(boolean allow) {
-		this.allowMultipleCascadedValidationOnReturnValues = allow;
-		return this;
-	}
-
-
-	/**
-	 * Define whether parallel methods that define constraints should throw a {@code ConstraintDefinitionException}. The
-	 * default value is {@code false}, i.e. do not allow.
-	 *
-	 * See Section 4.5.5 of JSR-380 Specification, specifically
-	 * "If a sub type overrides/implements a method originally defined in several parallel types of the hierarchy
-	 * (e.g. two interfaces not extending each other, or a class and an interface not implemented by said class),
-	 * no parameter constraints may be declared for that method at all nor parameters be marked for cascaded validation.
-	 * This again is to avoid an unexpected strengthening of preconditions to be fulfilled by the caller."
-	 *
-	 * @param allow flag determining whether validation will allow parameter constraints in parallel hierarchies
-	 *
-	 * @return {@code this} following the chaining method pattern
-	 */
-	public MethodValidationConfiguration allowParallelMethodsDefineParameterConstraints(boolean allow) {
-		this.allowParallelMethodsDefineParameterConstraints = allow;
-		return this;
+	private MethodValidationConfiguration(boolean allowOverridingMethodAlterParameterConstraint, boolean allowMultipleCascadedValidationOnReturnValues,
+			boolean allowParallelMethodsDefineParameterConstraints) {
+		this.allowOverridingMethodAlterParameterConstraint = allowOverridingMethodAlterParameterConstraint;
+		this.allowMultipleCascadedValidationOnReturnValues = allowMultipleCascadedValidationOnReturnValues;
+		this.allowParallelMethodsDefineParameterConstraints = allowParallelMethodsDefineParameterConstraints;
 	}
 
 	/**
@@ -146,5 +96,100 @@ public class MethodValidationConfiguration {
 		result.add( new ParallelMethodsMustNotDefineGroupConversionForCascadedReturnValue() );
 
 		return Collections.unmodifiableSet( result );
+	}
+
+	public static class Builder {
+
+		private boolean allowOverridingMethodAlterParameterConstraint = false;
+		private boolean allowMultipleCascadedValidationOnReturnValues = false;
+		private boolean allowParallelMethodsDefineParameterConstraints = false;
+
+		public Builder() {
+		}
+
+		public Builder(MethodValidationConfiguration template) {
+			allowOverridingMethodAlterParameterConstraint = template.allowOverridingMethodAlterParameterConstraint;
+			allowMultipleCascadedValidationOnReturnValues = template.allowMultipleCascadedValidationOnReturnValues;
+			allowParallelMethodsDefineParameterConstraints = template.allowParallelMethodsDefineParameterConstraints;
+		}
+
+		/**
+		 * Define whether overriding methods that override constraints should throw a {@code ConstraintDefinitionException}.
+		 * The default value is {@code false}, i.e. do not allow.
+		 *
+		 * See Section 4.5.5 of JSR-380 Specification, specifically
+		 * <pre>
+		 * "In sub types (be it sub classes/interfaces or interface implementations), no parameter constraints may
+		 * be declared on overridden or implemented methods, nor may parameters be marked for cascaded validation.
+		 * This would pose a strengthening of preconditions to be fulfilled by the caller."
+		 * </pre>
+		 *
+		 * @param allow flag determining whether validation will allow overriding to alter parameter constraints.
+		 *
+		 * @return {@code this} following the chaining method pattern
+		 */
+		public Builder allowOverridingMethodAlterParameterConstraint(boolean allow) {
+			this.allowOverridingMethodAlterParameterConstraint = allow;
+			return this;
+		}
+
+		/**
+		 * Define whether more than one constraint on a return value may be marked for cascading validation are allowed.
+		 * The default value is {@code false}, i.e. do not allow.
+		 *
+		 * "One must not mark a method return value for cascaded validation more than once in a line of a class hierarchy.
+		 * In other words, overriding methods on sub types (be it sub classes/interfaces or interface implementations)
+		 * cannot mark the return value for cascaded validation if the return value has already been marked on the
+		 * overridden method of the super type or interface."
+		 *
+		 * @param allow flag determining whether validation will allow multiple cascaded validation on return values.
+		 *
+		 * @return {@code this} following the chaining method pattern
+		 */
+		public Builder allowMultipleCascadedValidationOnReturnValues(boolean allow) {
+			this.allowMultipleCascadedValidationOnReturnValues = allow;
+			return this;
+		}
+
+
+		/**
+		 * Define whether parallel methods that define constraints should throw a {@code ConstraintDefinitionException}. The
+		 * default value is {@code false}, i.e. do not allow.
+		 *
+		 * See Section 4.5.5 of JSR-380 Specification, specifically
+		 * "If a sub type overrides/implements a method originally defined in several parallel types of the hierarchy
+		 * (e.g. two interfaces not extending each other, or a class and an interface not implemented by said class),
+		 * no parameter constraints may be declared for that method at all nor parameters be marked for cascaded validation.
+		 * This again is to avoid an unexpected strengthening of preconditions to be fulfilled by the caller."
+		 *
+		 * @param allow flag determining whether validation will allow parameter constraints in parallel hierarchies
+		 *
+		 * @return {@code this} following the chaining method pattern
+		 */
+		public Builder allowParallelMethodsDefineParameterConstraints(boolean allow) {
+			this.allowParallelMethodsDefineParameterConstraints = allow;
+			return this;
+		}
+
+		public boolean isAllowOverridingMethodAlterParameterConstraint() {
+			return allowOverridingMethodAlterParameterConstraint;
+		}
+
+		public boolean isAllowMultipleCascadedValidationOnReturnValues() {
+			return allowMultipleCascadedValidationOnReturnValues;
+		}
+
+		public boolean isAllowParallelMethodsDefineParameterConstraints() {
+			return allowParallelMethodsDefineParameterConstraints;
+		}
+
+		public MethodValidationConfiguration build() {
+			return new MethodValidationConfiguration(
+					allowOverridingMethodAlterParameterConstraint,
+					allowMultipleCascadedValidationOnReturnValues,
+					allowParallelMethodsDefineParameterConstraints
+			);
+		}
+
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/MethodValidationConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/MethodValidationConfiguration.java
@@ -98,6 +98,40 @@ public class MethodValidationConfiguration {
 		return Collections.unmodifiableSet( result );
 	}
 
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ( allowMultipleCascadedValidationOnReturnValues ? 1231 : 1237 );
+		result = prime * result + ( allowOverridingMethodAlterParameterConstraint ? 1231 : 1237 );
+		result = prime * result + ( allowParallelMethodsDefineParameterConstraints ? 1231 : 1237 );
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		MethodValidationConfiguration other = (MethodValidationConfiguration) obj;
+		if ( allowMultipleCascadedValidationOnReturnValues != other.allowMultipleCascadedValidationOnReturnValues ) {
+			return false;
+		}
+		if ( allowOverridingMethodAlterParameterConstraint != other.allowOverridingMethodAlterParameterConstraint ) {
+			return false;
+		}
+		if ( allowParallelMethodsDefineParameterConstraints != other.allowParallelMethodsDefineParameterConstraints ) {
+			return false;
+		}
+		return true;
+	}
+
 	public static class Builder {
 
 		private boolean allowOverridingMethodAlterParameterConstraint = false;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
@@ -35,7 +35,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 	private ClockProvider clockProvider;
 	private boolean failFast;
 	private final ValueExtractorManager valueExtractorManager;
-	private final MethodValidationConfiguration methodValidationConfiguration = new MethodValidationConfiguration();
+	private final MethodValidationConfiguration.Builder methodValidationConfigurationBuilder;
 
 
 	public ValidatorContextImpl(ValidatorFactoryImpl validatorFactory) {
@@ -46,6 +46,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 		this.parameterNameProvider = validatorFactory.getExecutableParameterNameProvider();
 		this.clockProvider = validatorFactory.getClockProvider();
 		this.failFast = validatorFactory.isFailFast();
+		this.methodValidationConfigurationBuilder = new MethodValidationConfiguration.Builder( validatorFactory.getMethodValidationConfiguration() );
 		// TODO make overwritable per this context
 		this.valueExtractorManager = validatorFactory.getValueExtractorManager();
 	}
@@ -113,19 +114,19 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 
 	@Override
 	public HibernateValidatorContext allowOverridingMethodAlterParameterConstraint(boolean allow) {
-		this.methodValidationConfiguration.allowOverridingMethodAlterParameterConstraint( allow );
+		methodValidationConfigurationBuilder.allowOverridingMethodAlterParameterConstraint( allow );
 		return this;
 	}
 
 	@Override
 	public HibernateValidatorContext allowMultipleCascadedValidationOnReturnValues(boolean allow) {
-		this.methodValidationConfiguration.allowMultipleCascadedValidationOnReturnValues( allow );
+		methodValidationConfigurationBuilder.allowMultipleCascadedValidationOnReturnValues( allow );
 		return this;
 	}
 
 	@Override
 	public HibernateValidatorContext allowParallelMethodsDefineParameterConstraints(boolean allow) {
-		this.methodValidationConfiguration.allowParallelMethodsDefineParameterConstraints( allow );
+		methodValidationConfigurationBuilder.allowParallelMethodsDefineParameterConstraints( allow );
 		return this;
 	}
 
@@ -139,7 +140,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 				clockProvider,
 				failFast,
 				valueExtractorManager,
-				methodValidationConfiguration
+				methodValidationConfigurationBuilder.build()
 		);
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -187,7 +187,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		}
 		else {
 			this.xmlMetaDataProvider = new XmlMetaDataProvider(
-					constraintHelper, typeResolutionHelper, parameterNameProvider, valueExtractorManager, configurationState.getMappingStreams(), externalClassLoader
+					constraintHelper, typeResolutionHelper, valueExtractorManager, configurationState.getMappingStreams(), externalClassLoader
 			);
 		}
 
@@ -362,7 +362,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 						typeResolutionHelper,
 						parameterNameProvider,
 						valueExtractorManager,
-						buildDataProviders( parameterNameProvider ),
+						buildDataProviders(),
 						methodValidationConfiguration
 				)
 		 );
@@ -380,7 +380,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		);
 	}
 
-	private List<MetaDataProvider> buildDataProviders(ExecutableParameterNameProvider parameterNameProvider) {
+	private List<MetaDataProvider> buildDataProviders() {
 		List<MetaDataProvider> metaDataProviders = newArrayList();
 		if ( xmlMetaDataProvider != null ) {
 			metaDataProviders.add( xmlMetaDataProvider );
@@ -391,7 +391,6 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 					new ProgrammaticMetaDataProvider(
 							constraintHelper,
 							typeResolutionHelper,
-							parameterNameProvider,
 							valueExtractorManager,
 							constraintMappings
 					)

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -34,6 +34,7 @@ import org.hibernate.validator.HibernateValidatorContext;
 import org.hibernate.validator.HibernateValidatorFactory;
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
+import org.hibernate.validator.internal.engine.MethodValidationConfiguration.Builder;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.engine.constraintdefinition.ConstraintDefinitionContribution;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
@@ -205,14 +206,14 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		tmpFailFast = checkPropertiesForBoolean( properties, HibernateValidatorConfiguration.FAIL_FAST, tmpFailFast );
 		this.failFast = tmpFailFast;
 
-		this.methodValidationConfiguration = new MethodValidationConfiguration();
+		Builder methodValidationConfigurationBuilder = new MethodValidationConfiguration.Builder();
 
 		tmpAllowOverridingMethodAlterParameterConstraint = checkPropertiesForBoolean(
 				properties,
 				HibernateValidatorConfiguration.ALLOW_PARAMETER_CONSTRAINT_OVERRIDE,
 				tmpAllowOverridingMethodAlterParameterConstraint
 		);
-		this.methodValidationConfiguration.allowOverridingMethodAlterParameterConstraint(
+		methodValidationConfigurationBuilder.allowOverridingMethodAlterParameterConstraint(
 				tmpAllowOverridingMethodAlterParameterConstraint
 		);
 
@@ -221,7 +222,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 				HibernateValidatorConfiguration.ALLOW_MULTIPLE_CASCADED_VALIDATION_ON_RESULT,
 				tmpAllowMultipleCascadedValidationOnReturnValues
 		);
-		this.methodValidationConfiguration.allowMultipleCascadedValidationOnReturnValues(
+		methodValidationConfigurationBuilder.allowMultipleCascadedValidationOnReturnValues(
 				tmpAllowMultipleCascadedValidationOnReturnValues
 		);
 
@@ -230,9 +231,10 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 				HibernateValidatorConfiguration.ALLOW_PARALLEL_METHODS_DEFINE_PARAMETER_CONSTRAINTS,
 				tmpAllowParallelMethodsDefineParameterConstraints
 		);
-		this.methodValidationConfiguration.allowParallelMethodsDefineParameterConstraints(
+		methodValidationConfigurationBuilder.allowParallelMethodsDefineParameterConstraints(
 				tmpAllowParallelMethodsDefineParameterConstraints
 		);
+		this.methodValidationConfiguration = methodValidationConfigurationBuilder.build();
 
 		this.constraintValidatorManager = new ConstraintValidatorManager( configurationState.getConstraintValidatorFactory() );
 	}
@@ -317,6 +319,10 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 
 	public boolean isFailFast() {
 		return failFast;
+	}
+
+	MethodValidationConfiguration getMethodValidationConfiguration() {
+		return methodValidationConfiguration;
 	}
 
 	ValueExtractorManager getValueExtractorManager() {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/BeanMetaDataManager.java
@@ -92,6 +92,8 @@ public class BeanMetaDataManager {
 	 */
 	private final ValueExtractorManager valueExtractorManager;
 
+	private final ExecutableParameterNameProvider parameterNameProvider;
+
 	/**
 	 * Used to cache the constraint meta data for validated entities
 	 */
@@ -111,29 +113,6 @@ public class BeanMetaDataManager {
 	 */
 	private final MethodValidationConfiguration methodValidationConfiguration;
 
-	/**
-	 * Creates a new {@code BeanMetaDataManager}.
-	 *
-	 * @param constraintHelper the constraint helper
-	 * @param executableHelper the executable helper
-	 * @param typeResolutionHelper the type resolution helper
-	 * @param parameterNameProvider the parameter name provider
-	 * @param valueExtractorManager the {@link ValueExtractor} manager
-	 * @param optionalMetaDataProviders optional meta data provider used on top of the annotation based provider
-	 */
-	public BeanMetaDataManager(ConstraintHelper constraintHelper,
-			ExecutableHelper executableHelper,
-			TypeResolutionHelper typeResolutionHelper,
-			ExecutableParameterNameProvider parameterNameProvider,
-			ValueExtractorManager valueExtractorManager,
-			List<MetaDataProvider> optionalMetaDataProviders) {
-		this(
-				constraintHelper, executableHelper, typeResolutionHelper, parameterNameProvider,
-				valueExtractorManager, optionalMetaDataProviders,
-				new MethodValidationConfiguration()
-		);
-	}
-
 	public BeanMetaDataManager(ConstraintHelper constraintHelper,
 			ExecutableHelper executableHelper,
 			TypeResolutionHelper typeResolutionHelper,
@@ -145,6 +124,7 @@ public class BeanMetaDataManager {
 		this.executableHelper = executableHelper;
 		this.typeResolutionHelper = typeResolutionHelper;
 		this.valueExtractorManager = valueExtractorManager;
+		this.parameterNameProvider = parameterNameProvider;
 
 		this.metaDataProviders = newArrayList();
 		this.metaDataProviders.addAll( optionalMetaDataProviders );
@@ -164,7 +144,6 @@ public class BeanMetaDataManager {
 		AnnotationMetaDataProvider defaultProvider = new AnnotationMetaDataProvider(
 					constraintHelper,
 					typeResolutionHelper,
-					parameterNameProvider,
 					valueExtractorManager,
 					annotationProcessingOptions
 			);
@@ -199,7 +178,7 @@ public class BeanMetaDataManager {
 	 */
 	private <T> BeanMetaDataImpl<T> createBeanMetaData(Class<T> clazz) {
 		BeanMetaDataBuilder<T> builder = BeanMetaDataBuilder.getInstance(
-				constraintHelper, executableHelper, typeResolutionHelper, valueExtractorManager, validationOrderGenerator, clazz, methodValidationConfiguration );
+				constraintHelper, executableHelper, typeResolutionHelper, valueExtractorManager, parameterNameProvider, validationOrderGenerator, clazz, methodValidationConfiguration );
 
 		for ( MetaDataProvider provider : metaDataProviders ) {
 			for ( BeanConfiguration<? super T> beanConfiguration : getBeanConfigurationForHierarchy( provider, clazz ) ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -26,7 +26,6 @@ import javax.validation.ElementKind;
 import javax.validation.groups.Default;
 import javax.validation.metadata.BeanDescriptor;
 import javax.validation.metadata.ConstructorDescriptor;
-import javax.validation.metadata.MethodType;
 import javax.validation.metadata.PropertyDescriptor;
 
 import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
@@ -48,6 +47,7 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
 import org.hibernate.validator.internal.util.ExecutableHelper;
+import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
 import org.hibernate.validator.internal.util.classhierarchy.Filters;
@@ -479,34 +479,27 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	public static class BeanMetaDataBuilder<T> {
 
 		private final ConstraintHelper constraintHelper;
-
 		private final ValidationOrderGenerator validationOrderGenerator;
-
 		private final Class<T> beanClass;
-
 		private final Set<BuilderDelegate> builders = newHashSet();
-
 		private final ExecutableHelper executableHelper;
-
 		private final TypeResolutionHelper typeResolutionHelper;
-
 		private final ValueExtractorManager valueExtractorManager;
+		private final ExecutableParameterNameProvider parameterNameProvider;
+		private final MethodValidationConfiguration methodValidationConfiguration;
 
 		private ConfigurationSource sequenceSource;
-
 		private ConfigurationSource providerSource;
-
 		private List<Class<?>> defaultGroupSequence;
-
 		private DefaultGroupSequenceProvider<? super T> defaultGroupSequenceProvider;
 
-		private final MethodValidationConfiguration methodValidationConfiguration;
 
 		private BeanMetaDataBuilder(
 				ConstraintHelper constraintHelper,
 				ExecutableHelper executableHelper,
 				TypeResolutionHelper typeResolutionHelper,
 				ValueExtractorManager valueExtractorManager,
+				ExecutableParameterNameProvider parameterNameProvider,
 				ValidationOrderGenerator validationOrderGenerator,
 				Class<T> beanClass,
 				MethodValidationConfiguration methodValidationConfiguration) {
@@ -516,6 +509,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 			this.executableHelper = executableHelper;
 			this.typeResolutionHelper = typeResolutionHelper;
 			this.valueExtractorManager = valueExtractorManager;
+			this.parameterNameProvider = parameterNameProvider;
 			this.methodValidationConfiguration = methodValidationConfiguration;
 		}
 
@@ -524,6 +518,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 				ExecutableHelper executableHelper,
 				TypeResolutionHelper typeResolutionHelper,
 				ValueExtractorManager valueExtractorManager,
+				ExecutableParameterNameProvider parameterNameProvider,
 				ValidationOrderGenerator validationOrderGenerator,
 				Class<T> beanClass,
 				MethodValidationConfiguration methodValidationConfiguration) {
@@ -532,6 +527,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 					executableHelper,
 					typeResolutionHelper,
 					valueExtractorManager,
+					parameterNameProvider,
 					validationOrderGenerator,
 					beanClass,
 					methodValidationConfiguration );
@@ -578,6 +574,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 							executableHelper,
 							typeResolutionHelper,
 							valueExtractorManager,
+							parameterNameProvider,
 							methodValidationConfiguration
 					)
 			);
@@ -606,6 +603,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 		private final ExecutableHelper executableHelper;
 		private final TypeResolutionHelper typeResolutionHelper;
 		private final ValueExtractorManager valueExtractorManager;
+		private final ExecutableParameterNameProvider parameterNameProvider;
 		private MetaDataBuilder propertyBuilder;
 		private ExecutableMetaData.Builder methodBuilder;
 		private final MethodValidationConfiguration methodValidationConfiguration;
@@ -618,6 +616,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 				ExecutableHelper executableHelper,
 				TypeResolutionHelper typeResolutionHelper,
 				ValueExtractorManager valueExtractorManager,
+				ExecutableParameterNameProvider parameterNameProvider,
 				MethodValidationConfiguration methodValidationConfiguration
 		) {
 			this.beanClass = beanClass;
@@ -625,6 +624,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 			this.executableHelper = executableHelper;
 			this.typeResolutionHelper = typeResolutionHelper;
 			this.valueExtractorManager = valueExtractorManager;
+			this.parameterNameProvider = parameterNameProvider;
 			this.methodValidationConfiguration = methodValidationConfiguration;
 
 			switch ( constrainedElement.getKind() ) {
@@ -653,6 +653,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 								executableHelper,
 								typeResolutionHelper,
 								valueExtractorManager,
+								parameterNameProvider,
 								methodValidationConfiguration
 						);
 					}
@@ -700,6 +701,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 							executableHelper,
 							typeResolutionHelper,
 							valueExtractorManager,
+							parameterNameProvider,
 							methodValidationConfiguration
 					);
 				}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -73,6 +73,11 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	 */
 	private static final List<Class<?>> DEFAULT_GROUP_SEQUENCE = Collections.<Class<?>>singletonList( Default.class );
 
+	/**
+	 * Whether there are any constraints or cascades at all.
+	 */
+	private final boolean hasConstraints;
+
 	private final ValidationOrderGenerator validationOrderGenerator;
 
 	/**
@@ -157,8 +162,11 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 
 		Set<PropertyMetaData> propertyMetaDataSet = newHashSet();
 		Set<ExecutableMetaData> executableMetaDataSet = newHashSet();
+		boolean hasConstraints = false;
 
 		for ( ConstraintMetaData constraintMetaData : constraintMetaDataSet ) {
+			hasConstraints |= constraintMetaData.isCascading() || constraintMetaData.isConstrained();
+
 			if ( constraintMetaData.getKind() == ElementKind.PROPERTY ) {
 				propertyMetaDataSet.add( (PropertyMetaData) constraintMetaData );
 			}
@@ -176,6 +184,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 			allMetaConstraints.addAll( propertyMetaData.getConstraints() );
 		}
 
+		this.hasConstraints = hasConstraints;
 		this.cascadedProperties = Collections.unmodifiableSet( cascadedProperties );
 		this.allMetaConstraints = Collections.unmodifiableSet( allMetaConstraints );
 
@@ -232,13 +241,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 
 	@Override
 	public boolean hasConstraints() {
-		if ( beanDescriptor.isBeanConstrained()
-				|| !beanDescriptor.getConstrainedConstructors().isEmpty()
-				|| !beanDescriptor.getConstrainedMethods( MethodType.NON_GETTER, MethodType.GETTER ).isEmpty() ) {
-			return true;
-		}
-
-		return false;
+		return hasConstraints;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
@@ -37,6 +37,7 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
 import org.hibernate.validator.internal.util.ExecutableHelper;
+import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 
@@ -262,6 +263,8 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 
 		private final ExecutableHelper executableHelper;
 
+		private final ExecutableParameterNameProvider parameterNameProvider;
+
 		public Builder(
 				Class<?> beanClass,
 				ConstrainedExecutable constrainedExecutable,
@@ -269,10 +272,12 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 				ExecutableHelper executableHelper,
 				TypeResolutionHelper typeResolutionHelper,
 				ValueExtractorManager valueExtractorManager,
+				ExecutableParameterNameProvider parameterNameProvider,
 				MethodValidationConfiguration methodValidationConfiguration) {
 			super( beanClass, constraintHelper, typeResolutionHelper, valueExtractorManager );
 
 			this.executableHelper = executableHelper;
+			this.parameterNameProvider = parameterNameProvider;
 			this.kind = constrainedExecutable.getKind();
 			this.executable = constrainedExecutable.getExecutable();
 			this.rules = new HashSet<>( methodValidationConfiguration.getConfiguredRuleSet() );
@@ -389,7 +394,8 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 										oneParameter,
 										constraintHelper,
 										typeResolutionHelper,
-										valueExtractorManager
+										valueExtractorManager,
+										parameterNameProvider
 								)
 						);
 					}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
@@ -65,7 +65,6 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.ConcurrentReferenceHashMap;
 import org.hibernate.validator.internal.util.ExecutableHelper;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -94,17 +93,14 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 	protected final TypeResolutionHelper typeResolutionHelper;
 	protected final ConcurrentReferenceHashMap<Class<?>, BeanConfiguration<?>> configuredBeans;
 	protected final AnnotationProcessingOptions annotationProcessingOptions;
-	protected final ExecutableParameterNameProvider parameterNameProvider;
 	protected final ValueExtractorManager valueExtractorManager;
 
 	public AnnotationMetaDataProvider(ConstraintHelper constraintHelper,
 			TypeResolutionHelper typeResolutionHelper,
-			ExecutableParameterNameProvider parameterNameProvider,
 			ValueExtractorManager valueExtractorManager,
 			AnnotationProcessingOptions annotationProcessingOptions) {
 		this.constraintHelper = constraintHelper;
 		this.typeResolutionHelper = typeResolutionHelper;
-		this.parameterNameProvider = parameterNameProvider;
 		this.valueExtractorManager = valueExtractorManager;
 		this.annotationProcessingOptions = annotationProcessingOptions;
 		this.configuredBeans = new ConcurrentReferenceHashMap<>(
@@ -395,8 +391,6 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 	private List<ConstrainedParameter> getParameterMetaData(Executable executable) {
 		List<ConstrainedParameter> metaData = newArrayList();
 
-		List<String> parameterNames = parameterNameProvider.getParameterNames( executable );
-
 		int i = 0;
 		for ( Parameter parameter : executable.getParameters() ) {
 			Annotation[] parameterAnnotations;
@@ -408,7 +402,6 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 				parameterAnnotations = new Annotation[0];
 			}
 
-			String parameterName = parameterNames.get( i );
 			Set<MetaConstraint<?>> parameterConstraints = newHashSet();
 			ConvertGroup groupConversion = null;
 			ConvertGroup.List groupConversionList = null;
@@ -420,7 +413,6 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 								executable,
 								ReflectionHelper.typeOf( executable, i ),
 								i,
-								parameterName,
 								parameterConstraints,
 								Collections.emptySet(),
 								getGroupConversions( groupConversion, groupConversionList ),
@@ -462,7 +454,6 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 							executable,
 							ReflectionHelper.typeOf( executable, i ),
 							i,
-							parameterName,
 							parameterConstraints,
 							typeArgumentsConstraints,
 							getGroupConversions( groupConversion, groupConversionList ),

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/ProgrammaticMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/ProgrammaticMetaDataProvider.java
@@ -20,7 +20,6 @@ import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOption
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.util.Contracts;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -42,13 +41,12 @@ public class ProgrammaticMetaDataProvider implements MetaDataProvider {
 
 	public ProgrammaticMetaDataProvider(ConstraintHelper constraintHelper,
 										TypeResolutionHelper typeResolutionHelper,
-										ExecutableParameterNameProvider parameterNameProvider,
 										ValueExtractorManager valueExtractorManager,
 										Set<DefaultConstraintMapping> constraintMappings) {
 		Contracts.assertNotNull( constraintMappings );
 
 		configuredBeans = Collections.unmodifiableMap(
-				createBeanConfigurations( constraintMappings, constraintHelper, typeResolutionHelper, parameterNameProvider, valueExtractorManager )
+				createBeanConfigurations( constraintMappings, constraintHelper, typeResolutionHelper, valueExtractorManager )
 		);
 
 		assertUniquenessOfConfiguredTypes( constraintMappings );
@@ -70,10 +68,10 @@ public class ProgrammaticMetaDataProvider implements MetaDataProvider {
 	}
 
 	private static Map<String, BeanConfiguration<?>> createBeanConfigurations(Set<DefaultConstraintMapping> mappings, ConstraintHelper constraintHelper,
-			TypeResolutionHelper typeResolutionHelper, ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager) {
+			TypeResolutionHelper typeResolutionHelper, ValueExtractorManager valueExtractorManager) {
 		final Map<String, BeanConfiguration<?>> configuredBeans = new HashMap<>();
 		for ( DefaultConstraintMapping mapping : mappings ) {
-			Set<BeanConfiguration<?>> beanConfigurations = mapping.getBeanConfigurations( constraintHelper, typeResolutionHelper, parameterNameProvider,
+			Set<BeanConfiguration<?>> beanConfigurations = mapping.getBeanConfigurations( constraintHelper, typeResolutionHelper,
 					valueExtractorManager );
 
 			for ( BeanConfiguration<?> beanConfiguration : beanConfigurations ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/XmlMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/XmlMetaDataProvider.java
@@ -18,7 +18,6 @@ import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.stereotypes.Immutable;
 import org.hibernate.validator.internal.xml.MappingXmlParser;
@@ -40,12 +39,11 @@ public class XmlMetaDataProvider implements MetaDataProvider {
 
 	public XmlMetaDataProvider(ConstraintHelper constraintHelper,
 			TypeResolutionHelper typeResolutionHelper,
-			ExecutableParameterNameProvider parameterNameProvider,
 			ValueExtractorManager valueExtractorManager,
 			Set<InputStream> mappingStreams,
 			ClassLoader externalClassLoader) {
 
-		MappingXmlParser mappingParser = new MappingXmlParser( constraintHelper, typeResolutionHelper, parameterNameProvider, valueExtractorManager,
+		MappingXmlParser mappingParser = new MappingXmlParser( constraintHelper, typeResolutionHelper, valueExtractorManager,
 				externalClassLoader );
 		mappingParser.parse( mappingStreams );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedParameter.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/raw/ConstrainedParameter.java
@@ -31,20 +31,17 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 
 	private final Executable executable;
 	private final Type type;
-	private final String name;
 	private final int index;
 
 	public ConstrainedParameter(ConfigurationSource source,
 								Executable executable,
 								Type type,
-								int index,
-								String name) {
+								int index) {
 		this(
 				source,
 				executable,
 				type,
 				index,
-				name,
 				Collections.<MetaConstraint<?>>emptySet(),
 				Collections.<MetaConstraint<?>>emptySet(),
 				Collections.<Class<?>, Class<?>>emptyMap(),
@@ -59,7 +56,6 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 	 * @param  executable The executable of the represented method parameter.
 	 * @param type the parameter type
 	 * @param index the index of the parameter
-	 * @param name The name of the represented parameter.
 	 * @param constraints The constraints of the represented method parameter, if
 	 * any.
 	 * @param typeArgumentConstraints Type arguments constraints, if any.
@@ -70,7 +66,6 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 								Executable executable,
 								Type type,
 								int index,
-								String name,
 								Set<MetaConstraint<?>> constraints,
 								Set<MetaConstraint<?>> typeArgumentConstraints,
 								Map<Class<?>, Class<?>> groupConversions,
@@ -86,7 +81,6 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 
 		this.executable = executable;
 		this.type = type;
-		this.name = name;
 		this.index = index;
 	}
 
@@ -96,10 +90,6 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 
 	public Executable getExecutable() {
 		return executable;
-	}
-
-	public String getName() {
-		return name;
 	}
 
 	public int getIndex() {
@@ -116,14 +106,6 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 	 */
 	public ConstrainedParameter merge(ConstrainedParameter other) {
 		ConfigurationSource mergedSource = ConfigurationSource.max( source, other.source );
-
-		String mergedName;
-		if ( source.getPriority() > other.source.getPriority() ) {
-			mergedName = name;
-		}
-		else {
-			mergedName = other.name;
-		}
 
 		Set<MetaConstraint<?>> mergedConstraints = newHashSet( constraints );
 		mergedConstraints.addAll( other.constraints );
@@ -142,7 +124,6 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 				executable,
 				type,
 				index,
-				mergedName,
 				mergedConstraints,
 				mergedTypeArgumentConstraints,
 				mergedGroupConversions,
@@ -162,7 +143,7 @@ public class ConstrainedParameter extends AbstractConstrainedElement {
 
 		String constraintsAsString = sb.length() > 0 ? sb.substring( 0, sb.length() - 2 ) : sb.toString();
 
-		return "ParameterMetaData [executable=" + executable + "], name=" + name + "], constraints=["
+		return "ParameterMetaData [executable=" + executable + "], index=" + index + "], constraints=["
 				+ constraintsAsString + "], isCascading=" + isCascading() + "]";
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedExecutableBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedExecutableBuilder.java
@@ -31,7 +31,6 @@ import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
 import org.hibernate.validator.internal.util.ExecutableHelper;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -59,15 +58,13 @@ class ConstrainedExecutableBuilder {
 	private final ConstrainedParameterBuilder constrainedParameterBuilder;
 	private final AnnotationProcessingOptionsImpl annotationProcessingOptions;
 
-	ConstrainedExecutableBuilder(ClassLoadingHelper classLoadingHelper, ExecutableParameterNameProvider parameterNameProvider,
-			MetaConstraintBuilder metaConstraintBuilder, GroupConversionBuilder groupConversionBuilder,
-			AnnotationProcessingOptionsImpl annotationProcessingOptions) {
+	ConstrainedExecutableBuilder(ClassLoadingHelper classLoadingHelper, MetaConstraintBuilder metaConstraintBuilder,
+			GroupConversionBuilder groupConversionBuilder, AnnotationProcessingOptionsImpl annotationProcessingOptions) {
 		this.classLoadingHelper = classLoadingHelper;
 		this.metaConstraintBuilder = metaConstraintBuilder;
 		this.groupConversionBuilder = groupConversionBuilder;
 		this.constrainedParameterBuilder = new ConstrainedParameterBuilder(
 				metaConstraintBuilder,
-				parameterNameProvider,
 				groupConversionBuilder,
 				annotationProcessingOptions
 		);

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedParameterBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ConstrainedParameterBuilder.java
@@ -23,7 +23,6 @@ import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.xml.binding.ConstraintType;
 import org.hibernate.validator.internal.xml.binding.ParameterType;
@@ -36,15 +35,13 @@ import org.hibernate.validator.internal.xml.binding.ParameterType;
 class ConstrainedParameterBuilder {
 
 	private final GroupConversionBuilder groupConversionBuilder;
-	private final ExecutableParameterNameProvider parameterNameProvider;
 	private final MetaConstraintBuilder metaConstraintBuilder;
 	private final AnnotationProcessingOptionsImpl annotationProcessingOptions;
 
 	ConstrainedParameterBuilder(MetaConstraintBuilder metaConstraintBuilder,
-			ExecutableParameterNameProvider parameterNameProvider, GroupConversionBuilder groupConversionBuilder,
+			GroupConversionBuilder groupConversionBuilder,
 			AnnotationProcessingOptionsImpl annotationProcessingOptions) {
 		this.metaConstraintBuilder = metaConstraintBuilder;
-		this.parameterNameProvider = parameterNameProvider;
 		this.groupConversionBuilder = groupConversionBuilder;
 		this.annotationProcessingOptions = annotationProcessingOptions;
 	}
@@ -54,7 +51,6 @@ class ConstrainedParameterBuilder {
 																		String defaultPackage) {
 		List<ConstrainedParameter> constrainedParameters = newArrayList();
 		int i = 0;
-		List<String> parameterNames = parameterNameProvider.getParameterNames( executable );
 		for ( ParameterType parameterType : parameterList ) {
 			ConstraintLocation constraintLocation = ConstraintLocation.forParameter( executable, i );
 			Set<MetaConstraint<?>> metaConstraints = newHashSet();
@@ -89,7 +85,6 @@ class ConstrainedParameterBuilder {
 					executable,
 					type,
 					i,
-					parameterNames.get( i ),
 					metaConstraints,
 					Collections.emptySet(),
 					groupConversions,

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/MappingXmlParser.java
@@ -41,7 +41,6 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -71,7 +70,6 @@ public class MappingXmlParser {
 	private final Map<Class<?>, Set<ConstrainedElement>> constrainedElements;
 
 	private final XmlParserHelper xmlParserHelper;
-	private final ExecutableParameterNameProvider parameterNameProvider;
 
 	private final ClassLoadingHelper classLoadingHelper;
 
@@ -87,8 +85,8 @@ public class MappingXmlParser {
 		return schemasByVersion;
 	}
 
-	public MappingXmlParser(ConstraintHelper constraintHelper, TypeResolutionHelper typeResolutionHelper, ExecutableParameterNameProvider parameterNameProvider,
-			ValueExtractorManager valueExtractorManager, ClassLoader externalClassLoader) {
+	public MappingXmlParser(ConstraintHelper constraintHelper, TypeResolutionHelper typeResolutionHelper, ValueExtractorManager valueExtractorManager,
+			ClassLoader externalClassLoader) {
 		this.constraintHelper = constraintHelper;
 		this.typeResolutionHelper = typeResolutionHelper;
 		this.valueExtractorManager = valueExtractorManager;
@@ -96,7 +94,6 @@ public class MappingXmlParser {
 		this.defaultSequences = newHashMap();
 		this.constrainedElements = newHashMap();
 		this.xmlParserHelper = new XmlParserHelper();
-		this.parameterNameProvider = parameterNameProvider;
 		this.classLoadingHelper = new ClassLoadingHelper( externalClassLoader );
 	}
 
@@ -133,7 +130,6 @@ public class MappingXmlParser {
 			);
 			ConstrainedExecutableBuilder constrainedExecutableBuilder = new ConstrainedExecutableBuilder(
 					classLoadingHelper,
-					parameterNameProvider,
 					metaConstraintBuilder,
 					groupConversionBuilder,
 					annotationProcessingOptions

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ConstraintMappingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ConstraintMappingTest.java
@@ -46,7 +46,6 @@ import org.hibernate.validator.cfg.defs.RangeDef;
 import org.hibernate.validator.cfg.defs.SizeDef;
 import org.hibernate.validator.group.GroupSequenceProvider;
 import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
-import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
@@ -54,7 +53,6 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement.ConstrainedElementKind;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 import org.hibernate.validator.testutils.ValidatorUtil;
@@ -516,7 +514,6 @@ public class ConstraintMappingTest {
 		Set<BeanConfiguration<?>> beanConfigurations = mapping.getBeanConfigurations(
 				new ConstraintHelper(),
 				new TypeResolutionHelper(),
-				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ) );
 
 		for ( BeanConfiguration<?> beanConfiguration : beanConfigurations ) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
@@ -188,7 +188,7 @@ public class PathImplTest {
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
 				Collections.<MetaDataProvider>emptyList(),
-				new MethodValidationConfiguration()
+				new MethodValidationConfiguration.Builder().build()
 		);
 
 		ExecutableMetaData executableMetaData = beanMetaDataManager.getBeanMetaData( Container.class )

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
@@ -26,6 +26,7 @@ import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
@@ -186,7 +187,8 @@ public class PathImplTest {
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
-				Collections.<MetaDataProvider>emptyList()
+				Collections.<MetaDataProvider>emptyList(),
+				new MethodValidationConfiguration()
 		);
 
 		ExecutableMetaData executableMetaData = beanMetaDataManager.getBeanMetaData( Container.class )

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
@@ -54,7 +54,7 @@ public class BeanMetaDataManagerTest {
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
 				Collections.<MetaDataProvider>emptyList(),
-				new MethodValidationConfiguration()
+				new MethodValidationConfiguration.Builder().build()
 		);
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
@@ -52,7 +53,8 @@ public class BeanMetaDataManagerTest {
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
-				Collections.<MetaDataProvider>emptyList()
+				Collections.<MetaDataProvider>emptyList(),
+				new MethodValidationConfiguration()
 		);
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
@@ -22,6 +22,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.groups.Default;
 
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
@@ -59,7 +60,8 @@ public class ExecutableMetaDataTest {
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
-				Collections.<MetaDataProvider>emptyList()
+				Collections.<MetaDataProvider>emptyList(),
+				new MethodValidationConfiguration()
 		);
 
 		beanMetaData = beanMetaDataManager.getBeanMetaData( CustomerRepositoryExt.class );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
@@ -61,7 +61,7 @@ public class ExecutableMetaDataTest {
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
 				Collections.<MetaDataProvider>emptyList(),
-				new MethodValidationConfiguration()
+				new MethodValidationConfiguration.Builder().build()
 		);
 
 		beanMetaData = beanMetaDataManager.getBeanMetaData( CustomerRepositoryExt.class );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
@@ -61,7 +61,7 @@ public class ParameterMetaDataTest {
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
 				Collections.<MetaDataProvider>emptyList(),
-				new MethodValidationConfiguration()
+				new MethodValidationConfiguration.Builder().build()
 		);
 
 		beanMetaData = beanMetaDataManager.getBeanMetaData( CustomerRepository.class );
@@ -136,7 +136,7 @@ public class ParameterMetaDataTest {
 				new ExecutableParameterNameProvider( new SkewedParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
 				Collections.<MetaDataProvider>emptyList(),
-				new MethodValidationConfiguration()
+				new MethodValidationConfiguration.Builder().build()
 		);
 		BeanMetaData<ServiceImpl> localBeanMetaData = beanMetaDataManager.getBeanMetaData( ServiceImpl.class );
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
@@ -24,6 +24,7 @@ import javax.validation.executable.ValidateOnExecution;
 import javax.validation.groups.Default;
 
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
@@ -59,7 +60,8 @@ public class ParameterMetaDataTest {
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
-				Collections.<MetaDataProvider>emptyList()
+				Collections.<MetaDataProvider>emptyList(),
+				new MethodValidationConfiguration()
 		);
 
 		beanMetaData = beanMetaDataManager.getBeanMetaData( CustomerRepository.class );
@@ -133,7 +135,8 @@ public class ParameterMetaDataTest {
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new SkewedParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
-				Collections.<MetaDataProvider>emptyList()
+				Collections.<MetaDataProvider>emptyList(),
+				new MethodValidationConfiguration()
 		);
 		BeanMetaData<ServiceImpl> localBeanMetaData = beanMetaDataManager.getBeanMetaData( ServiceImpl.class );
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
@@ -17,6 +17,7 @@ import javax.validation.groups.ConvertGroup;
 import javax.validation.groups.Default;
 
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.aggregated.PropertyMetaData;
@@ -43,7 +44,8 @@ public class PropertyMetaDataTest {
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
-				Collections.<MetaDataProvider>emptyList()
+				Collections.<MetaDataProvider>emptyList(),
+				new MethodValidationConfiguration()
 		);
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
@@ -45,7 +45,7 @@ public class PropertyMetaDataTest {
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
 				Collections.<MetaDataProvider>emptyList(),
-				new MethodValidationConfiguration()
+				new MethodValidationConfiguration.Builder().build()
 		);
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
@@ -29,7 +29,6 @@ import javax.validation.groups.Default;
 import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraints.ScriptAssert;
-import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
@@ -41,7 +40,6 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedElement.Constrai
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.joda.time.DateMidnight;
@@ -62,7 +60,6 @@ public class AnnotationMetaDataProviderTest extends AnnotationMetaDataProviderTe
 		provider = new AnnotationMetaDataProvider(
 				new ConstraintHelper(),
 				new TypeResolutionHelper(),
-				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
 				new AnnotationProcessingOptionsImpl()
 		);

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationMetaDataRetrievalTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationMetaDataRetrievalTest.java
@@ -18,7 +18,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.constraints.NotBlank;
-import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
@@ -28,7 +27,6 @@ import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedExecutable;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedField;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -47,7 +45,6 @@ public class TypeAnnotationMetaDataRetrievalTest extends AnnotationMetaDataProvi
 		provider = new AnnotationMetaDataProvider(
 				new ConstraintHelper(),
 				new TypeResolutionHelper(),
-				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new ValueExtractorManager( Collections.emptyList() ),
 				new AnnotationProcessingOptionsImpl()
 		);

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
@@ -22,11 +22,9 @@ import javax.validation.ConstraintValidatorContext;
 import javax.validation.ValidationException;
 import javax.validation.constraints.DecimalMin;
 
-import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
-import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.xml.MappingXmlParser;
 import org.hibernate.validator.testutil.TestForIssue;
@@ -44,8 +42,9 @@ public class MappingXmlParserTest {
 	@BeforeMethod
 	public void setupParserHelper() {
 		constraintHelper = new ConstraintHelper();
-		xmlMappingParser = new MappingXmlParser( constraintHelper, new TypeResolutionHelper(),
-				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ), new ValueExtractorManager( Collections.emptyList() ), null );
+		xmlMappingParser = new MappingXmlParser(
+				constraintHelper, new TypeResolutionHelper(), new ValueExtractorManager( Collections.emptyList() ), null
+		);
 	}
 
 	@Test


### PR DESCRIPTION
Before we'd have ignored a new method validation configuration if the parameter name provider was the same.

This also unties metadata providers from the parameter name provider. There should never have been a link between the two in the first place.

It's a fallout of the work on HV-1256/HV-1257; sending it separately as its good to go and probably also worth backporting.

https://hibernate.atlassian.net/browse/HV-1258