### PR TITLE
HV-1278 Add performance test for multi-level container element validation

### DIFF
--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -58,6 +58,29 @@
     </dependencies>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <!-- adding sources for BV 2.0 tests -->
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>add-source</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>add-source</goal>
+                            </goals>
+                            <configuration>
+                                <sources>
+                                    <source>${project.basedir}/src/main/java-bv2</source>
+                                </sources>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -154,6 +177,15 @@
                     <artifactId>log4j</artifactId>
                 </dependency>
             </dependencies>
+            <!-- adding sources for BV 2.0 tests -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>hv-5.4</id>

--- a/performance/src/main/java-bv2/org/hibernate/validator/performance/multilevel/MultiLevelContainerValidation.java
+++ b/performance/src/main/java-bv2/org/hibernate/validator/performance/multilevel/MultiLevelContainerValidation.java
@@ -4,7 +4,7 @@
  * License: Apache License, Version 2.0
  * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
  */
-package org.hibernate.validator.performance.simple;
+package org.hibernate.validator.performance.multilevel;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;

--- a/performance/src/main/java/org/hibernate/validator/performance/BenchmarkRunner.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/BenchmarkRunner.java
@@ -6,10 +6,10 @@
  */
 package org.hibernate.validator.performance;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 import org.hibernate.validator.performance.cascaded.CascadedValidation;
+import org.hibernate.validator.performance.simple.MultiLevelContainerValidation;
 import org.hibernate.validator.performance.simple.SimpleValidation;
 import org.hibernate.validator.performance.statistical.StatisticalValidation;
 import org.openjdk.jmh.results.format.ResultFormatType;
