### PR TITLE
HV-1152 Make JavaDoc render correctly with Java 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,10 @@
 
         <!-- add-opens options required for Arquillian and WildFly -->
         <arquillian.javaVmArguments.add-opens></arquillian.javaVmArguments.add-opens>
+
+        <!-- JavaDoc stylesheet name -->
+        <!-- styles for jdk8 and jdk9 are different-->
+        <javadoc-stylesheet-name>stylesheet.css</javadoc-stylesheet-name>
     </properties>
 
     <prerequisites>
@@ -645,7 +649,7 @@
                     <configuration>
                         <docfilessubdirs>true</docfilessubdirs>
                         <javadocDirectory>${project.basedir}/../src/main/javadoc</javadocDirectory>
-                        <stylesheetfile>stylesheet.css</stylesheetfile>
+                        <stylesheetfile>${javadoc-stylesheet-name}</stylesheetfile>
                         <bottom>
                             <![CDATA[Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="http://redhat.com">Red Hat, Inc.</a> All Rights Reserved]]></bottom>
                     </configuration>
@@ -996,6 +1000,7 @@
                     --add-opens=java.management/javax.management.openmbean=ALL-UNNAMED
                     --add-opens=java.naming/javax.naming=ALL-UNNAMED
                 </arquillian.javaVmArguments.add-opens>
+                <javadoc-stylesheet-name>stylesheet-jdk9.css</javadoc-stylesheet-name>
             </properties>
             <build>
                 <pluginManagement>

