### PR TITLE
HV-1266 Updating build instructions to reflect relocation of @Generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ There are more build options available as well. For more information refer to [C
 
 To build Hibernate Validator with JDK 9, export the following environment variable:
 
-    export MAVEN_OPTS="--add-modules java.annotations.common,java.xml.bind --add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
+    export MAVEN_OPTS="--add-opens=java.base/java.security=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
 
 Then the build can be started like this:
 
     mvn -s settings-example.xml clean install
 
-Also the OSGi integration tests will fail on Java 9 currently, hence the "osgi" module is excluded automatically when building on JDK 9. We are waiting for the release of Karaf 4.1.0.
+Also the OSGi integration tests will fail on Java 9 currently, hence the "osgi" module is excluded automatically when building on JDK 9. We are waiting for the release of a Karaf version supporting the latest Java 9 builds.
 
 Here are the reasons why we added the various --add-opens options:
 

--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>3.6.1</version>
                     <configuration>
                         <testCompilerArgument>-parameters</testCompilerArgument>
                     </configuration>
@@ -1000,6 +1000,15 @@
             <build>
                 <pluginManagement>
                     <plugins>
+                        <plugin>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <configuration>
+                                <fork>true</fork>
+                                <compilerArgs>
+                                    <arg>-J--add-modules=java.xml.ws.annotation</arg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
                         <plugin>
                             <artifactId>maven-surefire-plugin</artifactId>
                             <version>${maven-surefire-plugin.version}</version>


### PR DESCRIPTION
@gsmet Not sure what we have on CI; we can keep it on hold if there's still an older version installed. But I had the change handy so I thought I could well propose it.

https://hibernate.atlassian.net/browse/HV-1266