@@ -29,10 +29,11 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
  */
 public final class BenchmarkRunner {
 
-	private static final List<Class<?>> DEFAULT_TEST_CLASSES = Arrays.asList(
+	private static final Stream<Class<?>> DEFAULT_TEST_CLASSES = Stream.of(
 			SimpleValidation.class,
 			CascadedValidation.class,
-			StatisticalValidation.class
+			StatisticalValidation.class,
+			MultiLevelContainerValidation.class
 	);
 
 	private BenchmarkRunner() {
@@ -49,7 +50,7 @@ public final class BenchmarkRunner {
 			builder.resultFormat( ResultFormatType.JSON );
 		}
 		if ( commandLineOptions.getIncludes().isEmpty() ) {
-			DEFAULT_TEST_CLASSES.stream().forEach( testClass -> builder.include( testClass.getName() ) );
+			DEFAULT_TEST_CLASSES.forEach( testClass -> builder.include( testClass.getName() ) );
 		}
 
 		Options opt = builder.build();

--- a/performance/src/main/java/org/hibernate/validator/performance/simple/MultiLevelContainerValidation.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/simple/MultiLevelContainerValidation.java
@@ -1,0 +1,197 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.performance.simple;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * @author Marko Bekhta
+ */
+public class MultiLevelContainerValidation {
+
+	private static final int MAX_MAP_ENTRIES = 200;
+	private static final int MAX_LIST_ENTRIES = 50;
+
+	@State(Scope.Benchmark)
+	public static class MultiLevelContainerState {
+
+		volatile Validator validator;
+		volatile MapContainer mapContainer = new MapContainer(
+				RandomDataGenerator.prepareTestData( MAX_MAP_ENTRIES, MAX_LIST_ENTRIES )
+		);
+
+		public MultiLevelContainerState() {
+			try ( ValidatorFactory factory = Validation.buildDefaultValidatorFactory() ) {
+				validator = factory.getValidator();
+			}
+		}
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.Throughput)
+	@OutputTimeUnit(TimeUnit.MILLISECONDS)
+	@Fork(value = 1)
+	@Threads(50)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 50)
+	public void testMultiLevelPreGeneratedValidation(MultiLevelContainerState state, Blackhole bh) {
+		Set<ConstraintViolation<MapContainer>> violations = state.validator.validate( state.mapContainer );
+		bh.consume( violations );
+	}
+
+	/**
+	 * Model classes.
+	 */
+
+	private static class MapContainer {
+
+		private final Map<@NotNull Optional<@Valid Cinema>, List<@NotNull @Valid EmailAddress>> map;
+
+		public MapContainer(Map<@NotNull Optional<@Valid Cinema>, List<@NotNull @Valid EmailAddress>> map) {
+			this.map = map;
+		}
+
+		public Map<Optional<Cinema>, List<EmailAddress>> getMap() {
+			return map;
+		}
+	}
+
+	private static class Cinema {
+
+		private final String name;
+
+		private final Reference<@Valid Visitor> visitor;
+
+		Cinema(String name, Reference<Visitor> visitor) {
+			this.name = name;
+			this.visitor = visitor;
+		}
+
+		static Cinema generate() {
+			return new Cinema( RandomDataGenerator.randomString(), new SomeReference<>( Visitor.generate() ) );
+		}
+
+	}
+
+	private interface Reference<T> {
+
+		T getValue();
+	}
+
+	private static class SomeReference<T> implements Reference<T> {
+
+		private final T value;
+
+		public SomeReference(T value) {
+			this.value = value;
+		}
+
+		@Override
+		public T getValue() {
+			return value;
+		}
+	}
+
+	private static class Visitor {
+
+		@NotNull
+		private final String name;
+
+		Visitor(String name) {
+			this.name = name;
+		}
+
+		static Visitor generate() {
+			return new Visitor( RandomDataGenerator.randomString() );
+		}
+
+	}
+
+	private static class EmailAddress {
+
+		@Size(max = 50)
+		@NotNull
+		private final String email;
+
+		public EmailAddress(String value) {
+			this.email = value;
+		}
+
+		public static EmailAddress generate() {
+			return new EmailAddress(
+					String.format( "%s@%s.com", RandomDataGenerator.randomString(), RandomDataGenerator.randomString() )
+			);
+		}
+
+		public static List<EmailAddress> generateList(int numOfEntries) {
+			if ( numOfEntries < 0 ) {
+				throw new IllegalArgumentException( "numOfEntries should be a positive number" );
+			}
+			List<EmailAddress> addresses = new ArrayList<>( numOfEntries );
+			for ( int i = 0; i < numOfEntries; i++ ) {
+				addresses.add( generate() );
+			}
+			return addresses;
+		}
+
+	}
+
+	/**
+	 * Test data generator.
+	 */
+	private static final class RandomDataGenerator {
+
+		private static final Random RANDOM = new Random();
+
+		private RandomDataGenerator() {
+
+		}
+
+		public static Map<Optional<Cinema>, List<EmailAddress>> prepareTestData(int maxEntries, int maxListEntries) {
+			Map<Optional<Cinema>, List<EmailAddress>> map = new LinkedHashMap<>();
+			for ( int i = 0; i < maxEntries; i++ ) {
+				map.put( Optional.of( Cinema.generate() ), EmailAddress.generateList( maxListEntries ) );
+			}
+			return map;
+		}
+
+		public static String randomString() {
+			char[] chars = new char[RANDOM.nextInt( 10 ) + 1];
+			for ( int i = 0; i < chars.length; i++ ) {
+				chars[i] = (char) RANDOM.nextInt();
+			}
+			return String.valueOf( chars );
+		}
+	}
+
+}

--- a/performance/src/main/java/org/hibernate/validator/performance/simple/MultiLevelContainerValidation.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/simple/MultiLevelContainerValidation.java
@@ -81,26 +81,27 @@ public class MultiLevelContainerValidation {
 			this.map = map;
 		}
 
+		@SuppressWarnings("unused")
 		public Map<Optional<Cinema>, List<EmailAddress>> getMap() {
 			return map;
 		}
 	}
 
+	@SuppressWarnings("unused")
 	private static class Cinema {
 
 		private final String name;
 
 		private final Reference<@Valid Visitor> visitor;
 
-		Cinema(String name, Reference<Visitor> visitor) {
+		public Cinema(String name, Reference<Visitor> visitor) {
 			this.name = name;
 			this.visitor = visitor;
 		}
 
-		static Cinema generate() {
+		public static Cinema generate() {
 			return new Cinema( RandomDataGenerator.randomString(), new SomeReference<>( Visitor.generate() ) );
 		}
-
 	}
 
 	private interface Reference<T> {
@@ -127,18 +128,20 @@ public class MultiLevelContainerValidation {
 		@NotNull
 		private final String name;
 
-		Visitor(String name) {
+		public Visitor(String name) {
 			this.name = name;
 		}
 
-		static Visitor generate() {
+		public static Visitor generate() {
 			return new Visitor( RandomDataGenerator.randomString() );
 		}
-
 	}
 
 	private static class EmailAddress {
 
+		// we use these simple constraints here for 2 reasons:
+		// - @Email is not part of Bean Validation 1.x
+		// - we don't want to use expensive constraints
 		@Size(max = 50)
 		@NotNull
 		private final String email;
@@ -163,7 +166,6 @@ public class MultiLevelContainerValidation {
 			}
 			return addresses;
 		}
-
 	}
 
 	/**
@@ -174,7 +176,6 @@ public class MultiLevelContainerValidation {
 		private static final Random RANDOM = new Random();
 
 		private RandomDataGenerator() {
-
 		}
 
 		public static Map<Optional<Cinema>, List<EmailAddress>> prepareTestData(int maxEntries, int maxListEntries) {
@@ -193,5 +194,4 @@ public class MultiLevelContainerValidation {
 			return String.valueOf( chars );
 		}
 	}
-
 }


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1278

There are multiple different tests added. I'd probably leave just `testMultiLevelPreGeneratedValidation` this one with "UnConstrained" version of it, so no additional time is spent on creating maps and lists for each iteration. What would you say ?

Also didn't use `@Email` as it's part of HV and there's a test profile for bVal. 