### PR TITLE
Backports for 5.2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Typically *NIX text editors, by default, append '~' to files on saving to make backups
 *~
 
+# Our build scripts - necessary for our release jobs
+hibernate-noorm-release-scripts
+
 # Gradle work directory
 .gradle
 buildSrc/.gradle

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ atlassian-ide-plugin.xml
 .project
 .settings
 .factorypath
+.checkstyle
 .externalToolBuilders
 maven-eclipse.xml
 

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -85,6 +85,7 @@
                 <exclude>**/zanata.sh</exclude>
                 <exclude>**/zanata.xml</exclude>
                 <exclude>src/main/scripts/**</exclude>
+                <exclude>hibernate-noorm-release-scripts/**</exclude>
 
                 <!-- actual files which should be ignored -->
                 <exclude>.git</exclude>

--- a/documentation/src/main/asciidoc/ch01.asciidoc
+++ b/documentation/src/main/asciidoc/ch01.asciidoc
@@ -104,6 +104,7 @@ The following shows how to do this via a http://docs.oracle.com/javase/8/docs/te
 grant codeBase "file:path/to/hibernate-validator-{hvVersion}.jar" {
     permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
     permission java.lang.RuntimePermission "accessDeclaredMembers";
+    permission java.lang.RuntimePermission "setContextClassLoader";
 
     // Only needed when working with XML descriptors (validation.xml or XML constraint mappings)
     permission java.util.PropertyPermission "mapAnyUriToUri", "read";
@@ -321,4 +322,3 @@ To learn more about the validation of beans and properties, just continue readin
 <<chapter-bean-constraints>>. If you are interested in using Bean Validation for the validation of
 method pre- and postcondition refer to <<chapter-method-constraints>>. In case your application has
 specific validation requirements have a look at <<validator-customconstraints>>.
-

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -166,20 +166,15 @@
                 <configuration>
                     <packageName>org.hibernate.validator.internal.xml</packageName>
                     <extension>true</extension>
-                    <schemaFiles>validation-configuration-1.1.xsd,validation-mapping-1.1.xsd</schemaFiles>
+                    <!-- Generate correct getters for Boolean properties -->
+                    <enableIntrospection>true</enableIntrospection>
+                    <!-- Makes sure the generated code is compatible with JAXB 2.1 which is what comes with Java 1.6 -->
+                    <target>2.1</target>
+                    <sources>
+                        <source>src/main/xsd/validation-configuration-1.1.xsd</source>
+                        <source>src/main/xsd/validation-mapping-1.1.xsd</source>
+                    </sources>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>javax.xml.bind</groupId>
-                        <artifactId>jaxb-api</artifactId>
-                        <version>2.2.5</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>com.sun.xml.bind</groupId>
-                        <artifactId>jaxb-impl</artifactId>
-                        <version>2.1.13</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/engine/src/main/java/org/hibernate/validator/internal/util/StringHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/StringHelper.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.util;
 
 import java.util.Arrays;
+import java.util.Locale;
 
 /**
  * Helper class dealing with strings.
@@ -81,7 +82,7 @@ public class StringHelper {
 			return string;
 		}
 		else {
-			return string.substring( 0, 1 ).toLowerCase() + string.substring( 1 );
+			return string.substring( 0, 1 ).toLowerCase( Locale.ROOT ) + string.substring( 1 );
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/util/TypeHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/TypeHelper.java
@@ -571,7 +571,10 @@ public final class TypeHelper {
 		Map<Type, Type> actualTypeArgumentsByParameter = new LinkedHashMap<Type, Type>();
 
 		for ( int i = 0; i < typeParameters.length; i++ ) {
-			actualTypeArgumentsByParameter.put( typeParameters[i], typeArguments[i] );
+			// we only add the mapping if it is not a cyclic dependency (see HV-1032)
+			if ( !typeParameters[i].equals( typeArguments[i] ) ) {
+				actualTypeArgumentsByParameter.put( typeParameters[i], typeArguments[i] );
+			}
 		}
 
 		return actualTypeArgumentsByParameter;

--- a/engine/src/main/java/org/hibernate/validator/internal/util/privilegedactions/SetContextClassLoader.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/privilegedactions/SetContextClassLoader.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.util.privilegedactions;
+
+import java.security.PrivilegedAction;
+
+import org.hibernate.validator.internal.util.Contracts;
+
+/**
+ * Privileged action used to set the Thread context class loader.
+ *
+ * @author Guillaume Smet
+ */
+public final class SetContextClassLoader implements PrivilegedAction<Void> {
+	private final ClassLoader classLoader;
+
+	public static SetContextClassLoader action(ClassLoader classLoader) {
+		Contracts.assertNotNull( classLoader, "class loader must not be null" );
+		return new SetContextClassLoader( classLoader );
+	}
+
+	private SetContextClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
+
+	@Override
+	public Void run() {
+		Thread.currentThread().setContextClassLoader( classLoader );
+		return null;
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ValidationXmlParser.java
@@ -9,6 +9,7 @@ package org.hibernate.validator.internal.xml;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -27,7 +28,9 @@ import javax.xml.validation.Schema;
 
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
+import org.hibernate.validator.internal.util.privilegedactions.GetClassLoader;
 import org.hibernate.validator.internal.util.privilegedactions.NewJaxbContext;
+import org.hibernate.validator.internal.util.privilegedactions.SetContextClassLoader;
 import org.hibernate.validator.internal.util.privilegedactions.Unmarshal;
 
 /**
@@ -69,7 +72,11 @@ public class ValidationXmlParser {
 			return BootstrapConfigurationImpl.getDefaultBootstrapConfiguration();
 		}
 
+		ClassLoader previousTccl = run( GetClassLoader.fromContext() );
+
 		try {
+			run( SetContextClassLoader.action( ValidationXmlParser.class.getClassLoader() ) );
+
 			// HV-970 The parser helper is only loaded if there actually is a validation.xml file;
 			// this avoids accessing javax.xml.stream.* (which does not exist on Android) when not actually
 			// working with the XML configuration
@@ -83,6 +90,7 @@ public class ValidationXmlParser {
 			return createBootstrapConfiguration( validationConfig );
 		}
 		finally {
+			run( SetContextClassLoader.action( previousTccl ) );
 			closeStream( inputStream );
 		}
 	}
@@ -189,6 +197,16 @@ public class ValidationXmlParser {
 		executableTypes.addAll( validatedExecutables.getExecutableType() );
 
 		return executableTypes;
+	}
+
+	/**
+	 * Runs the given privileged action, using a privileged block if required.
+	 * <p>
+	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
+	 * privileged actions within HV's protection domain.
+	 */
+	private static <T> T run(PrivilegedAction<T> action) {
+		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}
 
 	/**

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/ChildEntity.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/ChildEntity.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.util;
+
+/**
+ * @author Guillaume Smet
+ */
+public class ChildEntity<T> extends ParentEntity<T> {
+
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/ParentEntity.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/ParentEntity.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.util;
+
+/**
+ * @author Guillaume Smet
+ */
+public class ParentEntity<T> {
+
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/StringHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/StringHelperTest.java
@@ -7,7 +7,9 @@
 package org.hibernate.validator.test.internal.util;
 
 import java.util.Arrays;
+import java.util.Locale;
 
+import org.hibernate.validator.testutil.TestForIssue;
 import org.testng.annotations.Test;
 
 import org.hibernate.validator.internal.util.StringHelper;
@@ -85,6 +87,15 @@ public class StringHelperTest {
 	@Test
 	public void decapitalizeShouldReturnDecapizalizedWord() {
 		assertEquals( StringHelper.decapitalize( "Giraffe" ), "giraffe" );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1140")
+	public void decapitalizeShouldReturnDecapizalizedWordOnTurkishLocale() {
+		Locale defaultLocale = Locale.getDefault();
+		Locale.setDefault( new Locale( "tr" , "TR" ) );
+		assertEquals( StringHelper.decapitalize( "IsIsolationLevelGuaranteed" ), "isIsolationLevelGuaranteed" );
+		Locale.setDefault( defaultLocale );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.lang.reflect.GenericDeclaration;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Proxy;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -37,8 +38,8 @@ import javax.validation.ConstraintValidator;
 
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
 import org.hibernate.validator.internal.util.TypeHelper;
+import org.hibernate.validator.testutil.TestForIssue;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 import static org.testng.Assert.assertEquals;
@@ -864,6 +865,15 @@ public class TypeHelperTest {
 
 		assertEquals( validatorsTypes.get( Integer.class ), PositiveConstraintValidator.class );
 		assertNull( validatorsTypes.get( String.class ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1032")
+	public void testTypeHelperDoesntGoIntoInfiniteLoop() {
+		Type parentEntityType = ChildEntity.class.getGenericSuperclass();
+		ParameterizedType childEntityType = TypeHelper.parameterizedType( ChildEntity.class, ChildEntity.class.getTypeParameters() );
+
+		assertTrue( TypeHelper.isAssignable( parentEntityType, childEntityType ) );
 	}
 
 	private static void assertAsymmetricallyAssignable(Type supertype, Type type) {

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/xml/Camera.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/xml/Camera.java
@@ -1,0 +1,15 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.integration.wildfly.xml;
+
+/**
+ * @author Gunnar Morling
+ */
+public class Camera {
+
+	public String brand = null;
+}

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/xml/JaxpContainedInDeploymentIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/xml/JaxpContainedInDeploymentIT.java
@@ -1,0 +1,142 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.integration.wildfly.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.validationConfiguration11.ValidationConfigurationDescriptor;
+import org.jboss.shrinkwrap.descriptor.api.validationMapping11.ValidationMappingDescriptor;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test for https://hibernate.atlassian.net/browse/HV-1280. To reproduce the issue, the deployment must be done twice
+ * (it will only show up during the 2nd deploy), which is why the test is managing the deployment itself via client-side
+ * test methods.
+ *
+ * @author Gunnar Morling
+ */
+@RunWith(Arquillian.class)
+public class JaxpContainedInDeploymentIT {
+
+	private static final String WAR_FILE_NAME = JaxpContainedInDeploymentIT.class.getSimpleName() + ".war";
+
+	@ArquillianResource
+	private Deployer deployer;
+
+	@Inject
+	private Validator validator;
+
+	@Deployment(name = "jaxpit", managed = false)
+	public static Archive<?> createTestArchive() {
+		return ShrinkWrap
+				.create( WebArchive.class, WAR_FILE_NAME )
+				.addClass( Camera.class )
+				.addAsResource( validationXml(), "META-INF/validation.xml" )
+				.addAsResource( mappingXml(), "META-INF/my-mapping.xml" )
+				.addAsLibrary( Maven.resolver().resolve( "xerces:xercesImpl:2.9.1" ).withoutTransitivity().asSingleFile() )
+				.addAsResource( "log4j.properties" )
+				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" );
+	}
+
+	private static Asset validationXml() {
+		String validationXml = Descriptors.create( ValidationConfigurationDescriptor.class )
+				.version( "1.1" )
+				.constraintMapping( "META-INF/my-mapping.xml" )
+				.exportAsString();
+		return new StringAsset( validationXml );
+	}
+
+	private static Asset mappingXml() {
+		String mappingXml = Descriptors.create( ValidationMappingDescriptor.class )
+				.version( "1.1" )
+				.createBean()
+					.clazz( Camera.class.getName() )
+						.createField()
+							.name( "brand" )
+							.createConstraint()
+								.annotation( "javax.validation.constraints.NotNull" )
+						.up()
+					.up()
+				.up()
+				.exportAsString();
+		return new StringAsset( mappingXml );
+	}
+
+	@Test
+	@RunAsClient
+	@InSequence(0)
+	public void deploy1() throws Exception {
+		deployer.deploy( "jaxpit" );
+	}
+
+	@Test
+	@InSequence(1)
+	public void test1() throws Exception {
+		doTest();
+	}
+
+	@Test
+	@RunAsClient
+	@InSequence(2)
+	public void undeploy1() throws Exception {
+		deployer.undeploy( "jaxpit" );
+	}
+
+	@Test
+	@RunAsClient
+	@InSequence(3)
+	public void deploy2() throws Exception {
+		deployer.deploy( "jaxpit" );
+	}
+
+	@Test
+	@InSequence(4)
+	public void test2() throws Exception {
+		doTest();
+	}
+
+	@Test
+	@RunAsClient
+	@InSequence(5)
+	public void undeploy2() throws Exception {
+		deployer.undeploy( "jaxpit" );
+	}
+
+	private void doTest() {
+		Set<ConstraintViolation<Camera>> violations = validator.validate( new Camera() );
+
+		assertEquals( 1, violations.size() );
+		assertSame( NotNull.class, violations.iterator()
+				.next()
+				.getConstraintDescriptor()
+				.getAnnotation()
+				.annotationType() );
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -502,7 +502,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>jaxb2-maven-plugin</artifactId>
-                    <version>1.3.1</version>
+                    <version>2.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jboss.maven.plugins</groupId>

--- a/settings-example.xml
+++ b/settings-example.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/settings/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <profiles>
+        <profile>
+            <id>jboss-public-repository</id>
+            <repositories>
+                <!-- Use Central first -->
+                <repository>
+                    <id>central</id>
+                    <name>Maven Central</name>
+                    <url>http://repo.maven.apache.org/maven2/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </repository>
+                <repository>
+                    <id>jboss-public-repository-group</id>
+                    <name>JBoss Public Maven Repository Group</name>
+                    <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
+                <!-- Use Central first -->
+                <pluginRepository>
+                    <id>central</id>
+                    <name>Maven Central</name>
+                    <url>http://repo.maven.apache.org/maven2/</url>
+                    <snapshots>
+                        <enabled>false</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </pluginRepository>
+                <pluginRepository>
+                    <id>jboss-public-repository-group</id>
+                    <name>JBoss Public Maven Repository Group</name>
+                    <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+                    <layout>default</layout>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>never</updatePolicy>
+                    </snapshots>
+                </pluginRepository>
+            </pluginRepositories>
+        </profile>
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>jboss-public-repository</activeProfile>
+    </activeProfiles>
+
+</settings>

--- a/tck-runner/src/test/resources/test.policy
+++ b/tck-runner/src/test/resources/test.policy
@@ -26,6 +26,7 @@
 grant codeBase "file:${localRepository}/org/hibernate/hibernate-validator/${project.version}/hibernate-validator-${project.version}.jar" {
     permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
     permission java.lang.RuntimePermission "accessDeclaredMembers";
+    permission java.lang.RuntimePermission "setContextClassLoader";
 
     // JAXB
     permission java.util.PropertyPermission "mapAnyUriToUri", "read";
@@ -36,6 +37,7 @@ grant codeBase "file:${localRepository}/org/hibernate/hibernate-validator/${proj
 grant codeBase "file:${basedir}/../engine/target/hibernate-validator-${project.version}.jar" {
     permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
     permission java.lang.RuntimePermission "accessDeclaredMembers";
+    permission java.lang.RuntimePermission "setContextClassLoader";
 
     // JAXB
     permission java.util.PropertyPermission "mapAnyUriToUri", "read";

--- a/tck-runner/src/test/resources/test.policy
+++ b/tck-runner/src/test/resources/test.policy
@@ -55,6 +55,10 @@ grant codeBase "file:${localRepository}/org/jboss/logging/jboss-logging/-" {
 
 grant codeBase "file:${localRepository}/javax/validation/validation-api/-" {
     permission java.io.FilePermission "<<ALL FILES>>", "read";
+
+    // in some tests this property is accessed by the TCK when the API JAR is on the callstack; the TCK doesn't
+    // use privileged actions, hence allow this read
+    permission java.util.PropertyPermission "validation.provider", "read";
 };
 
 /* =================== */


### PR DESCRIPTION
@gunnarmorling so here is the backport proposal for 5.2

I took the liberty to include HV-1140 as it really is a bugfix and I don't see how it could lead to a regression. If you feel strongly against it, I'll remove it.

I squashed HV-1280 to have only one commit for product review (I couldn't do it in 5.3 or 5.4 as I had already pushed the first commit).

I'll do the related work on JIRA once we agree on this.