--- a/src/main/javadoc/stylesheet-jdk9.css
+++ b/src/main/javadoc/stylesheet-jdk9.css
@@ -1,0 +1,934 @@
+/**
+ * Hibernate O/RM Java 7 compliant JavaDoc stylesheet.
+ */
+body {
+    background: #FFFFFF url(resources/bkg_gradient.gif) repeat-x;
+    margin: 0;
+    font-family: 'Lucida Grande', Geneva, Verdana, Arial, sans-serif;
+    font-size: 12px;
+    padding: 0;
+    color: #333;
+    height: 100%;
+    width: 100%;
+}
+
+iframe {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    width: 100%;
+    overflow-y: scroll;
+    border: none;
+}
+
+a:link, a:visited {
+    text-decoration: none;
+    color: #455e60;
+}
+
+a:hover, a:focus {
+    text-decoration: none;
+    color: #BCAE79;
+}
+
+a:active {
+    text-decoration: none;
+    color: #455e60;
+}
+
+a[name] {
+    color: #353833;
+}
+
+a[name]:hover {
+    text-decoration: none;
+    color: #353833;
+}
+
+a[name]:before, a[name]:target {
+    content: "";
+    display: block;
+    height: 120px;
+    margin: -120px 0 0;
+}
+
+a[id]:before, a[id]:target {
+    padding-top: 129px;
+    margin-top: -129px;
+    color: red;
+}
+
+pre {
+    font-family: 'DejaVu Sans Mono', monospace;
+    font-size: 14px;
+}
+
+h1 {
+    background: url(resources/h1_hdr.png) no-repeat;
+    line-height: 1.2em;
+    color: #586464;
+    font-size: 16pt;
+    padding: 17pt;
+    margin-top: 0;
+    text-align: left;
+}
+
+h2 {
+    color: #586464;
+    font-size: 1.5em;
+}
+
+h3 {
+    font-size: 1.4em;
+}
+
+h4 {
+    font-size: 1.3em;
+}
+
+h5 {
+    font-size: 1.2em;
+}
+
+h6 {
+    font-size: 1.1em;
+}
+
+ul {
+    list-style-type: disc;
+}
+
+code, tt {
+    font-size: 14px;
+    padding-top: 4px;
+    margin-top: 8px;
+    line-height: 1.4em;
+}
+
+dt code {
+    font-size: 14px;
+    padding-top: 4px;
+}
+
+table tr td dt code {
+    font-size: 14px;
+    vertical-align: top;
+    padding-top: 4px;
+}
+
+sup {
+    font-size: 8px;
+}
+
+/*
+Document title and Copyright styles
+*/
+.clear {
+    clear: both;
+    height: 0;
+    overflow: hidden;
+}
+
+.aboutLanguage {
+    float: right;
+    padding: 0 21px;
+    font-size: 11px;
+    z-index: 200;
+    margin-top: -9px;
+}
+
+.legalCopy {
+    margin-left: .5em;
+}
+
+.bar a, .bar a:link, .bar a:visited, .bar a:active {
+    color: #FFFFFF;
+    text-decoration: none;
+}
+
+.bar a:hover, .bar a:focus {
+    color: #BCAE79;
+}
+
+.tab {
+    background-color: #0066FF;
+    background-image: url(resources/bkgheader.png);
+    background-position: left top;
+    background-repeat: no-repeat;
+    color: #ffffff;
+    padding: 8px;
+    width: 5em;
+    font-weight: bold;
+}
+
+/*
+Navigation bar styles
+*/
+.bar {
+    background: url(resources/bkgheader.png) repeat-x;
+    color: #FFFFFF;
+    padding: .8em .5em .4em .8em;
+    height: auto; /*height:1.8em;*/
+    font-size: 11px;
+    margin: 0;
+}
+
+.navPadding {
+    padding-top: 107px;
+}
+
+.fixedNav {
+    position: fixed;
+    width: 100%;
+    z-index: 999;
+    background-color: #ffffff;
+}
+
+.topNav {
+    background: url(resources/bkgheader.png) repeat-x;
+    color: #FFFFFF;
+    float: left;
+    width: 100%;
+    clear: right;
+    height: 2.8em;
+    padding: 10px 0 0;
+    overflow: hidden;
+    font-size: 12px;
+}
+
+.bottomNav {
+    background: url(resources/bkgheader.png) repeat-x;
+    color: #FFFFFF;
+    float: left;
+    width: 100%;
+    clear: right;
+    height: 2.8em;
+    padding: 10px 0 0;
+    overflow: hidden;
+    font-size: 12px;
+}
+
+.subNav {
+    background-color: #cccdc7;
+    border-bottom: 1px solid #949c9c;
+    float: left;
+    width: 100%;
+    overflow: hidden;
+    font-size: 12px;
+}
+
+.subNav div {
+    clear: left;
+    float: left;
+    padding: 0 0 5px 6px;
+    text-transform: uppercase;
+}
+
+ul.navList, ul.subNavList {
+    float: left;
+    margin: 0 25px 0 0;
+    padding: 0;
+}
+
+ul.navList li {
+    list-style: none;
+    float: left;
+    padding: 5px 6px;
+    text-transform: uppercase;
+}
+
+ul.navListSearch {
+    float: right;
+    margin: 0 0 0 0;
+    padding: 0;
+}
+
+ul.navListSearch li {
+    list-style: none;
+    float: right;
+    padding: 5px 6px;
+    text-transform: uppercase;
+}
+
+ul.navListSearch li span {
+    position: relative;
+    right: -16px;
+}
+
+ul.subNavList li {
+    list-style: none;
+    float: left;
+}
+
+.topNav a:link, .topNav a:active, .topNav a:visited, .bottomNav a:link, .bottomNav a:active, .bottomNav a:visited {
+    color: #FFFFFF;
+    text-decoration: none;
+    text-transform: uppercase;
+}
+
+.topNav a:hover, .bottomNav a:hover {
+    text-decoration: none;
+    color: #BCAE79;
+}
+
+.navBarCell1Rev {
+    background: #ab9d69 url(resources/tab.gif);
+    color: #FFFFFF;
+    margin: auto 5px;
+    border: 1px solid #ab9d69;
+}
+
+.skipNav {
+    position: absolute;
+    top: auto;
+    left: -9999px;
+    overflow: hidden;
+}
+
+/*
+Page header and footer styles
+*/
+.header, .footer {
+    clear: both;
+    margin: 0 20px;
+    padding: 5px 0 0 0;
+}
+
+.indexNav {
+    position: relative;
+    font-size: 12px;
+    background-color: #dee3e9;
+}
+
+.indexNav ul {
+    margin-top: 0;
+    padding: 5px;
+}
+
+.indexNav ul li {
+    display: inline;
+    list-style-type: none;
+    padding-right: 10px;
+    text-transform: uppercase;
+}
+
+.indexNav h1 {
+    font-size: 13px;
+}
+
+.title {
+    color: #2c4557;
+    margin: 10px 0;
+}
+
+.subTitle {
+    margin: 5px 0 0 0;
+}
+
+.header ul {
+    margin: 0 0 15px 0;
+    padding: 0;
+}
+
+.footer ul {
+    margin: 20px 0 5px 0;
+}
+
+.header ul li, .footer ul li {
+    list-style: none;
+    font-size: 13px;
+}
+
+/*
+Heading styles
+*/
+div.details ul.blockList ul.blockList ul.blockList li.blockList h4, div.details ul.blockList ul.blockList ul.blockListLast li.blockList h4 {
+    background-color: #cccdc7;
+    border-top: 1px solid #949c9c;
+    border-bottom: 1px solid #949c9c;
+    margin: 0 0 6px -8px;
+    padding: 7px 5px;
+}
+
+ul.blockList ul.blockList ul.blockList li.blockList h3 {
+    background-color: #cccdc7;
+    border-top: 1px solid #949c9c;
+    border-bottom: 1px solid #949c9c;
+    margin: 0 0 6px -8px;
+    padding: 7px 5px;
+}
+
+ul.blockList ul.blockList li.blockList h3 {
+    padding: 0;
+    margin: 15px 0;
+}
+
+ul.blockList li.blockList h2 {
+    padding: 0 0 20px 0;
+}
+
+/*
+Page layout container styles
+*/
+.contentContainer, .sourceContainer, .classUseContainer, .serializedFormContainer, .constantValuesContainer {
+    clear: both;
+    padding: 10px 20px;
+    position: relative;
+}
+
+.indexContainer {
+    margin: 10px;
+    position: relative;
+    font-size: 12px;
+}
+
+.indexContainer h2 {
+    font-size: 13px;
+    padding: 0 0 3px 0;
+}
+
+.indexContainer ul {
+    margin: 0;
+    padding: 0;
+}
+
+.indexContainer ul li {
+    list-style: none;
+    padding-top: 2px;
+}
+
+.contentContainer .description dl dt, .contentContainer .details dl dt, .serializedFormContainer dl dt {
+    font-size: 12px;
+    font-weight: bold;
+    margin: 10px 0 0 0;
+    color: #4E4E4E;
+}
+
+.contentContainer .description dl dd, .contentContainer .details dl dd, .serializedFormContainer dl dd {
+    margin: 5px 0 10px 0;
+    font-size: 14px;
+    font-family: 'DejaVu Serif', Georgia, "Times New Roman", Times, serif;
+}
+
+.serializedFormContainer dl.nameValue dt {
+    margin-left: 1px;
+    font-size: 1.1em;
+    display: inline;
+    font-weight: bold;
+}
+
+.serializedFormContainer dl.nameValue dd {
+    margin: 0 0 0 1px;
+    font-size: 1.1em;
+    display: inline;
+}
+
+/*
+List styles
+*/
+li.circle {
+    list-style: circle;
+}
+
+ul.horizontal li {
+    display: inline;
+    font-size: 0.9em;
+}
+
+ul.inheritance {
+    margin: 0;
+    padding: 0;
+}
+
+ul.inheritance li {
+    display: inline;
+    list-style: none;
+}
+
+ul.inheritance li ul.inheritance {
+    margin-left: 15px;
+    padding-left: 15px;
+    padding-top: 1px;
+}
+
+ul.blockList, ul.blockListLast {
+    margin: 10px 0 10px 0;
+    padding: 0;
+}
+
+ul.blockList li.blockList, ul.blockListLast li.blockList {
+    list-style: none;
+    margin-bottom: 15px;
+    line-height: 1.4;
+}
+
+ul.blockList ul.blockList li.blockList, ul.blockList ul.blockListLast li.blockList {
+    padding: 0 20px 5px 10px;
+    border: 1px solid #949c9c;
+    background-color: #f9f9f9;
+}
+
+ul.blockList ul.blockList ul.blockList li.blockList, ul.blockList ul.blockList ul.blockListLast li.blockList {
+    padding: 0 0 5px 8px;
+    background-color: #ffffff;
+    border: 1px solid #949c9c;
+}
+
+ul.blockList ul.blockList ul.blockList ul.blockList li.blockList {
+    margin-left: 0;
+    padding-left: 0;
+    padding-bottom: 15px;
+    border: none;
+    border-bottom: 1px solid #949c9c;
+}
+
+ul.blockList ul.blockList ul.blockList ul.blockList li.blockListLast {
+    list-style: none;
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+table tr td dl, table tr td dl dt, table tr td dl dd {
+    margin-top: 0;
+    margin-bottom: 1px;
+}
+
+/*
+Table styles
+*/
+.contentContainer table, .classUseContainer table, .constantValuesContainer table {
+    border-bottom: 1px solid #949c9c;
+    width: 100%;
+}
+
+.overviewSummary, .memberSummary, .typeSummary, .useSummary, .constantsSummary, .deprecatedSummary,
+.requiresSummary, .packagesSummary, .providesSummary, .usesSummary {
+    width: 100%;
+    border-spacing: 0;
+    border-left: 1px solid #EEE;
+    border-right: 1px solid #EEE;
+    border-bottom: 1px solid #EEE;
+}
+
+.overviewSummary, .memberSummary, .requiresSummary, .packagesSummary, .providesSummary, .usesSummary {
+    padding: 0;
+}
+
+.overviewSummary caption, .memberSummary caption, .typeSummary caption,
+.useSummary caption, .constantsSummary caption, .deprecatedSummary caption,
+.requiresSummary caption, .packagesSummary caption, .providesSummary caption, .usesSummary caption {
+    position: relative;
+    text-align: left;
+    background-repeat: no-repeat;
+    color: #253441;
+    font-weight: bold;
+    clear: none;
+    overflow: hidden;
+    padding: 10px 0 0 1px;
+    margin: 0;
+    white-space: pre;
+}
+
+.overviewSummary caption a:link, .memberSummary caption a:link, .typeSummary caption a:link,
+.useSummary caption a:link, .constantsSummary caption a:link, .deprecatedSummary caption a:link,
+.requiresSummary caption a:link, .packagesSummary caption a:link, .providesSummary caption a:link,
+.usesSummary caption a:link,
+.overviewSummary caption a:hover, .memberSummary caption a:hover, .typeSummary caption a:hover,
+.useSummary caption a:hover, .constantsSummary caption a:hover, .deprecatedSummary caption a:hover,
+.requiresSummary caption a:hover, .packagesSummary caption a:hover, .providesSummary caption a:hover,
+.usesSummary caption a:hover,
+.overviewSummary caption a:active, .memberSummary caption a:active, .typeSummary caption a:active,
+.useSummary caption a:active, .constantsSummary caption a:active, .deprecatedSummary caption a:active,
+.requiresSummary caption a:active, .packagesSummary caption a:active, .providesSummary caption a:active,
+.usesSummary caption a:active,
+.overviewSummary caption a:visited, .memberSummary caption a:visited, .typeSummary caption a:visited,
+.useSummary caption a:visited, .constantsSummary caption a:visited, .deprecatedSummary caption a:visited,
+.requiresSummary caption a:visited, .packagesSummary caption a:visited, .providesSummary caption a:visited,
+.usesSummary caption a:visited {
+    color: #FFFFFF;
+}
+
+.overviewSummary caption span, .memberSummary caption span, .typeSummary caption span,
+.useSummary caption span, .constantsSummary caption span, .deprecatedSummary caption span,
+.requiresSummary caption span, .packagesSummary caption span, .providesSummary caption span,
+.usesSummary caption span {
+    white-space: nowrap;
+    padding: 5px 6px 7px 12px;
+    display: inline-block;
+    float: left;
+    background-image: url(resources/titlebar.gif);
+    border: none;
+    height: 16px;
+}
+
+.memberSummary caption span.activeTableTab span, .packagesSummary caption span.activeTableTab span {
+    white-space: nowrap;
+    padding-top: 5px;
+    padding-left: 12px;
+    padding-right: 6px;
+    display: inline-block;
+    float: left;
+    background-image: url(resources/titlebar.gif);
+    height: 16px;
+}
+
+.memberSummary caption span.tableTab span, .packagesSummary caption span.tableTab span {
+    white-space: nowrap;
+    padding-top: 5px;
+    padding-left: 12px;
+    padding-right: 6px;
+    display: inline-block;
+    float: left;
+    background-image: url(resources/titlebar.gif);
+    height: 16px;
+}
+
+.memberSummary caption span.tableTab, .memberSummary caption span.activeTableTab,
+.packagesSummary caption span.tableTab, .packagesSummary caption span.activeTableTab {
+    padding-top: 0;
+    padding-left: 0;
+    padding-right: 0;
+    background-image: none;
+    float: none;
+    display: inline;
+}
+
+.overviewSummary .tabEnd, .memberSummary .tabEnd, .typeSummary .tabEnd,
+.useSummary .tabEnd, .constantsSummary .tabEnd, .deprecatedSummary .tabEnd,
+.requiresSummary .tabEnd, .packagesSummary .tabEnd, .providesSummary .tabEnd, .usesSummary .tabEnd {
+    width: 0;
+    margin-right: 3px;
+    margin-left: 0;
+    padding-left: 0;
+    position: relative;
+    background: url(resources/titlebar_end.gif) no-repeat top right;
+    float: left;
+}
+
+.memberSummary .activeTableTab .tabEnd, .packagesSummary .activeTableTab .tabEnd {
+    width: 0;
+    margin-right: 3px;
+    margin-left: 0;
+    padding-left: 0;
+    position: relative;
+    float: left;
+    background: url(resources/titlebar_end.gif) no-repeat top right;
+}
+
+.memberSummary .tableTab .tabEnd, .packagesSummary .tableTab .tabEnd {
+    width: 0;
+    margin-right: 3px;
+    margin-left: 0;
+    padding-left: 0;
+    position: relative;
+    background: url(resources/titlebar_end.gif) no-repeat top right;
+    float: left;
+
+}
+
+.rowColor th, .altColor th {
+    font-weight: normal;
+}
+
+.overviewSummary td, .memberSummary td, .typeSummary td,
+.useSummary td, .constantsSummary td, .deprecatedSummary td,
+.requiresSummary td, .packagesSummary td, .providesSummary td, .usesSummary td {
+    text-align: left;
+    padding: 0 0 12px 10px;
+}
+
+th.colFirst, th.colSecond, th.colLast, .useSummary th, .constantsSummary th, .packagesSummary th,
+td.colFirst, td.colSecond, td.colLast, .useSummary td, .constantsSummary td {
+    vertical-align: top;
+    padding-right: 0;
+    padding-top: 8px;
+    padding-bottom: 3px;
+}
+
+th.colFirst, td.colFirst {
+    border-left: 1px solid #949c9c;
+}
+
+th.colFirst, th.colSecond, th.colLast, .constantsSummary th, .packagesSummary th,
+td.colFirst, td.colSecond, td.colLast, .constantsSummary td, .packagesSummary td {
+    border-right: 1px solid #949c9c;
+    border-top: 1px solid #949c9c;
+}
+
+th.colFirst, th.colSecond, th.colLast, .constantsSummary th, .packagesSummary th {
+    background: #cccdc7;
+    text-align: left;
+    padding: 8px 3px 3px 7px;
+}
+
+td.colFirst, th.colFirst {
+    white-space: nowrap;
+    font-size: 13px;
+}
+
+td.colSecond, th.colSecond, td.colLast, th.colLast {
+    font-size: 13px;
+}
+
+.constantsSummary th, .packagesSummary th {
+    font-size: 13px;
+}
+
+.providesSummary th.colFirst, .providesSummary th.colLast, .providesSummary td.colFirst,
+.providesSummary td.colLast {
+    white-space: normal;
+    font-size: 13px;
+}
+
+.overviewSummary td.colFirst, .overviewSummary th.colFirst,
+.requiresSummary td.colFirst, .requiresSummary th.colFirst,
+.packagesSummary td.colFirst, .packagesSummary td.colSecond, .packagesSummary th.colFirst, .packagesSummary th,
+.usesSummary td.colFirst, .usesSummary th.colFirst,
+.providesSummary td.colFirst, .providesSummary th.colFirst,
+.memberSummary td.colFirst, .memberSummary th.colFirst,
+.memberSummary td.colSecond, .memberSummary th.colSecond,
+.typeSummary td.colFirst {
+    vertical-align: top;
+}
+
+.packagesSummary th.colLast, .packagesSummary td.colLast {
+    white-space: normal;
+}
+
+td.colFirst a:link, td.colFirst a:active, td.colFirst a:visited, td.colFirst a:hover,
+td.colSecond a:link, td.colSecond a:active, td.colSecond a:visited, td.colSecond a:hover,
+th.colFirst a:link, th.colFirst a:active, th.colFirst a:visited, th.colFirst a:hover,
+th.colSecond a:link, th.colSecond a:active, th.colSecond a:visited, th.colSecond a:hover,
+td.colLast a:link, td.colLast a:active, td.colLast a:visited, td.colLast a:hover,
+.constantValuesContainer td a:link, .constantValuesContainer td a:active,
+.constantValuesContainer td a:visited, .constantValuesContainer td a:hover {
+    font-weight: bold;
+}
+
+.tableSubHeadingColor {
+    background-color: #EEEEFF;
+}
+
+.altColor, .altColor th {
+    background-color: #dad7ce;
+}
+
+.rowColor, .rowColor th {
+    background-color: #e8e6e0;
+}
+
+/*
+Content styles
+*/
+.description pre {
+    margin-top: 0;
+}
+
+.deprecatedContent {
+    margin: 0;
+    padding: 10px 0;
+}
+
+.docSummary {
+    padding: 0;
+}
+
+ul.blockList ul.blockList ul.blockList li.blockList h3 {
+    font-style: normal;
+}
+
+div.block {
+    font-size: 14px;
+    font-family: 'DejaVu Serif', Georgia, "Times New Roman", Times, serif;
+}
+
+td.colLast div {
+    padding-top: 0;
+}
+
+td.colLast a {
+    padding-bottom: 3px;
+}
+
+/*
+Formatting effect styles
+*/
+.sourceLineNo {
+    color: green;
+    padding: 0 30px 0 0;
+}
+
+h1.hidden {
+    visibility: hidden;
+    overflow: hidden;
+    font-size: 10px;
+}
+
+.block {
+    display: block;
+    margin: 3px 10px 2px 0;
+    color: #474747;
+}
+
+.deprecatedLabel, .descfrmTypeLabel, .implementationLabel, .memberNameLabel, .memberNameLink,
+.moduleLabelInClass, .overrideSpecifyLabel, .packageLabelInClass,
+.packageHierarchyLabel, .paramLabel, .returnLabel, .seeLabel, .simpleTagLabel,
+.throwsLabel, .typeNameLabel, .typeNameLink, .searchTagLink {
+    font-weight: bold;
+}
+
+.deprecationComment, .emphasizedPhrase, .interfaceName {
+    font-style: italic;
+}
+
+div.block div.block span.deprecationComment, div.block div.block span.emphasizedPhrase,
+div.block div.block span.interfaceName {
+    font-style: normal;
+}
+
+div.contentContainer ul.blockList li.blockList h2 {
+    padding-bottom: 0;
+}
+
+/*
+IFRAME specific styles
+*/
+.mainContainer {
+    margin: 0 auto;
+    padding: 0;
+    height: 100%;
+    width: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+}
+
+.leftContainer {
+    height: 100%;
+    position: fixed;
+    width: 320px;
+}
+
+.leftTop {
+    position: relative;
+    float: left;
+    width: 315px;
+    top: 0;
+    left: 0;
+    height: 30%;
+    border-right: 6px solid #ccc;
+    border-bottom: 6px solid #ccc;
+}
+
+.leftBottom {
+    position: relative;
+    float: left;
+    width: 315px;
+    bottom: 0;
+    left: 0;
+    height: 70%;
+    border-right: 6px solid #ccc;
+    border-top: 1px solid #000;
+}
+
+.rightContainer {
+    position: absolute;
+    left: 320px;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+    right: 0;
+    border-left: 1px solid #000;
+}
+
+.rightIframe {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+    right: 30px;
+    width: 100%;
+    overflow: visible;
+    margin-bottom: 30px;
+}
+
+/*
+HTML5 specific styles
+*/
+main, nav, header, footer, section {
+    display: block;
+}
+
+.ui-autocomplete-category {
+    font-weight: bold;
+    font-size: 15px;
+    padding: 7px 0 7px 3px;
+    background-color: #ab9d69;
+    color: #FFFFFF;
+}
+
+.resultItem {
+    font-size: 13px;
+}
+
+.ui-autocomplete {
+    max-height: 85%;
+    max-width: 65%;
+    overflow-y: scroll;
+    overflow-x: scroll;
+    white-space: nowrap;
+    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.16), 0 3px 6px rgba(0, 0, 0, 0.23);
+}
+
+input[type=text]:focus {
+    outline: none !important;
+    box-shadow: 0 0 10px #BCAE79, 0 0 10px #ab9d69;
+}
+
+ul.ui-autocomplete {
+    position: fixed;
+    z-index: 999999;
+}
+
+ul.ui-autocomplete li {
+    float: left;
+    clear: both;
+    width: 100%;
+}
+
+.resultHighlight {
+    font-weight: bold;
+}
+
+#search {
+    background-image: url('resources/glass.png');
+    background-size: 13px;
+    background-repeat: no-repeat;
+    background-position: 2px 3px;
+    padding-left: 20px;
+    position: relative;
+    right: -18px;
+}
+
+#reset {
+    border: 0 none;
+    width: 15px;
+    height: 16px;
+    position: relative;
+    left: -2px;
+    background-size: 12px;
+    background: rgb(255, 255, 255) url('resources/x.png') no-repeat center;
+}
+
+.watermark {
+    color: #888;
+}
+
+.searchTagDescResult {
+    font-style: italic;
+    font-size: 11px;
+}
+
+.searchTagHolderResult {
+    font-style: italic;
+    font-size: 12px;
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1152

As for the `add-modules` part I was using Java:
```
java version "9-ea"
Java(TM) SE Runtime Environment (build 9-ea+158)
Java HotSpot(TM) 64-Bit Server VM (build 9-ea+158, mixed mode)
```
and it was failing to find `java.annotations.common`. So I've looked and `java.annotation.Generated` was present in `java.xml.ws.annotation` so I've made this change. 

I've also moved that `<finalName>` to a build level from assembly plugin configuration as IDE was complaining about it's location

As for the css part - I didn't want to change current look of JavaDoc, and that's why I ended up adding a new stylesheet. It's mainly because of the borders - if keep them for the tables - some of them start to look vary bad for jdk9 build (if needed can send a screenshot of it :) ). So I've took regular jdk9 JavaDoc and adapted it to Hibernate style.