### PR TITLE
HV-1257 et al.: Allowing to pass in value extractors during bootstrap

### DIFF
--- a/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/injection/MyValidationProvider.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/internal/cdi/injection/MyValidationProvider.java
@@ -8,6 +8,7 @@ package org.hibernate.validator.test.internal.cdi.injection;
 
 import java.io.InputStream;
 import java.util.Set;
+
 import javax.enterprise.inject.Alternative;
 import javax.validation.BootstrapConfiguration;
 import javax.validation.ClockProvider;
@@ -25,6 +26,7 @@ import javax.validation.metadata.BeanDescriptor;
 import javax.validation.spi.BootstrapState;
 import javax.validation.spi.ConfigurationState;
 import javax.validation.spi.ValidationProvider;
+import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.internal.engine.ValidatorFactoryImpl;
 
@@ -79,6 +81,11 @@ public class MyValidationProvider implements ValidationProvider<MyValidationProv
 
 		@Override
 		public MyConfiguration clockProvider(ClockProvider clockProvider) {
+			return null;
+		}
+
+		@Override
+		public MyConfiguration addValueExtractor(ValueExtractor<?> extractor) {
 			return null;
 		}
 

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter02/typeargument/custom/CarTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter02/typeargument/custom/CarTest.java
@@ -21,7 +21,7 @@ public class CarTest {
 	public static void setUpValidator() {
 		ValidatorFactory factory = Validation.byProvider( HibernateValidator.class )
 				.configure()
-				.addCascadedValueExtractor( new GearBoxExtractor() )
+				.addValueExtractor( new GearBoxExtractor() )
 				.buildValidatorFactory();
 		validator = factory.getValidator();
 	}

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/valuehandling/UnwrapValidatedValueTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter11/valuehandling/UnwrapValidatedValueTest.java
@@ -13,7 +13,7 @@ public class UnwrapValidatedValueTest {
 		//tag::unwrapValidated[]
 		Validator validator = Validation.byProvider( HibernateValidator.class )
 				.configure()
-				.addCascadedValueExtractor( new PropertyValueExtractor() )
+				.addValueExtractor( new PropertyValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 		//end::unwrapValidated[]

--- a/engine/src/main/java/org/hibernate/validator/HibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/HibernateValidatorConfiguration.java
@@ -7,7 +7,6 @@
 package org.hibernate.validator;
 
 import javax.validation.Configuration;
-import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
@@ -119,8 +118,6 @@ public interface HibernateValidatorConfiguration extends Configuration<Hibernate
 	 * @return {@code this} following the chaining method pattern
 	 */
 	HibernateValidatorConfiguration failFast(boolean failFast);
-
-	HibernateValidatorConfiguration addCascadedValueExtractor(ValueExtractor<?> extractor);
 
 	/**
 	 * Sets the class loader to be used for loading user-provided resources:

--- a/engine/src/main/java/org/hibernate/validator/HibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/HibernateValidatorConfiguration.java
@@ -6,7 +6,10 @@
  */
 package org.hibernate.validator;
 
+import java.util.Set;
+
 import javax.validation.Configuration;
+import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
@@ -96,6 +99,18 @@ public interface HibernateValidatorConfiguration extends Configuration<Hibernate
 	 * @return A new constraint mapping.
 	 */
 	ConstraintMapping createConstraintMapping();
+
+	/**
+	 * Returns the default {@link ValueExtractor} implementations as per the
+	 * specification.
+	 *
+	 * @return the default {@code ValueExtractor} implementations compliant
+	 * with the specification
+	 *
+	 * @since 6.0
+	 */
+	@Incubating
+	Set<ValueExtractor<?>> getDefaultValueExtractors();
 
 	/**
 	 * Adds the specified {@link ConstraintMapping} instance to the configuration. Constraints configured in {@code mapping}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -91,7 +90,6 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 	// HV-specific options
 	private final Set<DefaultConstraintMapping> programmaticMappings = newHashSet();
 	private boolean failFast;
-	private final List<ValueExtractor<?>> cascadedValueExtractors = new ArrayList<>();
 	private ClassLoader externalClassLoader;
 	private final MethodValidationConfiguration.Builder methodValidationConfigurationBuilder = new MethodValidationConfiguration.Builder();
 
@@ -198,6 +196,19 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 	}
 
 	@Override
+	public HibernateValidatorConfiguration addValueExtractor(ValueExtractor<?> extractor) {
+		Contracts.assertNotNull( extractor, MESSAGES.parameterMustNotBeNull( "extractor" ) );
+
+		if ( log.isDebugEnabled() ) {
+			log.debug( "Adding value extractor " + extractor );
+		}
+
+		validationBootstrapParameters.addValueExtractor( extractor );
+
+		return this;
+	}
+
+	@Override
 	public final HibernateValidatorConfiguration addMapping(InputStream stream) {
 		Contracts.assertNotNull( stream, MESSAGES.inputStreamCannotBeNull() );
 
@@ -263,14 +274,6 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 		if ( value != null ) {
 			validationBootstrapParameters.addConfigProperty( name, value );
 		}
-		return this;
-	}
-
-	@Override
-	public HibernateValidatorConfiguration addCascadedValueExtractor(ValueExtractor<?> extractor) {
-		Contracts.assertNotNull( extractor, MESSAGES.parameterMustNotBeNull( "extractor" ) );
-		cascadedValueExtractors.add( extractor );
-
 		return this;
 	}
 
@@ -387,8 +390,9 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 		return validationBootstrapParameters.getClockProvider();
 	}
 
-	public List<ValueExtractor<?>> getCascadedValueExtractors() {
-		return cascadedValueExtractors;
+	@Override
+	public Set<ValueExtractor<?>> getValueExtractors() {
+		return validationBootstrapParameters.getValueExtractors();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
@@ -39,6 +39,7 @@ import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorDescriptor;
+import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
 import org.hibernate.validator.internal.engine.resolver.DefaultTraversableResolver;
 import org.hibernate.validator.internal.util.Contracts;
@@ -450,6 +451,11 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 	@Override
 	public ClockProvider getDefaultClockProvider() {
 		return defaultClockProvider;
+	}
+
+	@Override
+	public Set<ValueExtractor<?>> getDefaultValueExtractors() {
+		return ValueExtractorManager.getDefaultValueExtractors();
 	}
 
 	public final Set<DefaultConstraintMapping> getProgrammaticMappings() {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
@@ -521,6 +521,8 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 			}
 		}
 
+		validationBootstrapParameters.addAllNonExistingValueExtractors( xmlParameters.getValueExtractors() );
+
 		validationBootstrapParameters.addAllMappings( xmlParameters.getMappings() );
 		configurationStreams.addAll( xmlParameters.getMappings() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
@@ -12,6 +12,8 @@ import javax.validation.MessageInterpolator;
 import javax.validation.ParameterNameProvider;
 import javax.validation.TraversableResolver;
 import javax.validation.Validator;
+import javax.validation.ValidatorContext;
+import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.HibernateValidatorContext;
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorManager;
@@ -104,6 +106,11 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 			this.clockProvider = clockProvider;
 		}
 		return this;
+	}
+
+	@Override
+	public ValidatorContext addValueExtractor(ValueExtractor<?> extractor) {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
@@ -6,13 +6,15 @@
  */
 package org.hibernate.validator.internal.engine;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import javax.validation.ClockProvider;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.MessageInterpolator;
 import javax.validation.ParameterNameProvider;
 import javax.validation.TraversableResolver;
 import javax.validation.Validator;
-import javax.validation.ValidatorContext;
 import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.HibernateValidatorContext;
@@ -38,7 +40,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 	private boolean failFast;
 	private final ValueExtractorManager valueExtractorManager;
 	private final MethodValidationConfiguration.Builder methodValidationConfigurationBuilder;
-
+	private final Set<ValueExtractor<?>> valueExtractors;
 
 	public ValidatorContextImpl(ValidatorFactoryImpl validatorFactory) {
 		this.validatorFactory = validatorFactory;
@@ -49,8 +51,8 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 		this.clockProvider = validatorFactory.getClockProvider();
 		this.failFast = validatorFactory.isFailFast();
 		this.methodValidationConfigurationBuilder = new MethodValidationConfiguration.Builder( validatorFactory.getMethodValidationConfiguration() );
-		// TODO make overwritable per this context
 		this.valueExtractorManager = validatorFactory.getValueExtractorManager();
+		this.valueExtractors = new HashSet<>();
 	}
 
 	@Override
@@ -109,8 +111,9 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 	}
 
 	@Override
-	public ValidatorContext addValueExtractor(ValueExtractor<?> extractor) {
-		throw new UnsupportedOperationException();
+	public HibernateValidatorContext addValueExtractor(ValueExtractor<?> extractor) {
+		valueExtractors.add( extractor );
+		return this;
 	}
 
 	@Override
@@ -146,7 +149,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 				parameterNameProvider,
 				clockProvider,
 				failFast,
-				valueExtractorManager,
+				valueExtractors.isEmpty() ? valueExtractorManager : new ValueExtractorManager( valueExtractorManager, valueExtractors ),
 				methodValidationConfigurationBuilder.build()
 		);
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -12,7 +12,6 @@ import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 import java.lang.annotation.Annotation;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +26,6 @@ import javax.validation.ParameterNameProvider;
 import javax.validation.TraversableResolver;
 import javax.validation.Validator;
 import javax.validation.spi.ConfigurationState;
-import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.HibernateValidatorContext;
@@ -150,6 +148,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		this.traversableResolver = configurationState.getTraversableResolver();
 		this.parameterNameProvider = new ExecutableParameterNameProvider( configurationState.getParameterNameProvider() );
 		this.clockProvider = configurationState.getClockProvider();
+		this.valueExtractorManager = new ValueExtractorManager( configurationState.getValueExtractors() );
 		this.beanMetaDataManagers = new ConcurrentHashMap<>();
 		this.constraintHelper = new ConstraintHelper();
 		this.typeResolutionHelper = new TypeResolutionHelper();
@@ -159,7 +158,6 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		boolean tmpAllowOverridingMethodAlterParameterConstraint = false;
 		boolean tmpAllowMultipleCascadedValidationOnReturnValues = false;
 		boolean tmpAllowParallelMethodsDefineParameterConstraints = false;
-		List<ValueExtractor<?>> tmpCascadedValueExtractors = new ArrayList<>( 5 );
 
 		if ( configurationState instanceof ConfigurationImpl ) {
 			ConfigurationImpl hibernateSpecificConfig = (ConfigurationImpl) configurationState;
@@ -176,11 +174,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 			tmpAllowParallelMethodsDefineParameterConstraints =
 					hibernateSpecificConfig.getMethodValidationConfiguration()
 							.isAllowParallelMethodsDefineParameterConstraints();
-
-			tmpCascadedValueExtractors = new ArrayList<>( hibernateSpecificConfig.getCascadedValueExtractors() );
 		}
-
-		this.valueExtractorManager = new ValueExtractorManager( tmpCascadedValueExtractors );
 
 		// HV-302; don't load XmlMappingParser if not necessary
 		if ( configurationState.getMappingStreams().isEmpty() ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -501,21 +501,27 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		private final ExecutableParameterNameProvider parameterNameProvider;
 		private final ValueExtractorManager valueExtractorManager;
 		private final MethodValidationConfiguration methodValidationConfiguration;
+		private final int hashCode;
 
 		public BeanMetaDataManagerKey(ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager, MethodValidationConfiguration methodValidationConfiguration) {
 			this.parameterNameProvider = parameterNameProvider;
 			this.valueExtractorManager = valueExtractorManager;
 			this.methodValidationConfiguration = methodValidationConfiguration;
+			this.hashCode = buildHashCode( parameterNameProvider, valueExtractorManager, methodValidationConfiguration );
 		}
 
-		@Override
-		public int hashCode() {
+		private static int buildHashCode(ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager, MethodValidationConfiguration methodValidationConfiguration) {
 			final int prime = 31;
 			int result = 1;
 			result = prime * result + ( ( methodValidationConfiguration == null ) ? 0 : methodValidationConfiguration.hashCode() );
 			result = prime * result + ( ( parameterNameProvider == null ) ? 0 : parameterNameProvider.hashCode() );
 			result = prime * result + ( ( valueExtractorManager == null ) ? 0 : valueExtractorManager.hashCode() );
 			return result;
+		}
+
+		@Override
+		public int hashCode() {
+			return hashCode;
 		}
 
 		@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -355,13 +355,12 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 			MethodValidationConfiguration methodValidationConfiguration) {
 
 		BeanMetaDataManager beanMetaDataManager = beanMetaDataManagers.computeIfAbsent(
-				new BeanMetaDataManagerKey( parameterNameProvider, methodValidationConfiguration ),
+				new BeanMetaDataManagerKey( parameterNameProvider, valueExtractorManager, methodValidationConfiguration ),
 				key -> new BeanMetaDataManager(
 						constraintHelper,
 						executableHelper,
 						typeResolutionHelper,
 						parameterNameProvider,
-						// TODO make part of the cache key, too
 						valueExtractorManager,
 						buildDataProviders(),
 						methodValidationConfiguration
@@ -500,10 +499,12 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 
 	private static class BeanMetaDataManagerKey {
 		private final ExecutableParameterNameProvider parameterNameProvider;
+		private final ValueExtractorManager valueExtractorManager;
 		private final MethodValidationConfiguration methodValidationConfiguration;
 
-		public BeanMetaDataManagerKey(ExecutableParameterNameProvider parameterNameProvider, MethodValidationConfiguration methodValidationConfiguration) {
+		public BeanMetaDataManagerKey(ExecutableParameterNameProvider parameterNameProvider, ValueExtractorManager valueExtractorManager, MethodValidationConfiguration methodValidationConfiguration) {
 			this.parameterNameProvider = parameterNameProvider;
+			this.valueExtractorManager = valueExtractorManager;
 			this.methodValidationConfiguration = methodValidationConfiguration;
 		}
 
@@ -513,6 +514,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 			int result = 1;
 			result = prime * result + ( ( methodValidationConfiguration == null ) ? 0 : methodValidationConfiguration.hashCode() );
 			result = prime * result + ( ( parameterNameProvider == null ) ? 0 : parameterNameProvider.hashCode() );
+			result = prime * result + ( ( valueExtractorManager == null ) ? 0 : valueExtractorManager.hashCode() );
 			return result;
 		}
 
@@ -528,29 +530,16 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 				return false;
 			}
 			BeanMetaDataManagerKey other = (BeanMetaDataManagerKey) obj;
-			if ( methodValidationConfiguration == null ) {
-				if ( other.methodValidationConfiguration != null ) {
-					return false;
-				}
-			}
-			else if ( !methodValidationConfiguration.equals( other.methodValidationConfiguration ) ) {
-				return false;
-			}
-			if ( parameterNameProvider == null ) {
-				if ( other.parameterNameProvider != null ) {
-					return false;
-				}
-			}
-			else if ( !parameterNameProvider.equals( other.parameterNameProvider ) ) {
-				return false;
-			}
-			return true;
+
+			return methodValidationConfiguration.equals( other.methodValidationConfiguration ) &&
+					parameterNameProvider.equals( other.parameterNameProvider ) &&
+					valueExtractorManager.equals( other.valueExtractorManager );
 		}
 
 		@Override
 		public String toString() {
-			return "BeanMetaDataManagerKey [parameterNameProvider=" + parameterNameProvider + ", methodValidationConfiguration=" + methodValidationConfiguration
-					+ "]";
+			return "BeanMetaDataManagerKey [parameterNameProvider=" + parameterNameProvider + ", valueExtractorManager=" + valueExtractorManager
+					+ ", methodValidationConfiguration=" + methodValidationConfiguration + "]";
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/BooleanArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/BooleanArrayValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class BooleanArrayValueExtractor implements ValueExtractor<boolean @ExtractedValue[]> {
 
-	static final BooleanArrayValueExtractor INSTANCE = new BooleanArrayValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new BooleanArrayValueExtractor() );
 
 	private BooleanArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ByteArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ByteArrayValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class ByteArrayValueExtractor implements ValueExtractor<byte @ExtractedValue[]> {
 
-	static final ByteArrayValueExtractor INSTANCE = new ByteArrayValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ByteArrayValueExtractor() );
 
 	private ByteArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/CharArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/CharArrayValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class CharArrayValueExtractor implements ValueExtractor<char @ExtractedValue[]> {
 
-	static final CharArrayValueExtractor INSTANCE = new CharArrayValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new CharArrayValueExtractor() );
 
 	private CharArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/DoubleArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/DoubleArrayValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class DoubleArrayValueExtractor implements ValueExtractor<double @ExtractedValue[]> {
 
-	static final DoubleArrayValueExtractor INSTANCE = new DoubleArrayValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new DoubleArrayValueExtractor() );
 
 	private DoubleArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/FloatArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/FloatArrayValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class FloatArrayValueExtractor implements ValueExtractor<float @ExtractedValue[]> {
 
-	static final FloatArrayValueExtractor INSTANCE = new FloatArrayValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new FloatArrayValueExtractor() );
 
 	private FloatArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/IntArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/IntArrayValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class IntArrayValueExtractor implements ValueExtractor<int @ExtractedValue[]> {
 
-	static final IntArrayValueExtractor INSTANCE = new IntArrayValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new IntArrayValueExtractor() );
 
 	private IntArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/IterableValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/IterableValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class IterableValueExtractor implements ValueExtractor<Iterable<@ExtractedValue ?>> {
 
-	static final IterableValueExtractor INSTANCE = new IterableValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new IterableValueExtractor() );
 
 	private IterableValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LegacyIterableValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LegacyIterableValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class LegacyIterableValueExtractor implements ValueExtractor<@ExtractedValue Iterable<?>> {
 
-	static final LegacyIterableValueExtractor INSTANCE = new LegacyIterableValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new LegacyIterableValueExtractor() );
 
 	private LegacyIterableValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LegacyListValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LegacyListValueExtractor.java
@@ -15,7 +15,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class LegacyListValueExtractor implements ValueExtractor<@ExtractedValue List<?>> {
 
-	static final LegacyListValueExtractor INSTANCE = new LegacyListValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new LegacyListValueExtractor() );
 
 	private LegacyListValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LegacyMapValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LegacyMapValueExtractor.java
@@ -15,7 +15,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class LegacyMapValueExtractor implements ValueExtractor<@ExtractedValue Map<?, ?>> {
 
-	static final LegacyMapValueExtractor INSTANCE = new LegacyMapValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new LegacyMapValueExtractor() );
 
 	private LegacyMapValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LegacyOptionalValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LegacyOptionalValueExtractor.java
@@ -19,7 +19,7 @@ import javax.validation.valueextraction.ValueExtractor;
 // TODO should we keep that, or only support {@code Optional<@Valid Foo>}.
 public class LegacyOptionalValueExtractor implements ValueExtractor<@ExtractedValue Optional<?>> {
 
-	static final LegacyOptionalValueExtractor INSTANCE = new LegacyOptionalValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new LegacyOptionalValueExtractor() );
 
 	private LegacyOptionalValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ListValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ListValueExtractor.java
@@ -15,7 +15,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class ListValueExtractor implements ValueExtractor<List<@ExtractedValue ?>> {
 
-	static final ListValueExtractor INSTANCE = new ListValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ListValueExtractor() );
 
 	private ListValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LongArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LongArrayValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class LongArrayValueExtractor implements ValueExtractor<long @ExtractedValue[]> {
 
-	static final LongArrayValueExtractor INSTANCE = new LongArrayValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new LongArrayValueExtractor() );
 
 	private LongArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/MapKeyExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/MapKeyExtractor.java
@@ -15,7 +15,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class MapKeyExtractor implements ValueExtractor<Map<@ExtractedValue ?, ?>> {
 
-	static final MapKeyExtractor INSTANCE = new MapKeyExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapKeyExtractor() );
 
 	private MapKeyExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/MapValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/MapValueExtractor.java
@@ -15,7 +15,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class MapValueExtractor implements ValueExtractor<Map<?, @ExtractedValue ?>> {
 
-	static final MapValueExtractor INSTANCE = new MapValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapValueExtractor() );
 
 	private MapValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ObjectArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ObjectArrayValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class ObjectArrayValueExtractor implements ValueExtractor<Object @ExtractedValue[]> {
 
-	static final ObjectArrayValueExtractor INSTANCE = new ObjectArrayValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ObjectArrayValueExtractor() );
 
 	private ObjectArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ObjectValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ObjectValueExtractor.java
@@ -11,7 +11,7 @@ import javax.validation.valueextraction.ValueExtractor;
 
 class ObjectValueExtractor implements ValueExtractor<@ExtractedValue Object> {
 
-	static final ObjectValueExtractor INSTANCE = new ObjectValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ObjectValueExtractor() );
 
 	private ObjectValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ObservableValueValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ObservableValueValueExtractor.java
@@ -20,7 +20,7 @@ import javafx.beans.value.ObservableValue;
 @UnwrapByDefault
 public class ObservableValueValueExtractor implements ValueExtractor<ObservableValue<@ExtractedValue ?>> {
 
-	static final ObservableValueValueExtractor INSTANCE = new ObservableValueValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ObservableValueValueExtractor() );
 
 	private ObservableValueValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/OptionalValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/OptionalValueExtractor.java
@@ -16,7 +16,7 @@ import javax.validation.valueextraction.ValueExtractor;
  */
 public class OptionalValueExtractor implements ValueExtractor<Optional<@ExtractedValue ?>> {
 
-	static final OptionalValueExtractor INSTANCE = new OptionalValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalValueExtractor() );
 
 	private OptionalValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ShortArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ShortArrayValueExtractor.java
@@ -13,7 +13,7 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class ShortArrayValueExtractor implements ValueExtractor<short @ExtractedValue[]> {
 
-	static final ShortArrayValueExtractor INSTANCE = new ShortArrayValueExtractor();
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ShortArrayValueExtractor() );
 
 	private ShortArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ValueExtractorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ValueExtractorDescriptor.java
@@ -123,19 +123,25 @@ public class ValueExtractorDescriptor {
 
 		private final Type extractedType;
 		private final TypeVariable<?> extractedTypeParameter;
+		private final int hashCode;
 
 		public Key(Type extractedType, TypeVariable<?> extractedTypeParameter) {
 			this.extractedType = extractedType;
 			this.extractedTypeParameter = extractedTypeParameter;
+			this.hashCode = buildHashCode( extractedType, extractedTypeParameter );
 		}
 
-		@Override
-		public int hashCode() {
+		private static int buildHashCode(Type extractedType, TypeVariable<?> extractedTypeParameter) {
 			final int prime = 31;
 			int result = 1;
 			result = prime * result + extractedType.hashCode();
 			result = prime * result + extractedTypeParameter.hashCode();
 			return result;
+		}
+
+		@Override
+		public int hashCode() {
+			return hashCode;
 		}
 
 		@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ValueExtractorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ValueExtractorDescriptor.java
@@ -16,7 +16,6 @@ import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.UnwrapByDefault;
 import javax.validation.valueextraction.ValueExtractor;
 
-import org.hibernate.validator.internal.util.StringHelper;
 import org.hibernate.validator.internal.util.TypeHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -31,15 +30,16 @@ public class ValueExtractorDescriptor {
 
 	private static final Log LOG = LoggerFactory.make();
 
+	private final Key key;
 	private final ValueExtractor<?> valueExtractor;
-	private final Type extractedType;
-	private final TypeVariable<?> extractedTypeParameter;
 	private final boolean unwrapByDefault;
 
 	public ValueExtractorDescriptor(ValueExtractor<?> valueExtractor) {
+		this.key = new Key(
+				getExtractedType( valueExtractor.getClass() ),
+				getExtractedTypeParameter( valueExtractor.getClass() )
+		);
 		this.valueExtractor = valueExtractor;
-		this.extractedTypeParameter = getExtractedTypeParameter( valueExtractor.getClass() );
-		this.extractedType = getExtractedType( valueExtractor.getClass() );
 		this.unwrapByDefault = hasUnwrapByDefaultAnnotation( valueExtractor.getClass() );
 	}
 
@@ -93,12 +93,16 @@ public class ValueExtractorDescriptor {
 		return extractorImplementationType.isAnnotationPresent( UnwrapByDefault.class );
 	}
 
+	public Key getKey() {
+		return key;
+	}
+
 	public Type getExtractedType() {
-		return extractedType;
+		return key.extractedType;
 	}
 
 	public TypeVariable<?> getExtractedTypeParameter() {
-		return extractedTypeParameter;
+		return key.extractedTypeParameter;
 	}
 
 	public ValueExtractor<?> getValueExtractor() {
@@ -110,33 +114,49 @@ public class ValueExtractorDescriptor {
 	}
 
 	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + extractedType.hashCode();
-		result = prime * result + extractedTypeParameter.hashCode();
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if ( this == obj ) {
-			return true;
-		}
-		if ( obj == null ) {
-			return false;
-		}
-		if ( getClass() != obj.getClass() ) {
-			return false;
-		}
-		ValueExtractorDescriptor other = (ValueExtractorDescriptor) obj;
-
-		return extractedTypeParameter.equals( other.extractedTypeParameter );
-	}
-
-	@Override
 	public String toString() {
-		return "ValueExtractorDescriptor [valueExtractor=" + StringHelper.toShortString( valueExtractor.getClass() ) + ", extractedType=" + StringHelper.toShortString( extractedType )
-				+ ", extractedTypeParameter=" + extractedTypeParameter + ", unwrapByDefault=" + unwrapByDefault + "]";
+		return "ValueExtractorDescriptor [key=" + key + ", valueExtractor=" + valueExtractor + ", unwrapByDefault=" + unwrapByDefault + "]";
+	}
+
+	public static class Key {
+
+		private final Type extractedType;
+		private final TypeVariable<?> extractedTypeParameter;
+
+		public Key(Type extractedType, TypeVariable<?> extractedTypeParameter) {
+			this.extractedType = extractedType;
+			this.extractedTypeParameter = extractedTypeParameter;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result + extractedType.hashCode();
+			result = prime * result + extractedTypeParameter.hashCode();
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if ( this == obj ) {
+				return true;
+			}
+			if ( obj == null ) {
+				return false;
+			}
+			if ( getClass() != obj.getClass() ) {
+				return false;
+			}
+			Key other = (Key) obj;
+
+			return extractedType.equals( other.extractedType ) &&
+					extractedTypeParameter.equals( other.extractedTypeParameter );
+		}
+
+		@Override
+		public String toString() {
+			return "Key [extractedType=" + extractedType + ", extractedTypeParameter=" + extractedTypeParameter + "]";
+		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ValueExtractorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ValueExtractorDescriptor.java
@@ -110,6 +110,31 @@ public class ValueExtractorDescriptor {
 	}
 
 	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + extractedType.hashCode();
+		result = prime * result + extractedTypeParameter.hashCode();
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		ValueExtractorDescriptor other = (ValueExtractorDescriptor) obj;
+
+		return extractedTypeParameter.equals( other.extractedTypeParameter );
+	}
+
+	@Override
 	public String toString() {
 		return "ValueExtractorDescriptor [valueExtractor=" + StringHelper.toShortString( valueExtractor.getClass() ) + ", extractedType=" + StringHelper.toShortString( extractedType )
 				+ ", extractedTypeParameter=" + extractedTypeParameter + ", unwrapByDefault=" + unwrapByDefault + "]";

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ValueExtractorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ValueExtractorDescriptor.java
@@ -16,6 +16,7 @@ import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.UnwrapByDefault;
 import javax.validation.valueextraction.ValueExtractor;
 
+import org.hibernate.validator.internal.util.StringHelper;
 import org.hibernate.validator.internal.util.TypeHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -156,7 +157,7 @@ public class ValueExtractorDescriptor {
 
 		@Override
 		public String toString() {
-			return "Key [extractedType=" + extractedType + ", extractedTypeParameter=" + extractedTypeParameter + "]";
+			return "Key [extractedType=" + StringHelper.toShortString( extractedType ) + ", extractedTypeParameter=" + extractedTypeParameter + "]";
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ValueExtractorManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ValueExtractorManager.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.validation.ValidationException;
 import javax.validation.valueextraction.ValueExtractor;
@@ -29,6 +30,34 @@ import org.hibernate.validator.internal.util.stereotypes.Immutable;
  * @author Guillaume Smet
  */
 public class ValueExtractorManager {
+
+	@Immutable
+	public static final Set<ValueExtractor<?>> SPEC_DEFINED_EXTRACTORS = Stream.of(
+			ByteArrayValueExtractor.DESCRIPTOR,
+			ShortArrayValueExtractor.DESCRIPTOR,
+			IntArrayValueExtractor.DESCRIPTOR,
+			LongArrayValueExtractor.DESCRIPTOR,
+			FloatArrayValueExtractor.DESCRIPTOR,
+			DoubleArrayValueExtractor.DESCRIPTOR,
+			CharArrayValueExtractor.DESCRIPTOR,
+			BooleanArrayValueExtractor.DESCRIPTOR,
+			ObjectArrayValueExtractor.DESCRIPTOR,
+
+			LegacyListValueExtractor.DESCRIPTOR,
+			ListValueExtractor.DESCRIPTOR,
+
+			LegacyMapValueExtractor.DESCRIPTOR,
+			MapValueExtractor.DESCRIPTOR,
+			MapKeyExtractor.DESCRIPTOR,
+
+			LegacyIterableValueExtractor.DESCRIPTOR,
+			IterableValueExtractor.DESCRIPTOR,
+
+			OptionalValueExtractor.DESCRIPTOR,
+			ObjectValueExtractor.DESCRIPTOR
+		)
+		.map( ValueExtractorDescriptor::getValueExtractor )
+		.collect( Collectors.collectingAndThen( Collectors.toSet(), Collections::unmodifiableSet ) );
 
 	@Immutable
 	private final Map<ValueExtractorDescriptor.Key, ValueExtractorDescriptor> valueExtractors;
@@ -81,6 +110,10 @@ public class ValueExtractorManager {
 		}
 
 		valueExtractors = Collections.unmodifiableMap( tmpValueExtractors );
+	}
+
+	public static Set<ValueExtractor<?>> getDefaultValueExtractors() {
+		return SPEC_DEFINED_EXTRACTORS;
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -36,6 +36,7 @@ import javax.validation.TraversableResolver;
 import javax.validation.UnexpectedTypeException;
 import javax.validation.ValidationException;
 import javax.validation.spi.ValidationProvider;
+import javax.validation.valueextraction.ValueExtractor;
 import javax.validation.valueextraction.ValueExtractorDefinitionException;
 import javax.xml.stream.XMLStreamException;
 
@@ -703,4 +704,10 @@ public interface Log extends BasicLogger {
 	@Message(id = 205, value = "Invalid unwrapping configuration for constraint %2$s on %1$s. You can only define one of 'Unwrapping.Skip' or 'Unwrapping.Unwrap'.")
 	ConstraintDefinitionException getInvalidUnwrappingConfigurationForConstraintException(Member member, @FormatWith(ClassObjectFormatter.class) Class<? extends Annotation> constraint);
 
+	@Message(id = 206, value = "Unable to instantiate value extractor class %s.")
+	ValidationException getUnableToInstantiateValueExtractorClassException(String valueExtractorClassName, @Cause ValidationException e);
+
+	@LogMessage(level = INFO)
+	@Message(id = 207, value = "Adding value extractor %s.")
+	void addingValueExtractor(@FormatWith(ClassObjectFormatter.class) Class<? extends ValueExtractor<?>> valueExtractorClass);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -37,6 +37,7 @@ import javax.validation.UnexpectedTypeException;
 import javax.validation.ValidationException;
 import javax.validation.spi.ValidationProvider;
 import javax.validation.valueextraction.ValueExtractor;
+import javax.validation.valueextraction.ValueExtractorDeclarationException;
 import javax.validation.valueextraction.ValueExtractorDefinitionException;
 import javax.xml.stream.XMLStreamException;
 
@@ -710,4 +711,7 @@ public interface Log extends BasicLogger {
 	@LogMessage(level = INFO)
 	@Message(id = 207, value = "Adding value extractor %s.")
 	void addingValueExtractor(@FormatWith(ClassObjectFormatter.class) Class<? extends ValueExtractor<?>> valueExtractorClass);
+
+	@Message(id = 208, value = "Given value extractor %2$s handles the same type and type use as previously given value extractor %1$s.")
+	ValueExtractorDeclarationException getValueExtractorForTypeAndTypeUseAlreadyPresentException(ValueExtractor<?> first, ValueExtractor<?> second);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/BootstrapConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/BootstrapConfigurationImpl.java
@@ -6,17 +6,17 @@
  */
 package org.hibernate.validator.internal.xml;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
-
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import javax.validation.BootstrapConfiguration;
 import javax.validation.executable.ExecutableType;
+
+import org.hibernate.validator.internal.util.stereotypes.Immutable;
 
 /**
  * Wrapper class for the bootstrap parameters defined in <i>validation.xml</i>
@@ -28,6 +28,7 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 	/**
 	 * The executable types validated by default.
 	 */
+	@Immutable
 	private static final Set<ExecutableType> DEFAULT_VALIDATED_EXECUTABLE_TYPES =
 			Collections.unmodifiableSet(
 					EnumSet.of( ExecutableType.CONSTRUCTORS, ExecutableType.NON_GETTER_METHODS )
@@ -36,6 +37,7 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 	/**
 	 * The validated executable types, when ALL is given.
 	 */
+	@Immutable
 	private static final Set<ExecutableType> ALL_VALIDATED_EXECUTABLE_TYPES =
 			Collections.unmodifiableSet(
 					EnumSet.complementOf(
@@ -61,7 +63,6 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 	private final Set<ExecutableType> validatedExecutableTypes;
 	private final boolean isExecutableValidationEnabled;
 
-
 	private BootstrapConfigurationImpl() {
 		this.defaultProviderClassName = null;
 		this.constraintValidatorFactoryClassName = null;
@@ -69,11 +70,11 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 		this.traversableResolverClassName = null;
 		this.parameterNameProviderClassName = null;
 		this.clockProviderClassName = null;
-		this.valueExtractorClassNames = new HashSet<>( 0 );
+		this.valueExtractorClassNames = new HashSet<>();
 		this.validatedExecutableTypes = DEFAULT_VALIDATED_EXECUTABLE_TYPES;
 		this.isExecutableValidationEnabled = true;
-		this.constraintMappingResourcePaths = newHashSet();
-		this.properties = newHashMap();
+		this.constraintMappingResourcePaths = new HashSet<>();
+		this.properties = new HashMap<>();
 	}
 
 	public BootstrapConfigurationImpl(String defaultProviderClassName,
@@ -151,12 +152,12 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 
 	@Override
 	public Set<String> getValueExtractorClassNames() {
-		return valueExtractorClassNames;
+		return new HashSet<>( valueExtractorClassNames );
 	}
 
 	@Override
 	public Set<String> getConstraintMappingResourcePaths() {
-		return newHashSet( constraintMappingResourcePaths );
+		return new HashSet<>( constraintMappingResourcePaths );
 	}
 
 	@Override
@@ -166,12 +167,12 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 
 	@Override
 	public Set<ExecutableType> getDefaultValidatedExecutableTypes() {
-		return newHashSet( validatedExecutableTypes );
+		return new HashSet<>( validatedExecutableTypes );
 	}
 
 	@Override
 	public Map<String, String> getProperties() {
-		return newHashMap( properties );
+		return new HashMap<>( properties );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/BootstrapConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/BootstrapConfigurationImpl.java
@@ -11,6 +11,7 @@ import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -54,10 +55,12 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 	private final String traversableResolverClassName;
 	private final String parameterNameProviderClassName;
 	private final String clockProviderClassName;
+	private final Set<String> valueExtractorClassNames;
 	private final Set<String> constraintMappingResourcePaths;
 	private final Map<String, String> properties;
 	private final Set<ExecutableType> validatedExecutableTypes;
 	private final boolean isExecutableValidationEnabled;
+
 
 	private BootstrapConfigurationImpl() {
 		this.defaultProviderClassName = null;
@@ -66,6 +69,7 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 		this.traversableResolverClassName = null;
 		this.parameterNameProviderClassName = null;
 		this.clockProviderClassName = null;
+		this.valueExtractorClassNames = new HashSet<>( 0 );
 		this.validatedExecutableTypes = DEFAULT_VALIDATED_EXECUTABLE_TYPES;
 		this.isExecutableValidationEnabled = true;
 		this.constraintMappingResourcePaths = newHashSet();
@@ -78,6 +82,7 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 									  String traversableResolverClassName,
 									  String parameterNameProviderClassName,
 									  String clockProviderClassName,
+									  Set<String> valueExtractorClassNames,
 									  EnumSet<ExecutableType> validatedExecutableTypes,
 									  boolean isExecutableValidationEnabled,
 									  Set<String> constraintMappingResourcePaths,
@@ -88,6 +93,7 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 		this.traversableResolverClassName = traversableResolverClassName;
 		this.parameterNameProviderClassName = parameterNameProviderClassName;
 		this.clockProviderClassName = clockProviderClassName;
+		this.valueExtractorClassNames = valueExtractorClassNames;
 		this.validatedExecutableTypes = prepareValidatedExecutableTypes( validatedExecutableTypes );
 		this.isExecutableValidationEnabled = isExecutableValidationEnabled;
 		this.constraintMappingResourcePaths = constraintMappingResourcePaths;
@@ -145,8 +151,7 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 
 	@Override
 	public Set<String> getValueExtractorClassNames() {
-		// TODO implement
-		return Collections.emptySet();
+		return valueExtractorClassNames;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/BootstrapConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/BootstrapConfigurationImpl.java
@@ -6,15 +6,16 @@
  */
 package org.hibernate.validator.internal.xml;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Set;
+
 import javax.validation.BootstrapConfiguration;
 import javax.validation.executable.ExecutableType;
-
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 
 /**
  * Wrapper class for the bootstrap parameters defined in <i>validation.xml</i>
@@ -140,6 +141,12 @@ public class BootstrapConfigurationImpl implements BootstrapConfiguration {
 	@Override
 	public String getClockProviderClassName() {
 		return clockProviderClassName;
+	}
+
+	@Override
+	public Set<String> getValueExtractorClassNames() {
+		// TODO implement
+		return Collections.emptySet();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationBootstrapParameters.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationBootstrapParameters.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.validation.BootstrapConfiguration;
 import javax.validation.ClockProvider;
@@ -29,6 +28,7 @@ import javax.validation.spi.ValidationProvider;
 import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.internal.engine.cascading.ValueExtractorDescriptor;
+import org.hibernate.validator.internal.engine.cascading.ValueExtractorDescriptor.Key;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
@@ -142,30 +142,13 @@ public class ValidationBootstrapParameters {
 		this.clockProvider = clockProvider;
 	}
 
-	public Set<ValueExtractor<?>> getValueExtractors() {
-		return valueExtractors.values()
-				.stream()
-				.map( ValueExtractorDescriptor::getValueExtractor )
-				.collect( Collectors.toSet() );
+	public Map<Key, ValueExtractorDescriptor> getValueExtractors() {
+		return valueExtractors;
 	}
 
 	public void addValueExtractor(ValueExtractor<?> valueExtractor) {
-		// TODO raise error if already there
 		ValueExtractorDescriptor descriptor = new ValueExtractorDescriptor( valueExtractor );
 		valueExtractors.put( descriptor.getKey(), descriptor );
-	}
-
-	/**
-	 * Adds all those extractors from the given input which are not for a type and type parameter handled by any of the
-	 * already added extractors.
-	 */
-	public void addAllNonExistingValueExtractors(Iterable<ValueExtractor<?>> valueExtractors) {
-		for ( ValueExtractor<?> valueExtractor : valueExtractors ) {
-			ValueExtractorDescriptor descriptor = new ValueExtractorDescriptor( valueExtractor );
-			if ( !this.valueExtractors.containsKey( descriptor.getKey() ) ) {
-				this.valueExtractors.put( descriptor.getKey(), descriptor );
-			}
-		}
 	}
 
 	@SuppressWarnings("unchecked")

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationBootstrapParameters.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationBootstrapParameters.java
@@ -13,8 +13,10 @@ import java.io.InputStream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.validation.BootstrapConfiguration;
 import javax.validation.ClockProvider;
@@ -24,7 +26,9 @@ import javax.validation.ParameterNameProvider;
 import javax.validation.TraversableResolver;
 import javax.validation.ValidationException;
 import javax.validation.spi.ValidationProvider;
+import javax.validation.valueextraction.ValueExtractor;
 
+import org.hibernate.validator.internal.engine.cascading.ValueExtractorDescriptor;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
@@ -45,6 +49,7 @@ public class ValidationBootstrapParameters {
 	private Class<? extends ValidationProvider<?>> providerClass = null;
 	private final Map<String, String> configProperties = newHashMap();
 	private final Set<InputStream> mappings = newHashSet();
+	private final Set<ValueExtractorDescriptor> valueExtractors = new HashSet<>();
 
 	public ValidationBootstrapParameters() {
 	}
@@ -134,6 +139,16 @@ public class ValidationBootstrapParameters {
 
 	public void setClockProvider(ClockProvider clockProvider) {
 		this.clockProvider = clockProvider;
+	}
+
+	public Set<ValueExtractor<?>> getValueExtractors() {
+		return valueExtractors.stream()
+				.map( ValueExtractorDescriptor::getValueExtractor )
+				.collect( Collectors.toSet() );
+	}
+
+	public void addValueExtractor(ValueExtractor<?> valueExtractor) {
+		valueExtractors.add( new ValueExtractorDescriptor( valueExtractor ) );
 	}
 
 	@SuppressWarnings("unchecked")

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationXmlParser.java
@@ -27,6 +27,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.Validator;
 
+import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.NewJaxbContext;
@@ -53,7 +54,7 @@ public class ValidationXmlParser {
 	private final ClassLoader externalClassLoader;
 
 	private static Map<String, String> getSchemasByVersion() {
-		Map<String, String> schemasByVersion = new HashMap<String, String>();
+		Map<String, String> schemasByVersion = CollectionHelper.newHashMap( 3 );
 
 		schemasByVersion.put( "1.0", "META-INF/validation-configuration-1.0.xsd" );
 		schemasByVersion.put( "1.1", "META-INF/validation-configuration-1.1.xsd" );
@@ -167,7 +168,7 @@ public class ValidationXmlParser {
 	}
 
 	private BootstrapConfiguration createBootstrapConfiguration(ValidationConfigType config) {
-		Map<String, String> properties = new HashMap<String, String>();
+		Map<String, String> properties = new HashMap<>();
 		for ( PropertyType property : config.getProperty() ) {
 			if ( log.isDebugEnabled() ) {
 				log.debugf(
@@ -192,9 +193,10 @@ public class ValidationXmlParser {
 				config.getTraversableResolver(),
 				config.getParameterNameProvider(),
 				config.getClockProvider(),
+				new HashSet<>( config.getValueExtractor() ),
 				defaultValidatedExecutableTypes,
 				executableValidationEnabled,
-				new HashSet<String>( config.getConstraintMapping() ),
+				new HashSet<>( config.getConstraintMapping() ),
 				properties
 		);
 	}

--- a/engine/src/main/xsd/validation-configuration-2.0.xsd
+++ b/engine/src/main/xsd/validation-configuration-2.0.xsd
@@ -47,6 +47,7 @@
             <xs:element type="xs:string" name="constraint-validator-factory" minOccurs="0"/>
             <xs:element type="xs:string" name="parameter-name-provider" minOccurs="0"/>
             <xs:element type="xs:string" name="clock-provider" minOccurs="0"/>
+            <xs:element type="xs:string" name="value-extractor" maxOccurs="unbounded" minOccurs="0"/>
             <xs:element type="config:executable-validationType" name="executable-validation" minOccurs="0"/>
             <xs:element type="xs:string" name="constraint-mapping" maxOccurs="unbounded" minOccurs="0"/>
             <xs:element type="config:propertyType" name="property" maxOccurs="unbounded" minOccurs="0"/>

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ConstraintMappingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ConstraintMappingTest.java
@@ -514,7 +514,8 @@ public class ConstraintMappingTest {
 		Set<BeanConfiguration<?>> beanConfigurations = mapping.getBeanConfigurations(
 				new ConstraintHelper(),
 				new TypeResolutionHelper(),
-				new ValueExtractorManager( Collections.emptyList() ) );
+				new ValueExtractorManager( Collections.emptySet() )
+		);
 
 		for ( BeanConfiguration<?> beanConfiguration : beanConfigurations ) {
 			if ( beanConfiguration.getBeanClass() == type ) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
@@ -34,7 +34,7 @@ public class CustomValueExtractorTest {
 
 		Validator validator = Validation.byProvider( HibernateValidator.class )
 				.configure()
-				.addCascadedValueExtractor( new ReferenceValueExtractor() )
+				.addValueExtractor( new ReferenceValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 
@@ -49,7 +49,7 @@ public class CustomValueExtractorTest {
 
 		Validator validator = Validation.byProvider( HibernateValidator.class )
 				.configure()
-				.addCascadedValueExtractor( new MultimapValueExtractor() )
+				.addValueExtractor( new MultimapValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
@@ -93,6 +93,19 @@ public class CustomValueExtractorTest {
 		} );
 	}
 
+	public void canUseCustomValueExtractorPerValidatorForMultimaps() throws Exception {
+		CustomerWithStringStringMultimap bob = new CustomerWithStringStringMultimap();
+
+		Validator validator = Validation.buildDefaultValidatorFactory()
+				.usingContext()
+				.addValueExtractor( new MultimapValueExtractor() )
+				.getValidator();
+
+		Set<ConstraintViolation<CustomerWithStringStringMultimap>> violations = validator.validate( bob );
+
+		assertCorrectPropertyPaths( violations, "addressByType[work].multimap_value", "addressByType[work].multimap_value" );
+	}
+
 	@Test(expectedExceptions = ConstraintDeclarationException.class, expectedExceptionsMessageRegExp = "HV000197.*")
 	public void missingCustomExtractorThrowsException() throws Exception {
 		Cinema cinema = new Cinema();
@@ -124,6 +137,15 @@ public class CustomValueExtractorTest {
 
 				// VF overrides validation.xml
 				assertCorrectPropertyPaths( violations, "address.2" );
+
+				validator = validatorFactory.usingContext()
+						.addValueExtractor( new GuavaOptionalValueExtractor3() )
+						.getValidator();
+
+				violations = validator.validate( bob );
+
+				// V overrides VF
+				assertCorrectPropertyPaths( violations, "address.3" );
 			}
 		);
 	}
@@ -182,6 +204,14 @@ public class CustomValueExtractorTest {
 		@Override
 		public void extractValues(Optional<@ExtractedValue ?> originalValue, ValueExtractor.ValueReceiver receiver) {
 			receiver.value( "2", originalValue.isPresent() ? originalValue.get() : null );
+		}
+	}
+
+	public static class GuavaOptionalValueExtractor3 implements ValueExtractor<Optional<@ExtractedValue ?>> {
+
+		@Override
+		public void extractValues(Optional<@ExtractedValue ?> originalValue, ValueExtractor.ValueReceiver receiver) {
+			receiver.value( "3", originalValue.isPresent() ? originalValue.get() : null );
 		}
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
@@ -24,6 +24,7 @@ import javax.validation.ValidatorFactory;
 import javax.validation.constraints.Size;
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
+import javax.validation.valueextraction.ValueExtractorDeclarationException;
 
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
@@ -217,6 +218,29 @@ public class CustomValueExtractorTest {
 
 		assertThat( guavaOptionalExtractors ).describedAs( "Extractor for Guava's Optional shouldn't be part of default extractors" )
 			.isEmpty();
+	}
+
+	@Test(expectedExceptions = ValueExtractorDeclarationException.class, expectedExceptionsMessageRegExp = "HV000208.*")
+	public void configuringMultipleExtractorsForSameTypeAndTypeUseCausesException() throws Exception {
+		Validation.byDefaultProvider()
+				.configure()
+				.addValueExtractor( new GuavaOptionalValueExtractor1() )
+				.addValueExtractor( new GuavaOptionalValueExtractor1() );
+	}
+
+	@Test(expectedExceptions = ValueExtractorDeclarationException.class, expectedExceptionsMessageRegExp = "HV000208.*")
+	public void configuringValidatorWithMultipleExtractorsForSameTypeAndTypeUseCausesException() throws Exception {
+		Validation.buildDefaultValidatorFactory()
+				.usingContext()
+				.addValueExtractor( new GuavaOptionalValueExtractor1() )
+				.addValueExtractor( new GuavaOptionalValueExtractor1() );
+	}
+
+	@Test(expectedExceptions = ValueExtractorDeclarationException.class, expectedExceptionsMessageRegExp = "HV000208.*")
+	public void configuringMultipleExtractorsForSameTypeAndTypeUseInValidationXmlCausesException() throws Exception {
+		validationXmlTestHelper.runWithCustomValidationXml(
+			"multiple-value-extractors-for-same-type-and-type-use-validation.xml",
+			() -> Validation.buildDefaultValidatorFactory() );
 	}
 
 	private static class CustomerWithMultimap {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
@@ -8,6 +8,7 @@ package org.hibernate.validator.test.internal.engine.cascaded;
 
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
 
+import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.validation.ConstraintDeclarationException;
@@ -15,17 +16,34 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
 import javax.validation.Validation;
 import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Size;
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.constraints.Email;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutil.ValidationXmlTestHelper;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
 
 /**
  * @author Gunnar Morling
  */
 public class CustomValueExtractorTest {
+
+	private ValidationXmlTestHelper validationXmlTestHelper;
+
+	@BeforeMethod
+	public void setupValidationXmlTestHelper() {
+		validationXmlTestHelper = new ValidationXmlTestHelper( getClass() );
+	}
 
 	@Test
 	public void canUseCustomExtractor() throws Exception {
@@ -58,6 +76,23 @@ public class CustomValueExtractorTest {
 		assertCorrectPropertyPaths( violations, "addressByType[work].email", "addressByType[work].email" );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HV-1260")
+	public void canUseValueExtractorGivenInValidationXml() {
+		validationXmlTestHelper.runWithCustomValidationXml(
+				"value-extractor-validation.xml", () -> {
+
+				CustomerWithMultimap bob = new CustomerWithMultimap();
+
+				Validator validator = Validation.buildDefaultValidatorFactory()
+						.getValidator();
+
+				Set<ConstraintViolation<CustomerWithMultimap>> violations = validator.validate( bob );
+
+				assertCorrectPropertyPaths( violations, "addressByType[work].email", "addressByType[work].email" );
+		} );
+	}
+
 	@Test(expectedExceptions = ConstraintDeclarationException.class, expectedExceptionsMessageRegExp = "HV000197.*")
 	public void missingCustomExtractorThrowsException() throws Exception {
 		Cinema cinema = new Cinema();
@@ -71,6 +106,28 @@ public class CustomValueExtractorTest {
 		validator.validate( cinema );
 	}
 
+	@Test
+	public void valueExtractorPrecedenceIsAppliedCorrectly() {
+		validationXmlTestHelper.runWithCustomValidationXml(
+			"value-extractor-validation.xml",
+			() -> {
+				CustomerWithOptionalAddress bob = new CustomerWithOptionalAddress();
+
+				ValidatorFactory validatorFactory = Validation.byDefaultProvider()
+						.configure()
+						.addValueExtractor( new GuavaOptionalValueExtractor2() )
+						.buildValidatorFactory();
+
+				Validator validator = validatorFactory.getValidator();
+
+				Set<ConstraintViolation<CustomerWithOptionalAddress>> violations = validator.validate( bob );
+
+				// VF overrides validation.xml
+				assertCorrectPropertyPaths( violations, "address.2" );
+			}
+		);
+	}
+
 	private static class CustomerWithMultimap {
 
 		ListMultimap<String, @Valid EmailAddress> addressByType;
@@ -81,6 +138,50 @@ public class CustomValueExtractorTest {
 			addressByType.put( "work", new EmailAddress( "invalid" ) );
 			addressByType.put( "work", new EmailAddress( "alsoinvalid" ) );
 			addressByType.put( "home", new EmailAddress( "home@bob.de" ) );
+		}
+	}
+
+	private static class CustomerWithStringStringMultimap {
+
+		ListMultimap<String, @Email String> addressByType;
+
+		public CustomerWithStringStringMultimap() {
+			addressByType = ArrayListMultimap.create();
+			addressByType.put( "work", "work@bob.de" );
+			addressByType.put( "work", "invalid" );
+			addressByType.put( "work", "alsoinvalid" );
+			addressByType.put( "home", "home@bob.de" );
+		}
+	}
+
+	private static class CustomerWithOptionalAddress {
+
+		Optional<@Size(min = 5) String> address = Optional.of( "aaa" );
+	}
+
+	public static class CustomMultimapValueExtractor implements ValueExtractor<Multimap<?, @ExtractedValue ?>> {
+
+		@Override
+		public void extractValues(Multimap<?, ?> originalValue, ValueExtractor.ValueReceiver receiver) {
+			for ( Entry<?, ?> entry : originalValue.entries() ) {
+				receiver.keyedValue( "multimap_value_1", entry.getKey(), entry.getValue() );
+			}
+		}
+	}
+
+	public static class GuavaOptionalValueExtractor1 implements ValueExtractor<Optional<@ExtractedValue ?>> {
+
+		@Override
+		public void extractValues(Optional<@ExtractedValue ?> originalValue, ValueExtractor.ValueReceiver receiver) {
+			receiver.value( "1", originalValue.isPresent() ? originalValue.get() : null );
+		}
+	}
+
+	public static class GuavaOptionalValueExtractor2 implements ValueExtractor<Optional<@ExtractedValue ?>> {
+
+		@Override
+		public void extractValues(Optional<@ExtractedValue ?> originalValue, ValueExtractor.ValueReceiver receiver) {
+			receiver.value( "2", originalValue.isPresent() ? originalValue.get() : null );
 		}
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
@@ -106,6 +106,19 @@ public class CustomValueExtractorTest {
 		assertCorrectPropertyPaths( violations, "addressByType[work].multimap_value", "addressByType[work].multimap_value" );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HV-1261")
+	public void canUseValueExtractorGivenViaServiceLoader() {
+		CustomerWithOptionalAddress bob = new CustomerWithOptionalAddress();
+
+		Validator validator = Validation.buildDefaultValidatorFactory()
+				.getValidator();
+
+		Set<ConstraintViolation<CustomerWithOptionalAddress>> violations = validator.validate( bob );
+
+		assertCorrectPropertyPaths( violations, "address" );
+	}
+
 	@Test(expectedExceptions = ConstraintDeclarationException.class, expectedExceptionsMessageRegExp = "HV000197.*")
 	public void missingCustomExtractorThrowsException() throws Exception {
 		Cinema cinema = new Cinema();
@@ -126,14 +139,22 @@ public class CustomValueExtractorTest {
 			() -> {
 				CustomerWithOptionalAddress bob = new CustomerWithOptionalAddress();
 
+				Validator validator = Validation.buildDefaultValidatorFactory()
+						.getValidator();
+
+				Set<ConstraintViolation<CustomerWithOptionalAddress>> violations = validator.validate( bob );
+
+				// validation.xml overrides service loader
+				assertCorrectPropertyPaths( violations, "address.1" );
+
 				ValidatorFactory validatorFactory = Validation.byDefaultProvider()
 						.configure()
 						.addValueExtractor( new GuavaOptionalValueExtractor2() )
 						.buildValidatorFactory();
 
-				Validator validator = validatorFactory.getValidator();
+				validator = validatorFactory.getValidator();
 
-				Set<ConstraintViolation<CustomerWithOptionalAddress>> violations = validator.validate( bob );
+				violations = validator.validate( bob );
 
 				// VF overrides validation.xml
 				assertCorrectPropertyPaths( violations, "address.2" );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/GuavaOptionalValueExtractor.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/GuavaOptionalValueExtractor.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.cascaded;
+
+import javax.validation.valueextraction.ExtractedValue;
+import javax.validation.valueextraction.ValueExtractor;
+
+import com.google.common.base.Optional;
+
+/**
+ * @author Gunnar Morling
+ */
+public class GuavaOptionalValueExtractor implements ValueExtractor<Optional<@ExtractedValue ?>> {
+
+	@Override
+	public void extractValues(Optional<@ExtractedValue ?> originalValue, ValueExtractor.ValueReceiver receiver) {
+		receiver.value( null, originalValue.isPresent() ? originalValue.get() : null );
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/MultimapValueExtractor.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/MultimapValueExtractor.java
@@ -13,7 +13,7 @@ import javax.validation.valueextraction.ValueExtractor;
 
 import com.google.common.collect.Multimap;
 
-class MultimapValueExtractor implements ValueExtractor<Multimap<?, @ExtractedValue ?>> {
+public class MultimapValueExtractor implements ValueExtractor<Multimap<?, @ExtractedValue ?>> {
 
 	@Override
 	public void extractValues(Multimap<?, ?> originalValue, ValueExtractor.ValueReceiver receiver) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/NestedCascadedConstraintsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/NestedCascadedConstraintsTest.java
@@ -67,7 +67,7 @@ public class NestedCascadedConstraintsTest {
 	public void testMultipleNestedValidWithCustomExtractor() {
 		Validator validator = Validation.byProvider( HibernateValidator.class )
 				.configure()
-				.addCascadedValueExtractor( new ReferenceValueExtractor() )
+				.addValueExtractor( new ReferenceValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 
@@ -121,7 +121,7 @@ public class NestedCascadedConstraintsTest {
 	public void testNestedOnArray() {
 		Validator validator = Validation.byProvider( HibernateValidator.class )
 				.configure()
-				.addCascadedValueExtractor( new ReferenceValueExtractor() )
+				.addValueExtractor( new ReferenceValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
@@ -186,7 +186,7 @@ public class PathImplTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
-				new ValueExtractorManager( Collections.emptyList() ),
+				new ValueExtractorManager( Collections.emptySet() ),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()
 		);

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/InvalidValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/InvalidValueExtractorTest.java
@@ -26,7 +26,7 @@ public class InvalidValueExtractorTest {
 	@Test(expectedExceptions = ValueExtractorDefinitionException.class, expectedExceptionsMessageRegExp = "HV000204.*")
 	public void severalExtractedValuesThrowException() {
 		ValidatorUtil.getConfiguration()
-				.addCascadedValueExtractor( new SeveralExtractedValuesValueExtractor() )
+				.addValueExtractor( new SeveralExtractedValuesValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 	}
@@ -34,7 +34,7 @@ public class InvalidValueExtractorTest {
 	@Test(expectedExceptions = ValueExtractorDefinitionException.class, expectedExceptionsMessageRegExp = "HV000203.*")
 	public void noExtractedValueThrowsException() {
 		ValidatorUtil.getConfiguration()
-				.addCascadedValueExtractor( new NoExtractedValueValueExtractor() )
+				.addValueExtractor( new NoExtractedValueValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/UnwrapValidatedValueTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/UnwrapValidatedValueTest.java
@@ -49,8 +49,8 @@ public class UnwrapValidatedValueTest {
 	@BeforeMethod
 	public void setupValidator() {
 		validator = ValidatorUtil.getConfiguration()
-				.addCascadedValueExtractor( new PropertyValueExtractor() )
-				.addCascadedValueExtractor( new UiInputValueExtractor() )
+				.addValueExtractor( new PropertyValueExtractor() )
+				.addValueExtractor( new UiInputValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 	}
@@ -71,7 +71,7 @@ public class UnwrapValidatedValueTest {
 	public void shouldUnwrapPropertyValuesDuringParameterValidation() throws Exception {
 		Customer customer = new Customer();
 		Method method = Customer.class.getMethod( "setName", Property.class );
-		Object[] parameterValues = new Object[] { new Property<String>( "Bob" ) };
+		Object[] parameterValues = new Object[] { new Property<>( "Bob" ) };
 
 		Set<ConstraintViolation<Customer>> violations = validator.forExecutables()
 				.validateParameters( customer, method, parameterValues );
@@ -83,7 +83,7 @@ public class UnwrapValidatedValueTest {
 	public void shouldUnwrapPropertyValuesDuringReturnValueValidation() throws Exception {
 		Customer customer = new Customer();
 		Method method = Customer.class.getMethod( "retrieveName" );
-		Property<String> returnValue = new Property<String>( "Bob" );
+		Property<String> returnValue = new Property<>( "Bob" );
 
 		Set<ConstraintViolation<Customer>> violations = validator.forExecutables()
 				.validateReturnValue( customer, method, returnValue );
@@ -131,7 +131,7 @@ public class UnwrapValidatedValueTest {
 				.constraint( new MaxDef().value( 5 ) );
 
 		Validator validator = configuration.addMapping( mapping )
-				.addCascadedValueExtractor( new PropertyValueExtractor() )
+				.addValueExtractor( new PropertyValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 
@@ -149,7 +149,7 @@ public class UnwrapValidatedValueTest {
 				.constraint( new MaxDef().value( 5 ).payload( Unwrapping.Skip.class ) );
 
 		Validator validator = configuration.addMapping( mapping )
-				.addCascadedValueExtractor( new PropertyValueExtractor() )
+				.addValueExtractor( new PropertyValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 
@@ -166,7 +166,7 @@ public class UnwrapValidatedValueTest {
 				.constraint( new MaxDef().value( 5 ).payload( Unwrapping.Skip.class, Unwrapping.Unwrap.class ) );
 
 		validator = configuration.addMapping( mapping )
-				.addCascadedValueExtractor( new PropertyValueExtractor() )
+				.addValueExtractor( new PropertyValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/UnwrappingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/UnwrappingTest.java
@@ -60,9 +60,9 @@ public class UnwrappingTest {
 		validatorWithoutValueExtractor = ValidatorUtil.getValidator();
 
 		validatorWithValueExtractor = ValidatorUtil.getConfiguration()
-				.addCascadedValueExtractor( new ValueHolderExtractor() )
-				.addCascadedValueExtractor( new UnwrapByDefaultWrapperValueExtractor() )
-				.addCascadedValueExtractor( new WrapperWithTwoTypeArgumentsValueExtractor() )
+				.addValueExtractor( new ValueHolderExtractor() )
+				.addValueExtractor( new UnwrapByDefaultWrapperValueExtractor() )
+				.addValueExtractor( new WrapperWithTwoTypeArgumentsValueExtractor() )
 				.buildValidatorFactory()
 				.getValidator();
 	}
@@ -181,25 +181,25 @@ public class UnwrappingTest {
 	private class WrapperWithImplicitUnwrapping {
 
 		@Min(10)
-		private final Wrapper<Integer> integerWrapper = new Wrapper<Integer>( 5 );
+		private final Wrapper<Integer> integerWrapper = new Wrapper<>( 5 );
 	}
 
 	private class WrapperWithDisabledUnwrapping {
 
 		@Min(value = 10, payload = { Unwrapping.Skip.class })
-		private final Wrapper<Integer> integerWrapper = new Wrapper<Integer>( 5 );
+		private final Wrapper<Integer> integerWrapper = new Wrapper<>( 5 );
 	}
 
 	private class WrapperWithForcedUnwrapping {
 
 		@Min(value = 10, payload = { Unwrapping.Unwrap.class })
-		private final Wrapper<Integer> integerWrapper = new Wrapper<Integer>( 5 );
+		private final Wrapper<Integer> integerWrapper = new Wrapper<>( 5 );
 	}
 
 	private class BeanWithWrapperWithTwoTypeArguments {
 
 		@Min(value = 10, payload = { Unwrapping.Unwrap.class })
-		private final WrapperWithTwoTypeArguments<Long, String> wrapper = new WrapperWithTwoTypeArguments<Long, String>( 5L, "value" );
+		private final WrapperWithTwoTypeArguments<Long, String> wrapper = new WrapperWithTwoTypeArguments<>( 5L, "value" );
 	}
 
 	private class ValueHolder<T> {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
@@ -52,7 +52,7 @@ public class BeanMetaDataManagerTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
-				new ValueExtractorManager( Collections.emptyList() ),
+				new ValueExtractorManager( Collections.emptySet() ),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()
 		);

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
@@ -59,7 +59,7 @@ public class ExecutableMetaDataTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
-				new ValueExtractorManager( Collections.emptyList() ),
+				new ValueExtractorManager( Collections.emptySet() ),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()
 		);

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
@@ -59,7 +59,7 @@ public class ParameterMetaDataTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
-				new ValueExtractorManager( Collections.emptyList() ),
+				new ValueExtractorManager( Collections.emptySet() ),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()
 		);
@@ -134,7 +134,7 @@ public class ParameterMetaDataTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new SkewedParameterNameProvider() ),
-				new ValueExtractorManager( Collections.emptyList() ),
+				new ValueExtractorManager( Collections.emptySet() ),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()
 		);

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
@@ -43,7 +43,7 @@ public class PropertyMetaDataTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new TypeResolutionHelper(),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
-				new ValueExtractorManager( Collections.emptyList() ),
+				new ValueExtractorManager( Collections.emptySet() ),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()
 		);

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/core/MetaConstraintTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/core/MetaConstraintTest.java
@@ -39,7 +39,7 @@ public class MetaConstraintTest {
 	public void setUp() throws Exception {
 		constraintHelper = new ConstraintHelper();
 		typeResolutionHelper = new TypeResolutionHelper();
-		valueExtractorManager = new ValueExtractorManager( Collections.emptyList() );
+		valueExtractorManager = new ValueExtractorManager( Collections.emptySet() );
 		barMethod = Foo.class.getMethod( "getBar" );
 		constraintAnnotation = barMethod.getAnnotation( NotNull.class );
 	}
@@ -47,14 +47,14 @@ public class MetaConstraintTest {
 	@Test
 	@TestForIssue(jiraKey = "HV-930")
 	public void two_meta_constraints_for_the_same_constraint_should_be_equal() throws Exception {
-		ConstraintDescriptorImpl<NotNull> constraintDescriptor1 = new ConstraintDescriptorImpl<NotNull>(
+		ConstraintDescriptorImpl<NotNull> constraintDescriptor1 = new ConstraintDescriptorImpl<>(
 				constraintHelper, barMethod, constraintAnnotation, METHOD
 		);
 		ConstraintLocation location1 = ConstraintLocation.forClass( Foo.class );
 		MetaConstraint<NotNull> metaConstraint1 = MetaConstraints.create( typeResolutionHelper, valueExtractorManager, constraintDescriptor1, location1 );
 
 
-		ConstraintDescriptorImpl<NotNull> constraintDescriptor2 = new ConstraintDescriptorImpl<NotNull>(
+		ConstraintDescriptorImpl<NotNull> constraintDescriptor2 = new ConstraintDescriptorImpl<>(
 				constraintHelper, barMethod, constraintAnnotation, METHOD
 		);
 		ConstraintLocation location2 = ConstraintLocation.forClass( Foo.class );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
@@ -60,7 +60,7 @@ public class AnnotationMetaDataProviderTest extends AnnotationMetaDataProviderTe
 		provider = new AnnotationMetaDataProvider(
 				new ConstraintHelper(),
 				new TypeResolutionHelper(),
-				new ValueExtractorManager( Collections.emptyList() ),
+				new ValueExtractorManager( Collections.emptySet() ),
 				new AnnotationProcessingOptionsImpl()
 		);
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationMetaDataRetrievalTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationMetaDataRetrievalTest.java
@@ -45,7 +45,7 @@ public class TypeAnnotationMetaDataRetrievalTest extends AnnotationMetaDataProvi
 		provider = new AnnotationMetaDataProvider(
 				new ConstraintHelper(),
 				new TypeResolutionHelper(),
-				new ValueExtractorManager( Collections.emptyList() ),
+				new ValueExtractorManager( Collections.emptySet() ),
 				new AnnotationProcessingOptionsImpl()
 		);
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
@@ -43,7 +43,7 @@ public class MappingXmlParserTest {
 	public void setupParserHelper() {
 		constraintHelper = new ConstraintHelper();
 		xmlMappingParser = new MappingXmlParser(
-				constraintHelper, new TypeResolutionHelper(), new ValueExtractorManager( Collections.emptyList() ), null
+				constraintHelper, new TypeResolutionHelper(), new ValueExtractorManager( Collections.emptySet() ), null
 		);
 	}
 

--- a/engine/src/test/resources/META-INF/services/javax.validation.valueextraction.ValueExtractor
+++ b/engine/src/test/resources/META-INF/services/javax.validation.valueextraction.ValueExtractor
@@ -1,0 +1,1 @@
+org.hibernate.validator.test.internal.engine.cascaded.GuavaOptionalValueExtractor

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/engine/cascaded/multiple-value-extractors-for-same-type-and-type-use-validation.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/engine/cascaded/multiple-value-extractors-for-same-type-and-type-use-validation.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<validation-config
+    xmlns="http://xmlns.jcp.org/xml/ns/validation/configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-configuration-2.0.xsd"
+    version="2.0">
+
+    <value-extractor>org.hibernate.validator.test.internal.engine.cascaded.CustomValueExtractorTest$GuavaOptionalValueExtractor1</value-extractor>
+    <value-extractor>org.hibernate.validator.test.internal.engine.cascaded.CustomValueExtractorTest$GuavaOptionalValueExtractor2</value-extractor>
+</validation-config>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/engine/cascaded/value-extractor-validation.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/engine/cascaded/value-extractor-validation.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<validation-config
+    xmlns="http://xmlns.jcp.org/xml/ns/validation/configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-configuration-2.0.xsd"
+    version="2.0">
+
+    <value-extractor>org.hibernate.validator.test.internal.engine.cascaded.MultimapValueExtractor</value-extractor>
+    <value-extractor>org.hibernate.validator.test.internal.engine.cascaded.CustomValueExtractorTest$GuavaOptionalValueExtractor1</value-extractor>
+</validation-config>

--- a/integration/src/test/java/org/hibernate/validator/integration/util/MyValidatorConfiguration.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/util/MyValidatorConfiguration.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.integration.util;
 
 import java.io.InputStream;
+
 import javax.validation.BootstrapConfiguration;
 import javax.validation.ClockProvider;
 import javax.validation.Configuration;
@@ -16,6 +17,7 @@ import javax.validation.ParameterNameProvider;
 import javax.validation.TraversableResolver;
 import javax.validation.ValidatorFactory;
 import javax.validation.spi.ValidationProvider;
+import javax.validation.valueextraction.ValueExtractor;
 
 /**
  * @author Hardy Ferentschik
@@ -53,6 +55,21 @@ public class MyValidatorConfiguration implements Configuration<MyValidatorConfig
 	}
 
 	@Override
+	public MyValidatorConfiguration parameterNameProvider(ParameterNameProvider parameterNameProvider) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public MyValidatorConfiguration clockProvider(ClockProvider clockProvider) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public MyValidatorConfiguration addValueExtractor(ValueExtractor<?> extractor) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public MyValidatorConfiguration addMapping(InputStream stream) {
 		throw new UnsupportedOperationException();
 	}
@@ -78,28 +95,18 @@ public class MyValidatorConfiguration implements Configuration<MyValidatorConfig
 	}
 
 	@Override
-	public ValidatorFactory buildValidatorFactory() {
-		return provider.buildValidatorFactory( null );
-	}
-
-	@Override
-	public MyValidatorConfiguration parameterNameProvider(ParameterNameProvider parameterNameProvider) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
 	public ParameterNameProvider getDefaultParameterNameProvider() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public MyValidatorConfiguration clockProvider(ClockProvider clockProvider) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
 	public ClockProvider getDefaultClockProvider() {
 		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public ValidatorFactory buildValidatorFactory() {
+		return provider.buildValidatorFactory( null );
 	}
 
 	@Override


### PR DESCRIPTION
* https://hibernate.atlassian.net/browse/HV-1257 (`Configuration#addValueExtractor()`, `ValidatorContext#addValueExtractor()`)
* https://hibernate.atlassian.net/browse/HV-1260 (_validation.xml_)
* https://hibernate.atlassian.net/browse/HV-1261 (service loader)

Requires https://github.com/beanvalidation/beanvalidation-api/pull/89