### PR TITLE
HV-1291 Support container element type constraints definition via XML

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/CascadableConstraintMappingContextImplBase.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/CascadableConstraintMappingContextImplBase.java
@@ -115,7 +115,7 @@ abstract class CascadableConstraintMappingContextImplBase<C extends Cascadable<C
 		ContainerElementPathKey key = new ContainerElementPathKey( index, nestedIndexes );
 		boolean configuredBefore = !configuredPaths.add( key );
 		if ( configuredBefore ) {
-			throw LOG.getContainerElementHasAlreadyBeConfiguredViaProgrammaticApiException(
+			throw LOG.getContainerElementTypeHasAlreadyBeenConfiguredViaProgrammaticApiException(
 				location.getTypeForValidatorResolution()
 			);
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -737,8 +737,8 @@ public interface Log extends BasicLogger {
 	@Message(id = 213, value = "Given type has more than one type argument, hence an argument index must be specified: %s.")
 	ValidationException getNoTypeArgumentIndexIsGivenForTypeWithMultipleTypeArgumentsException(@FormatWith(TypeFormatter.class) Type type);
 
-	@Message(id = 214, value = "The same type argument of type %1$s is configured more than once via the programmatic constraint declaration API.")
-	ValidationException getContainerElementHasAlreadyBeConfiguredViaProgrammaticApiException(@FormatWith(TypeFormatter.class) Type type);
+	@Message(id = 214, value = "The same container element type of type %1$s is configured more than once via the programmatic constraint declaration API.")
+	ValidationException getContainerElementTypeHasAlreadyBeenConfiguredViaProgrammaticApiException(@FormatWith(TypeFormatter.class) Type type);
 
 	@Message(id = 215, value = "Calling parameter() is not allowed for the current element.")
 	ValidationException getParameterIsNotAValidCallException();

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -43,11 +43,13 @@ import javax.xml.stream.XMLStreamException;
 
 import org.hibernate.validator.internal.engine.messageinterpolation.parser.MessageDescriptorFormatException;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl.ConstraintType;
+import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.util.logging.formatter.ClassObjectFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.CollectionOfClassesObjectFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.CollectionOfObjectsToStringFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.ExecutableFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.TypeFormatter;
+import org.hibernate.validator.internal.xml.ContainerElementTypePath;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.FormatWith;
@@ -743,4 +745,8 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 216, value = "Calling returnValue() is not allowed for the current element.")
 	ValidationException getReturnValueIsNotAValidCallException();
+
+	@Message(id = 217, value = "The same container element type %2$s is configured more than once for location %1$s via the XML mapping configuration.")
+	ValidationException getContainerElementTypeHasAlreadyBeenConfiguredViaXmlMappingConfigurationException(ConstraintLocation rootConstraintLocation,
+			ContainerElementTypePath path);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ContainerElementTypeConfigurationBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ContainerElementTypeConfigurationBuilder.java
@@ -1,0 +1,169 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.xml;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.hibernate.validator.internal.engine.cascading.ArrayElement;
+import org.hibernate.validator.internal.metadata.cascading.CascadingTypeParameter;
+import org.hibernate.validator.internal.metadata.core.MetaConstraint;
+import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
+import org.hibernate.validator.internal.util.ReflectionHelper;
+import org.hibernate.validator.internal.util.TypeHelper;
+import org.hibernate.validator.internal.util.logging.Log;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
+import org.hibernate.validator.internal.xml.binding.ConstraintType;
+import org.hibernate.validator.internal.xml.binding.ContainerElementTypeType;
+
+/**
+ * Builds the cascading and type argument constraints configuration from the {@link ContainerElementType} elements.
+ *
+ * @author Guillaume Smet
+ */
+class ContainerElementTypeConfigurationBuilder {
+
+	private static final Log LOG = LoggerFactory.make();
+
+	private final ConstraintLocation rootConstraintLocation;
+
+	private final MetaConstraintBuilder metaConstraintBuilder;
+
+	private final String defaultPackage;
+
+	private final Set<ContainerElementTypePath> configuredPaths = new HashSet<>();
+
+	ContainerElementTypeConfigurationBuilder(MetaConstraintBuilder metaConstraintBuilder, ConstraintLocation rootConstraintLocation, String defaultPackage) {
+		this.metaConstraintBuilder = metaConstraintBuilder;
+		this.rootConstraintLocation = rootConstraintLocation;
+		this.defaultPackage = defaultPackage;
+	}
+
+	ContainerElementTypeConfiguration build(List<ContainerElementTypeType> xmlContainerElementTypes, Type enclosingType) {
+		return add( ContainerElementTypePath.root(), xmlContainerElementTypes, rootConstraintLocation, enclosingType );
+	}
+
+	private ContainerElementTypeConfiguration add(ContainerElementTypePath parentConstraintElementTypePath, List<ContainerElementTypeType> xmlContainerElementTypes,
+			ConstraintLocation parentConstraintLocation, Type enclosingType) {
+		if ( xmlContainerElementTypes.isEmpty() ) {
+			return new ContainerElementTypeConfiguration( Collections.emptySet(), Collections.emptyList() );
+		}
+
+		if ( !( enclosingType instanceof ParameterizedType ) && !TypeHelper.isArray( enclosingType ) ) {
+			throw LOG.getTypeIsNotAParameterizedNorArrayTypeException( enclosingType );
+		}
+
+		Set<MetaConstraint<?>> metaConstraints = new HashSet<>();
+		List<CascadingTypeParameter> cascadingTypeParameters = new ArrayList<>();
+
+		boolean isArray = TypeHelper.isArray( enclosingType );
+		TypeVariable<?>[] typeParameters = isArray ? new TypeVariable[0] : ReflectionHelper.getClassFromType( enclosingType ).getTypeParameters();
+
+		for ( ContainerElementTypeType xmlContainerElementType : xmlContainerElementTypes ) {
+			Integer typeArgumentIndex = getTypeArgumentIndex( xmlContainerElementType, typeParameters, isArray, enclosingType );
+
+			ContainerElementTypePath constraintElementTypePath = ContainerElementTypePath.of( parentConstraintElementTypePath, typeArgumentIndex );
+			boolean configuredBefore = !configuredPaths.add( constraintElementTypePath );
+			if ( configuredBefore ) {
+				throw LOG.getContainerElementTypeHasAlreadyBeenConfiguredViaXmlMappingConfigurationException( rootConstraintLocation, constraintElementTypePath );
+			}
+
+			TypeVariable<?> typeParameter = getTypeParameter( typeParameters, typeArgumentIndex, isArray, enclosingType );
+			Type containerElementType = getContainerElementType( enclosingType, typeArgumentIndex, isArray );
+			ConstraintLocation containerElementTypeConstraintLocation = ConstraintLocation.forTypeArgument( parentConstraintLocation, typeParameter,
+					containerElementType );
+
+			for ( ConstraintType constraint : xmlContainerElementType.getConstraint() ) {
+				MetaConstraint<?> metaConstraint = metaConstraintBuilder.buildMetaConstraint(
+						containerElementTypeConstraintLocation,
+						constraint,
+						java.lang.annotation.ElementType.TYPE_USE,
+						defaultPackage,
+						null
+				);
+				metaConstraints.add( metaConstraint );
+			}
+
+			ContainerElementTypeConfiguration nestedContainerElementTypeConfiguration = add( constraintElementTypePath, xmlContainerElementType.getContainerElementType(),
+					containerElementTypeConstraintLocation, containerElementType );
+
+			metaConstraints.addAll( nestedContainerElementTypeConfiguration.getMetaConstraints() );
+			cascadingTypeParameters.add( new CascadingTypeParameter( enclosingType, typeParameter, xmlContainerElementType.getValid() != null,
+					nestedContainerElementTypeConfiguration.getCascadingTypeParameters() ) );
+		}
+
+		return new ContainerElementTypeConfiguration( metaConstraints, cascadingTypeParameters );
+	}
+
+	private Integer getTypeArgumentIndex(ContainerElementTypeType xmlContainerElementType, TypeVariable<?>[] typeParameters, boolean isArray, Type enclosingType) {
+		if ( isArray ) {
+			return null;
+		}
+
+		Integer typeArgumentIndex = xmlContainerElementType.getTypeArgumentIndex();
+		if ( typeArgumentIndex == null ) {
+			if ( typeParameters.length > 1 ) {
+				throw LOG.getNoTypeArgumentIndexIsGivenForTypeWithMultipleTypeArgumentsException( enclosingType );
+			}
+			typeArgumentIndex = 0;
+		}
+
+		return typeArgumentIndex;
+	}
+
+	private TypeVariable<?> getTypeParameter(TypeVariable<?>[] typeParameters, Integer typeArgumentIndex, boolean isArray, Type enclosingType) {
+		TypeVariable<?> typeParameter;
+		if ( !isArray ) {
+			if ( typeArgumentIndex > typeParameters.length - 1 ) {
+				throw LOG.getInvalidTypeArgumentIndexException( enclosingType, typeArgumentIndex );
+			}
+
+			typeParameter = typeParameters[typeArgumentIndex];
+		}
+		else {
+			typeParameter = new ArrayElement( enclosingType );
+		}
+		return typeParameter;
+	}
+
+	private Type getContainerElementType(Type enclosingType, Integer typeArgumentIndex, boolean isArray) {
+		Type containerElementType;
+		if ( !isArray ) {
+			containerElementType = ( (ParameterizedType) enclosingType ).getActualTypeArguments()[typeArgumentIndex];
+		}
+		else {
+			containerElementType = TypeHelper.getComponentType( enclosingType );
+		}
+		return containerElementType;
+	}
+
+	class ContainerElementTypeConfiguration {
+
+		private final Set<MetaConstraint<?>> metaConstraints;
+
+		private final List<CascadingTypeParameter> cascadingTypeParameters;
+
+		private ContainerElementTypeConfiguration(Set<MetaConstraint<?>> metaConstraints, List<CascadingTypeParameter> cascadingTypeParameters) {
+			this.metaConstraints = metaConstraints;
+			this.cascadingTypeParameters = cascadingTypeParameters;
+		}
+
+		public Set<MetaConstraint<?>> getMetaConstraints() {
+			return metaConstraints;
+		}
+
+		public List<CascadingTypeParameter> getCascadingTypeParameters() {
+			return cascadingTypeParameters;
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/ContainerElementTypePath.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/ContainerElementTypePath.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.validator.internal.util.StringHelper;
+
+/**
+ * The path to a container element type.
+ *
+ * @author Guillaume Smet
+ */
+public class ContainerElementTypePath {
+
+	private final List<Integer> nodes;
+
+	private ContainerElementTypePath(List<Integer> nodes) {
+		this.nodes = nodes;
+	}
+
+	public static ContainerElementTypePath root() {
+		return new ContainerElementTypePath( new ArrayList<>() );
+	}
+
+	public static ContainerElementTypePath of(ContainerElementTypePath parentPath, Integer typeArgumentIndex) {
+		List<Integer> nodes = new ArrayList<>( parentPath.nodes );
+		nodes.add( typeArgumentIndex );
+
+		return new ContainerElementTypePath( nodes );
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if ( this == obj ) {
+			return true;
+		}
+		if ( obj == null ) {
+			return false;
+		}
+		if ( getClass() != obj.getClass() ) {
+			return false;
+		}
+		ContainerElementTypePath other = (ContainerElementTypePath) obj;
+		if ( !this.nodes.equals( other.nodes ) ) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		return nodes.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		sb.append( "[" ).append( StringHelper.join( nodes, ", " ) ).append( "]" );
+		return sb.toString();
+	}
+}

--- a/engine/src/main/xsd/validation-mapping-2.0.xsd
+++ b/engine/src/main/xsd/validation-mapping-2.0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Hibernate Validator, declare and validate application constraints
+  ~ Bean Validation API
   ~
   ~ License: Apache License, Version 2.0
   ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
@@ -109,6 +109,26 @@
         </xs:sequence>
         <xs:attribute type="xs:string" name="name" use="required"/>
     </xs:complexType>
+    <xs:complexType name="containerElementTypeType">
+        <xs:sequence>
+            <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
+            <xs:element type="map:constraintType"
+                        name="constraint"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="containerElementType"
+                        maxOccurs="unbounded"
+                        minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="typeArgumentIndex" use="optional">
+            <xs:simpleType>
+                <xs:restriction base="xs:int">
+                    <xs:minInclusive value="0" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
     <xs:complexType name="classType">
         <xs:sequence>
             <xs:element type="map:groupSequenceType"
@@ -162,6 +182,10 @@
                         name="convert-group"
                         minOccurs="0"
                         maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="containerElementType"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
             <xs:element type="map:constraintType"
                         name="constraint"
                         minOccurs="0"
@@ -212,6 +236,10 @@
                         name="convert-group"
                         minOccurs="0"
                         maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="containerElementType"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
             <xs:element type="map:constraintType"
                         name="constraint"
                         minOccurs="0"
@@ -225,6 +253,10 @@
             <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
             <xs:element type="map:groupConversionType"
                         name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="containerElementType"
                         minOccurs="0"
                         maxOccurs="unbounded"/>
             <xs:element type="map:constraintType"
@@ -255,6 +287,10 @@
             <xs:element type="xs:string" name="valid" minOccurs="0" fixed=""/>
             <xs:element type="map:groupConversionType"
                         name="convert-group"
+                        minOccurs="0"
+                        maxOccurs="unbounded"/>
+            <xs:element type="map:containerElementTypeType"
+                        name="containerElementType"
                         minOccurs="0"
                         maxOccurs="unbounded"/>
             <xs:element type="map:constraintType"

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/containerelementtype/ContainerElementTypeConstraintsForFieldXmlMappingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/containerelementtype/ContainerElementTypeConstraintsForFieldXmlMappingTest.java
@@ -1,0 +1,206 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+package org.hibernate.validator.test.internal.xml.containerelementtype;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.validation.Configuration;
+import javax.validation.ConstraintViolation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+
+import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ValidatorUtil;
+import org.testng.annotations.Test;
+
+/**
+ * @author Gunnar Morling
+ * @author Guillaume Smet
+ */
+public class ContainerElementTypeConstraintsForFieldXmlMappingTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForFieldWithXmlMapping() {
+		Validator validator = getValidator( "field-canDeclareContainerElementTypeConstraints-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"size must be between 0 and 5",
+				"size must be between 3 and 10",
+				"size must be between 3 and 10",
+				"must be greater than or equal to 1",
+				"must be greater than or equal to 1"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareNestedContainerElementTypeConstraintsForFieldWithXmlMapping() {
+		Validator validator = getValidator( "field-canDeclareNestedContainerElementTypeConstraints-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"may not be null"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareDeeplyNestedContainerElementTypeConstraintsForFieldWithXmlMapping() {
+		Validator validator = getValidator( "field-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"may not be null"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementCascadesForFieldWithXmlMapping() {
+		Validator validator = getValidator( "field-canDeclareContainerElementCascades-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"may not be null"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForArrayTypeFieldWithXmlMapping() {
+		Validator validator = getValidator( "field-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"size must be between 0 and 5"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForListContainingArrayTypeFieldWithXmlMapping() {
+		Validator validator = getValidator( "field-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"size must be between 0 and 5"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayTypeFieldWithXmlMapping() {
+		Validator validator = getValidator( "field-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"size must be between 0 and 5"
+		);
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000211.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintOnNonGenericFieldCausesException() {
+		getValidator( "field-declaringContainerElementTypeConstraintOnNonGenericFieldCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000212.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException() {
+		getValidator( "field-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000212.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException() {
+		getValidator( "field-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000213.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException() {
+		getValidator( "field-omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000217.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void configuringSameContainerElementTwiceCausesException() {
+		getValidator( "field-configuringSameContainerElementTwiceCausesException-mapping.xml" );
+	}
+
+	private Validator getValidator(String mappingFile) {
+		Configuration<?> config = ValidatorUtil.getConfiguration();
+		config.addMapping( ContainerElementTypeConstraintsForFieldXmlMappingTest.class.getResourceAsStream( mappingFile ) );
+		return config.buildValidatorFactory().getValidator();
+	}
+
+	public static class FishTank {
+
+		public Optional<String> model = Optional.of( "Too long" );
+		public Optional<Fish> boss = Optional.of( new Fish() );
+		public Map<String, Integer> fishCountByType;
+		public Map<String, List<Fish>> fishOfTheMonth;
+		public List<Map<String, Set<String>>> tagsOfFishOfTheMonth;
+		public String[] fishNames = new String[] { "Too Long" };
+		public List<String[]> fishNamesByMonth;
+		public String[][] fishNamesByMonthAsArray = new String[][]{ new String[] { "Too Long" } };
+		public int size = 0;
+
+		public FishTank() {
+			fishCountByType = new HashMap<>();
+			fishCountByType.put( "A", -1 );
+			fishCountByType.put( "BB", -2 );
+
+			fishOfTheMonth = new HashMap<>();
+			List<Fish> january = Arrays.asList( null, new Fish() );
+			fishOfTheMonth.put( "january", january );
+
+			Set<String> bobsTags = CollectionHelper.asSet( (String) null );
+			Map<String, Set<String>> januaryTags = new HashMap<>();
+			januaryTags.put( "bob", bobsTags );
+			tagsOfFishOfTheMonth = new ArrayList<>();
+			tagsOfFishOfTheMonth.add( januaryTags );
+
+			fishNamesByMonth = new ArrayList<>();
+			fishNamesByMonth.add(  new String[] { "Too Long" } );
+		}
+	}
+
+	public static class Fish {
+
+		public Fish() {
+		}
+
+		public String name;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/containerelementtype/ContainerElementTypeConstraintsForGetterXmlMappingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/containerelementtype/ContainerElementTypeConstraintsForGetterXmlMappingTest.java
@@ -1,0 +1,230 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+package org.hibernate.validator.test.internal.xml.containerelementtype;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.validation.Configuration;
+import javax.validation.ConstraintViolation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+
+import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ValidatorUtil;
+import org.testng.annotations.Test;
+
+public class ContainerElementTypeConstraintsForGetterXmlMappingTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForGetterProgrammatically() {
+		Validator validator = getValidator( "getter-canDeclareContainerElementTypeConstraints-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"size must be between 0 and 5",
+				"size must be between 3 and 10",
+				"size must be between 3 and 10",
+				"must be greater than or equal to 1",
+				"must be greater than or equal to 1"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareNestedContainerElementTypeConstraintsForGetterProgrammatically() {
+		Validator validator = getValidator( "getter-canDeclareNestedContainerElementTypeConstraints-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"may not be null"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareDeeplyNestedContainerElementTypeConstraintsForGetterProgrammatically() {
+		Validator validator = getValidator( "getter-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"may not be null"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementCascadesForGetterProgrammatically() {
+		Validator validator = getValidator( "getter-canDeclareContainerElementCascades-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"may not be null"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForArrayTypeGetterProgrammatically() {
+		Validator validator = getValidator( "getter-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"size must be between 0 and 5"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForListContainingArrayTypeGetterProgrammatically() {
+		Validator validator = getValidator( "getter-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"size must be between 0 and 5"
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayTypeGetterProgrammatically() {
+		Validator validator = getValidator( "getter-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml" );
+
+		Set<ConstraintViolation<FishTank>> violations = validator.validate( new FishTank() );
+
+		assertCorrectConstraintViolationMessages(
+				violations,
+				"size must be between 0 and 5"
+		);
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000211.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintOnNonGenericFieldCausesException() {
+		getValidator( "getter-declaringContainerElementTypeConstraintOnNonGenericFieldCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000212.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException() {
+		getValidator( "getter-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000212.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException() {
+		getValidator( "getter-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000213.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException() {
+		getValidator( "getter-omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000217.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void configuringSameContainerElementTwiceCausesException() {
+		getValidator( "getter-configuringSameContainerElementTwiceCausesException-mapping.xml" );
+	}
+
+	private Validator getValidator(String mappingFile) {
+		Configuration<?> config = ValidatorUtil.getConfiguration();
+		config.addMapping( ContainerElementTypeConstraintsForFieldXmlMappingTest.class.getResourceAsStream( mappingFile ) );
+		return config.buildValidatorFactory().getValidator();
+	}
+
+	public static class FishTank {
+
+		public Optional<String> getModel() {
+			return Optional.of( "Too long" );
+		}
+
+		public Optional<Fish> getBoss() {
+			return Optional.of( new Fish() );
+		}
+
+		public Map<String, Integer> getFishCountByType() {
+			Map<String, Integer> fishCount = new HashMap<>();
+			fishCount.put( "A", -1 );
+			fishCount.put( "BB", -2 );
+			return fishCount;
+		}
+
+		public Map<String, List<Fish>> getFishOfTheMonth() {
+			Map<String, List<Fish>> fishOfTheMonth = new HashMap<>();
+
+			List<Fish> january = Arrays.asList( null, new Fish() );
+			fishOfTheMonth.put( "january", january );
+
+			return fishOfTheMonth;
+		}
+
+		public List<Map<String, Set<String>>> getTagsOfFishOfTheMonth() {
+			Set<String> bobsTags = CollectionHelper.asSet( (String) null );
+
+			Map<String, Set<String>> january = new HashMap<>();
+			january.put( "bob", bobsTags );
+
+			List<Map<String, Set<String>>> tagsOfFishOfTheMonth = new ArrayList<>();
+			tagsOfFishOfTheMonth.add( january );
+
+			return tagsOfFishOfTheMonth;
+		}
+
+		public String[] getFishNames() {
+			return new String[] { "Too Long" };
+		}
+
+		public List<String[]> getFishNamesByMonth() {
+			List<String[]> names = new ArrayList<>();
+			names.add(  new String[] { "Too Long" } );
+			return names;
+		}
+
+		public String[][] getFishNamesByMonthAsArray() {
+			String[][] names = new String[][]{ new String[] { "Too Long" } };
+			return names;
+		}
+
+		public int getSize() {
+			return 0;
+		}
+	}
+
+	public static class Fish {
+
+		public Fish() {
+		}
+
+		public String getName() {
+			return null;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/containerelementtype/ContainerElementTypeConstraintsForParameterXmlMappingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/containerelementtype/ContainerElementTypeConstraintsForParameterXmlMappingTest.java
@@ -1,0 +1,321 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+package org.hibernate.validator.test.internal.xml.containerelementtype;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.validation.Configuration;
+import javax.validation.ConstraintViolationException;
+import javax.validation.UnexpectedTypeException;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+
+import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ValidatorUtil;
+import org.testng.annotations.Test;
+
+/**
+ * @author Gunnar Morling
+ * @author Guillaume Smet
+ */
+public class ContainerElementTypeConstraintsForParameterXmlMappingTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForParameterProgrammatically() {
+		Validator validator = getValidator( "parameter-canDeclareContainerElementTypeConstraints-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			HashMap<String, Integer> fishCountByType = new HashMap<>();
+			fishCountByType.put( "A", -1 );
+			fishCountByType.put( "BB", -2 );
+
+			fishTank.test1( Optional.of( "Too long" ), fishCountByType );
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+					e.getConstraintViolations(),
+					"size must be between 0 and 5",
+					"size must be between 3 and 10",
+					"size must be between 3 and 10",
+					"must be greater than or equal to 1",
+					"must be greater than or equal to 1"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareNestedContainerElementTypeConstraintsForParameterProgrammatically() {
+		Validator validator = getValidator( "parameter-canDeclareNestedContainerElementTypeConstraints-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			Map<String, List<Fish>> fishOfTheMonth = new HashMap<>();
+			List<Fish> january = Arrays.asList( null, new Fish() );
+			fishOfTheMonth.put( "january", january );
+
+			fishTank.test2( fishOfTheMonth );
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+					e.getConstraintViolations(),
+					"may not be null"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareDeeplyNestedContainerElementTypeConstraintsForParameterProgrammatically() {
+		Validator validator = getValidator( "parameter-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			Set<String> bobsTags = CollectionHelper.asSet( (String) null );
+			Map<String, Set<String>> januaryTags = new HashMap<>();
+			januaryTags.put( "bob", bobsTags );
+			List<Map<String, Set<String>>> tagsOfFishOfTheMonth = new ArrayList<>();
+			tagsOfFishOfTheMonth.add( januaryTags );
+
+			fishTank.test3( tagsOfFishOfTheMonth );
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+				e.getConstraintViolations(),
+				"may not be null"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementCascadesForParameterProgrammatically() {
+		Validator validator = getValidator( "parameter-canDeclareContainerElementCascades-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			fishTank.test4( Optional.of( new Fish() ) );
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+				e.getConstraintViolations(),
+				"may not be null"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForArrayTypeParameterProgrammatically() {
+		Validator validator = getValidator( "parameter-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			fishTank.test5( new String[] { "Too Long" } );
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+				e.getConstraintViolations(),
+				"size must be between 0 and 5"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForListContainingArrayTypeParameterProgrammatically() {
+		Validator validator = getValidator( "parameter-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			List<String[]> fishNamesByMonth = new ArrayList<>();
+			fishNamesByMonth.add(  new String[] { "Too Long" } );
+
+			fishTank.test6( fishNamesByMonth );
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+				e.getConstraintViolations(),
+				"size must be between 0 and 5"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayTypeParameterProgrammatically() {
+		Validator validator = getValidator( "parameter-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			String[][] fishNamesByMonthAsArray = new String[][]{ new String[] { "Too Long" } };
+
+			fishTank.test7( fishNamesByMonthAsArray );
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+				e.getConstraintViolations(),
+				"size must be between 0 and 5"
+			);
+		}
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000211.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintOnNonGenericParameterCausesException() {
+		getValidator( "parameter-declaringContainerElementTypeConstraintOnNonGenericParameterCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000212.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnParameterCausesException() {
+		getValidator( "parameter-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnParameterCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000212.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnParameterCausesException() {
+		getValidator( "parameter-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnParameterCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000213.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void omittingTypeArgumentForMultiTypeArgumentTypeOnParameterCausesException() {
+		getValidator( "parameter-omittingTypeArgumentForMultiTypeArgumentTypeOnParameterCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = UnexpectedTypeException.class, expectedExceptionsMessageRegExp = "HV000030:.*")
+	@TestForIssue(jiraKey = "HV-1279")
+	public void configuringConstraintsOnGenericTypeArgumentOfListThrowsException() {
+		Validator validator = getValidator( "parameter-configuringConstraintsOnGenericTypeArgumentOfListThrowsException-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+		fishTank.test8( Arrays.asList( "Too long" ) );
+	}
+
+	@Test(expectedExceptions = UnexpectedTypeException.class, expectedExceptionsMessageRegExp = "HV000030:.*")
+	@TestForIssue(jiraKey = "HV-1279")
+	public void configuringConstraintsOnGenericTypeArgumentOfArrayThrowsException() {
+		Validator validator = getValidator( "parameter-configuringConstraintsOnGenericTypeArgumentOfArrayThrowsException-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+		fishTank.test9( new String[]{ "Too long" } );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000217.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void configuringSameContainerElementTwiceCausesException() {
+		getValidator( "parameter-configuringSameContainerElementTwiceCausesException-mapping.xml" );
+	}
+
+	private Validator getValidator(String mappingFile) {
+		Configuration<?> config = ValidatorUtil.getConfiguration();
+		config.addMapping( ContainerElementTypeConstraintsForFieldXmlMappingTest.class.getResourceAsStream( mappingFile ) );
+		return config.buildValidatorFactory().getValidator();
+	}
+
+	public interface IFishTank {
+		void test1(Optional<String> model, Map<String, Integer> fishCountByType);
+		void test2(Map<String, List<Fish>> fishOfTheMonth);
+		void test3(List<Map<String, Set<String>>> tagsOfFishOfTheMonth);
+		void test4(Optional<Fish> boss);
+		void test5(String[] fishNames);
+		void test6(List<String[]> fishNamesByMonth);
+		void test7(String[][] fishNamesByMonthAsArray);
+		void setSize(int size);
+		<T> void test8(List<T> fishNames);
+		<T> void test9(T[] fishNames);
+	}
+
+	public static class FishTank implements IFishTank {
+
+		@Override
+		public void test1(Optional<String> model, Map<String, Integer> fishCountByType) {
+		}
+
+		@Override
+		public void test2(Map<String, List<Fish>> fishOfTheMonth) {
+		}
+
+		@Override
+		public void test3(List<Map<String, Set<String>>> tagsOfFishOfTheMonth) {
+		}
+
+		@Override
+		public void test4(Optional<Fish> boss) {
+		}
+
+		@Override
+		public void test5(String[] fishNames) {
+		}
+
+		@Override
+		public void test6(List<String[]> fishNamesByMonth) {
+		}
+
+		@Override
+		public void test7(String[][] fishNamesByMonthAsArray) {
+		}
+
+		@Override
+		public <T> void test8(List<T> fishNames) {
+		}
+
+		@Override
+		public <T> void test9(T[] fishNames) {
+		}
+
+		@Override
+		public void setSize(int size) {
+		}
+
+		public FishTank() {
+		}
+	}
+
+	public static class Fish {
+
+		public Fish() {
+		}
+
+		public String name;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/containerelementtype/ContainerElementTypeConstraintsForReturnValueXmlMappingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/containerelementtype/ContainerElementTypeConstraintsForReturnValueXmlMappingTest.java
@@ -1,0 +1,327 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+package org.hibernate.validator.test.internal.xml.containerelementtype;
+
+import static org.assertj.core.api.Assertions.fail;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectConstraintViolationMessages;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.validation.Configuration;
+import javax.validation.ConstraintViolationException;
+import javax.validation.UnexpectedTypeException;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+
+import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ValidatorUtil;
+import org.testng.annotations.Test;
+
+/**
+ * @author Gunnar Morling
+ * @author Guillaume Smet
+ */
+public class ContainerElementTypeConstraintsForReturnValueXmlMappingTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForReturnValueProgrammatically() {
+		Validator validator = getValidator( "returnvalue-canDeclareContainerElementTypeConstraints-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			fishTank.test1();
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+					e.getConstraintViolations(),
+					"size must be between 3 and 10",
+					"size must be between 3 and 10",
+					"must be greater than or equal to 1",
+					"must be greater than or equal to 1"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareNestedContainerElementTypeConstraintsForReturnValueProgrammatically() {
+		Validator validator = getValidator( "returnvalue-canDeclareNestedContainerElementTypeConstraints-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			fishTank.test2();
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+					e.getConstraintViolations(),
+					"may not be null"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareDeeplyNestedContainerElementTypeConstraintsForReturnValueProgrammatically() {
+		Validator validator = getValidator( "returnvalue-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			fishTank.test3();
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+				e.getConstraintViolations(),
+				"may not be null"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementCascadesForReturnValueProgrammatically() {
+		Validator validator = getValidator( "returnvalue-canDeclareContainerElementCascades-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			fishTank.test4();
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+				e.getConstraintViolations(),
+				"may not be null"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForArrayTypeReturnValueProgrammatically() {
+		Validator validator = getValidator( "returnvalue-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			fishTank.test5();
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+				e.getConstraintViolations(),
+				"size must be between 0 and 5"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForListContainingArrayTypeReturnValueProgrammatically() {
+		Validator validator = getValidator( "returnvalue-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			fishTank.test6();
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+				e.getConstraintViolations(),
+				"size must be between 0 and 5"
+			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1291")
+	public void canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayTypeReturnValueProgrammatically() {
+		Validator validator = getValidator( "returnvalue-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+
+		try {
+			fishTank.test7();
+
+			fail( "Expected exception wasn't raised" );
+		}
+		catch (ConstraintViolationException e) {
+			assertCorrectConstraintViolationMessages(
+				e.getConstraintViolations(),
+				"size must be between 0 and 5"
+			);
+		}
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000211.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintOnNonGenericReturnValueCausesException() {
+		getValidator( "returnvalue-declaringContainerElementTypeConstraintOnNonGenericReturnValueCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000212.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnReturnValueCausesException() {
+		getValidator( "returnvalue-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnReturnValueCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000212.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnReturnValueCausesException() {
+		getValidator( "returnvalue-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnReturnValueCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000213.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void omittingTypeArgumentForMultiTypeArgumentTypeOnReturnValueCausesException() {
+		getValidator( "returnvalue-omittingTypeArgumentForMultiTypeArgumentTypeOnReturnValueCausesException-mapping.xml" );
+	}
+
+	@Test(expectedExceptions = UnexpectedTypeException.class, expectedExceptionsMessageRegExp = "HV000030:.*")
+	@TestForIssue(jiraKey = "HV-1279")
+	public void configuringConstraintsOnGenericTypeArgumentOfListThrowsException() {
+		Validator validator = getValidator( "returnvalue-configuringConstraintsOnGenericTypeArgumentOfListThrowsException-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+		fishTank.test8( Arrays.asList( "Too long" ) );
+	}
+
+	@Test(expectedExceptions = UnexpectedTypeException.class, expectedExceptionsMessageRegExp = "HV000030:.*")
+	@TestForIssue(jiraKey = "HV-1279")
+	public void configuringConstraintsOnGenericTypeArgumentOfArrayThrowsException() {
+		Validator validator = getValidator( "returnvalue-configuringConstraintsOnGenericTypeArgumentOfArrayThrowsException-mapping.xml" );
+
+		IFishTank fishTank = ValidatorUtil.getValidatingProxy( new FishTank(), validator );
+		fishTank.test9( new String[]{ "Too long" } );
+	}
+
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000217.*")
+	@TestForIssue(jiraKey = "HV-1291")
+	public void configuringSameContainerElementTwiceCausesException() {
+		getValidator( "returnvalue-configuringSameContainerElementTwiceCausesException-mapping.xml" );
+	}
+
+	private Validator getValidator(String mappingFile) {
+		Configuration<?> config = ValidatorUtil.getConfiguration();
+		config.addMapping( ContainerElementTypeConstraintsForFieldXmlMappingTest.class.getResourceAsStream( mappingFile ) );
+		return config.buildValidatorFactory().getValidator();
+	}
+
+	public interface IFishTank {
+		Map<String, Integer> test1();
+		Map<String, List<Fish>> test2();
+		List<Map<String, Set<String>>> test3();
+		Optional<Fish> test4();
+		String[] test5();
+		List<String[]> test6();
+		String[][]  test7();
+		<T> List<T> test8(List<T> list);
+		<T> T[] test9(T[] array);
+		int getSize();
+	}
+
+	public static class FishTank implements IFishTank {
+
+		@Override
+		public Map<String, Integer> test1() {
+			HashMap<String, Integer> fishCountByType = new HashMap<>();
+			fishCountByType.put( "A", -1 );
+			fishCountByType.put( "BB", -2 );
+
+			return fishCountByType;
+		}
+
+		@Override
+		public Map<String, List<Fish>> test2() {
+			Map<String, List<Fish>> fishOfTheMonth = new HashMap<>();
+			List<Fish> january = Arrays.asList( null, new Fish() );
+			fishOfTheMonth.put( "january", january );
+
+			return fishOfTheMonth;
+		}
+
+		@Override
+		public List<Map<String, Set<String>>> test3() {
+			Set<String> bobsTags = CollectionHelper.asSet( (String) null );
+			Map<String, Set<String>> januaryTags = new HashMap<>();
+			januaryTags.put( "bob", bobsTags );
+			List<Map<String, Set<String>>> tagsOfFishOfTheMonth = new ArrayList<>();
+			tagsOfFishOfTheMonth.add( januaryTags );
+
+			return tagsOfFishOfTheMonth;
+		}
+
+		@Override
+		public Optional<Fish> test4() {
+			return Optional.of( new Fish() );
+		}
+
+		@Override
+		public String[] test5() {
+			return new String[] { "Too Long" };
+		}
+
+		@Override
+		public List<String[]> test6() {
+			List<String[]> fishNamesByMonth = new ArrayList<>();
+			fishNamesByMonth.add(  new String[] { "Too Long" } );
+			return fishNamesByMonth;
+		}
+
+		@Override
+		public String[][] test7() {
+			return new String[][]{ new String[] { "Too Long" } };
+		}
+
+		@Override
+		public <T> List<T> test8(List<T> list) {
+			return list;
+		}
+
+		@Override
+		public <T> T[] test9(T[] array) {
+			return array;
+		}
+
+		@Override
+		public int getSize() {
+			return 0;
+		}
+
+		public FishTank() {
+		}
+	}
+
+	public static class Fish {
+
+		public Fish() {
+		}
+
+		public String name;
+	}
+}

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareContainerElementCascades-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareContainerElementCascades-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="boss">
+            <containerElementType>
+                <valid />
+            </containerElementType>
+        </field>
+    </bean>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$Fish" ignore-annotations="false">
+        <field name="name">
+            <constraint annotation="javax.validation.constraints.NotNull" />
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,39 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="model">
+            <containerElementType>
+                <constraint annotation="javax.validation.constraints.Size">
+                    <element name="max">
+                        <value>5</value>
+                    </element>
+                </constraint>
+            </containerElementType>
+        </field>
+        <field name="fishCountByType">
+            <containerElementType typeArgumentIndex="0">
+                <constraint annotation="javax.validation.constraints.Size">
+                    <element name="min">
+                        <value>3</value>
+                    </element>
+                    <element name="max">
+                        <value>10</value>
+                    </element>
+                </constraint>
+            </containerElementType>
+            <containerElementType typeArgumentIndex="1">
+                <constraint annotation="javax.validation.constraints.Min">
+                    <element name="value">
+                        <value>1</value>
+                    </element>
+                </constraint>
+            </containerElementType>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml
@@ -1,0 +1,20 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="fishNames">
+            <containerElementType>
+                <constraint annotation="javax.validation.constraints.Size">
+                    <element name="max">
+                        <value>5</value>
+                    </element>
+                </constraint>
+            </containerElementType>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="fishNamesByMonth">
+            <containerElementType typeArgumentIndex="0">
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </containerElementType>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="fishNamesByMonthAsArray">
+            <containerElementType typeArgumentIndex="0">
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </containerElementType>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,20 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="tagsOfFishOfTheMonth">
+            <containerElementType typeArgumentIndex="0">
+                <containerElementType typeArgumentIndex="1">
+                    <containerElementType typeArgumentIndex="0">
+                        <constraint annotation="javax.validation.constraints.NotNull" />
+                    </containerElementType>
+                </containerElementType>
+            </containerElementType>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareNestedContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-canDeclareNestedContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,18 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="fishOfTheMonth">
+            <containerElementType typeArgumentIndex="1">
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.NotNull" />
+                </containerElementType>
+            </containerElementType>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-configuringSameContainerElementTwiceCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-configuringSameContainerElementTwiceCausesException-mapping.xml
@@ -1,0 +1,26 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="tagsOfFishOfTheMonth">
+            <containerElementType typeArgumentIndex="0">
+                <containerElementType typeArgumentIndex="1">
+                    <containerElementType typeArgumentIndex="0">
+                        <constraint annotation="javax.validation.constraints.NotNull" />
+                    </containerElementType>
+                </containerElementType>
+            </containerElementType>
+            <containerElementType typeArgumentIndex="0">
+                <containerElementType typeArgumentIndex="1">
+                    <containerElementType typeArgumentIndex="0">
+                    </containerElementType>
+                </containerElementType>
+            </containerElementType>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException-mapping.xml
@@ -1,0 +1,17 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="fishOfTheMonth">
+            <containerElementType typeArgumentIndex="1">
+                <containerElementType typeArgumentIndex="2">
+                </containerElementType>
+            </containerElementType>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException-mapping.xml
@@ -1,0 +1,15 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="model">
+            <containerElementType typeArgumentIndex="1">
+            </containerElementType>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-declaringContainerElementTypeConstraintOnNonGenericFieldCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-declaringContainerElementTypeConstraintOnNonGenericFieldCausesException-mapping.xml
@@ -1,0 +1,15 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="size">
+            <containerElementType typeArgumentIndex="1">
+            </containerElementType>
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/field-omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException-mapping.xml
@@ -1,0 +1,14 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForFieldXmlMappingTest$FishTank" ignore-annotations="false">
+        <field name="fishCountByType">
+            <containerElementType />
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareContainerElementCascades-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareContainerElementCascades-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="boss">
+            <containerElementType>
+                <valid />
+            </containerElementType>
+        </getter>
+    </bean>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$Fish" ignore-annotations="false">
+        <getter name="name">
+            <constraint annotation="javax.validation.constraints.NotNull" />
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,39 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="model">
+            <containerElementType>
+                <constraint annotation="javax.validation.constraints.Size">
+                    <element name="max">
+                        <value>5</value>
+                    </element>
+                </constraint>
+            </containerElementType>
+        </getter>
+        <getter name="fishCountByType">
+            <containerElementType typeArgumentIndex="0">
+                <constraint annotation="javax.validation.constraints.Size">
+                    <element name="min">
+                        <value>3</value>
+                    </element>
+                    <element name="max">
+                        <value>10</value>
+                    </element>
+                </constraint>
+            </containerElementType>
+            <containerElementType typeArgumentIndex="1">
+                <constraint annotation="javax.validation.constraints.Min">
+                    <element name="value">
+                        <value>1</value>
+                    </element>
+                </constraint>
+            </containerElementType>
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml
@@ -1,0 +1,20 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="fishNames">
+            <containerElementType>
+                <constraint annotation="javax.validation.constraints.Size">
+                    <element name="max">
+                        <value>5</value>
+                    </element>
+                </constraint>
+            </containerElementType>
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="fishNamesByMonth">
+            <containerElementType typeArgumentIndex="0">
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </containerElementType>
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="fishNamesByMonthAsArray">
+            <containerElementType typeArgumentIndex="0">
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </containerElementType>
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,20 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="tagsOfFishOfTheMonth">
+            <containerElementType typeArgumentIndex="0">
+                <containerElementType typeArgumentIndex="1">
+                    <containerElementType typeArgumentIndex="0">
+                        <constraint annotation="javax.validation.constraints.NotNull" />
+                    </containerElementType>
+                </containerElementType>
+            </containerElementType>
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareNestedContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-canDeclareNestedContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,18 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="fishOfTheMonth">
+            <containerElementType typeArgumentIndex="1">
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.NotNull" />
+                </containerElementType>
+            </containerElementType>
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-configuringSameContainerElementTwiceCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-configuringSameContainerElementTwiceCausesException-mapping.xml
@@ -1,0 +1,26 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="tagsOfFishOfTheMonth">
+            <containerElementType typeArgumentIndex="0">
+                <containerElementType typeArgumentIndex="1">
+                    <containerElementType typeArgumentIndex="0">
+                        <constraint annotation="javax.validation.constraints.NotNull" />
+                    </containerElementType>
+                </containerElementType>
+            </containerElementType>
+            <containerElementType typeArgumentIndex="0">
+                <containerElementType typeArgumentIndex="1">
+                    <containerElementType typeArgumentIndex="0">
+                    </containerElementType>
+                </containerElementType>
+            </containerElementType>
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnFieldCausesException-mapping.xml
@@ -1,0 +1,17 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="fishOfTheMonth">
+            <containerElementType typeArgumentIndex="1">
+                <containerElementType typeArgumentIndex="2">
+                </containerElementType>
+            </containerElementType>
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnFieldCausesException-mapping.xml
@@ -1,0 +1,15 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="model">
+            <containerElementType typeArgumentIndex="1">
+            </containerElementType>
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-declaringContainerElementTypeConstraintOnNonGenericFieldCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-declaringContainerElementTypeConstraintOnNonGenericFieldCausesException-mapping.xml
@@ -1,0 +1,15 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="size">
+            <containerElementType typeArgumentIndex="1">
+            </containerElementType>
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/getter-omittingTypeArgumentForMultiTypeArgumentTypeOnFieldCausesException-mapping.xml
@@ -1,0 +1,14 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForGetterXmlMappingTest$FishTank" ignore-annotations="false">
+        <getter name="fishCountByType">
+            <containerElementType />
+        </getter>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareContainerElementCascades-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareContainerElementCascades-mapping.xml
@@ -1,0 +1,24 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test4">
+            <parameter type="java.util.Optional">
+                <containerElementType>
+                    <valid />
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$Fish" ignore-annotations="false">
+        <field name="name">
+            <constraint annotation="javax.validation.constraints.NotNull" />
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,41 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test1">
+            <parameter type="java.util.Optional">
+                <containerElementType>
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </parameter>
+            <parameter type="java.util.Map">
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="min">
+                            <value>3</value>
+                        </element>
+                        <element name="max">
+                            <value>10</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+                <containerElementType typeArgumentIndex="1">
+                    <constraint annotation="javax.validation.constraints.Min">
+                        <element name="value">
+                            <value>1</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test5">
+            <parameter type="[Ljava.lang.String;">
+                <containerElementType>
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml
@@ -1,0 +1,24 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test6">
+            <parameter type="java.util.List">
+                <containerElementType typeArgumentIndex="0">
+                    <containerElementType typeArgumentIndex="0">
+                        <constraint annotation="javax.validation.constraints.Size">
+                            <element name="max">
+                                <value>5</value>
+                            </element>
+                        </constraint>
+                    </containerElementType>
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml
@@ -1,0 +1,24 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test7">
+            <parameter type="[[Ljava.lang.String;">
+                <containerElementType typeArgumentIndex="0">
+                    <containerElementType typeArgumentIndex="0">
+                        <constraint annotation="javax.validation.constraints.Size">
+                            <element name="max">
+                                <value>5</value>
+                            </element>
+                        </constraint>
+                    </containerElementType>
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test3">
+            <parameter type="java.util.List">
+                <containerElementType typeArgumentIndex="0">
+                    <containerElementType typeArgumentIndex="1">
+                        <containerElementType typeArgumentIndex="0">
+                            <constraint annotation="javax.validation.constraints.NotNull" />
+                        </containerElementType>
+                    </containerElementType>
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareNestedContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-canDeclareNestedContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,20 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test2">
+            <parameter type="java.util.Map">
+                <containerElementType typeArgumentIndex="1">
+                    <containerElementType typeArgumentIndex="0">
+                        <constraint annotation="javax.validation.constraints.NotNull" />
+                    </containerElementType>
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-configuringConstraintsOnGenericTypeArgumentOfArrayThrowsException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-configuringConstraintsOnGenericTypeArgumentOfArrayThrowsException-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test9">
+            <parameter type="[Ljava.lang.Object;">
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-configuringConstraintsOnGenericTypeArgumentOfListThrowsException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-configuringConstraintsOnGenericTypeArgumentOfListThrowsException-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test8">
+            <parameter type="java.util.List">
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-configuringSameContainerElementTwiceCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-configuringSameContainerElementTwiceCausesException-mapping.xml
@@ -1,0 +1,28 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test3">
+            <parameter type="java.util.List">
+                <containerElementType typeArgumentIndex="0">
+                    <containerElementType typeArgumentIndex="1">
+                        <containerElementType typeArgumentIndex="0">
+                            <constraint annotation="javax.validation.constraints.NotNull" />
+                        </containerElementType>
+                    </containerElementType>
+                </containerElementType>
+                <containerElementType typeArgumentIndex="0">
+                    <containerElementType typeArgumentIndex="1">
+                        <containerElementType typeArgumentIndex="0">
+                        </containerElementType>
+                    </containerElementType>
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnParameterCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnParameterCausesException-mapping.xml
@@ -1,0 +1,19 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test2">
+            <parameter type="java.util.Map">
+                <containerElementType typeArgumentIndex="1">
+                    <containerElementType typeArgumentIndex="2">
+                    </containerElementType>
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnParameterCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnParameterCausesException-mapping.xml
@@ -1,0 +1,19 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test1">
+            <parameter type="java.util.Optional">
+                <containerElementType typeArgumentIndex="2">
+                </containerElementType>
+            </parameter>
+            <parameter type="java.util.Map">
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-declaringContainerElementTypeConstraintOnNonGenericParameterCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-declaringContainerElementTypeConstraintOnNonGenericParameterCausesException-mapping.xml
@@ -1,0 +1,17 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="setSize">
+            <parameter type="int">
+                <containerElementType typeArgumentIndex="1">
+                </containerElementType>
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-omittingTypeArgumentForMultiTypeArgumentTypeOnParameterCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/parameter-omittingTypeArgumentForMultiTypeArgumentTypeOnParameterCausesException-mapping.xml
@@ -1,0 +1,18 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForParameterXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test1">
+            <parameter type="java.util.Optional">
+            </parameter>
+            <parameter type="java.util.Map">
+                <containerElementType />
+            </parameter>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareContainerElementCascades-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareContainerElementCascades-mapping.xml
@@ -1,0 +1,24 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test4">
+            <return-value>
+                <containerElementType>
+                    <valid />
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$Fish" ignore-annotations="false">
+        <field name="name">
+            <constraint annotation="javax.validation.constraints.NotNull" />
+        </field>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,32 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test1">
+            <return-value>
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="min">
+                            <value>3</value>
+                        </element>
+                        <element name="max">
+                            <value>10</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+                <containerElementType typeArgumentIndex="1">
+                    <constraint annotation="javax.validation.constraints.Min">
+                        <element name="value">
+                            <value>1</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareContainerElementTypeConstraintsForArrayType-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test5">
+            <return-value>
+                <containerElementType>
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareContainerElementTypeConstraintsForListContainingArrayType-mapping.xml
@@ -1,0 +1,24 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test6">
+            <return-value>
+                <containerElementType typeArgumentIndex="0">
+                    <containerElementType typeArgumentIndex="0">
+                        <constraint annotation="javax.validation.constraints.Size">
+                            <element name="max">
+                                <value>5</value>
+                            </element>
+                        </constraint>
+                    </containerElementType>
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareContainerElementTypeConstraintsForMultiDimensionalArrayType-mapping.xml
@@ -1,0 +1,24 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test7">
+            <return-value>
+                <containerElementType typeArgumentIndex="0">
+                    <containerElementType typeArgumentIndex="0">
+                        <constraint annotation="javax.validation.constraints.Size">
+                            <element name="max">
+                                <value>5</value>
+                            </element>
+                        </constraint>
+                    </containerElementType>
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareDeeplyNestedContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,22 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test3">
+            <return-value>
+                <containerElementType typeArgumentIndex="0">
+                    <containerElementType typeArgumentIndex="1">
+                        <containerElementType typeArgumentIndex="0">
+                            <constraint annotation="javax.validation.constraints.NotNull" />
+                        </containerElementType>
+                    </containerElementType>
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareNestedContainerElementTypeConstraints-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-canDeclareNestedContainerElementTypeConstraints-mapping.xml
@@ -1,0 +1,20 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test2">
+            <return-value>
+                <containerElementType typeArgumentIndex="1">
+                    <containerElementType typeArgumentIndex="0">
+                        <constraint annotation="javax.validation.constraints.NotNull" />
+                    </containerElementType>
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-configuringConstraintsOnGenericTypeArgumentOfArrayThrowsException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-configuringConstraintsOnGenericTypeArgumentOfArrayThrowsException-mapping.xml
@@ -1,0 +1,23 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test9">
+            <parameter type="[Ljava.lang.Object;" />
+            <return-value>
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-configuringConstraintsOnGenericTypeArgumentOfListThrowsException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-configuringConstraintsOnGenericTypeArgumentOfListThrowsException-mapping.xml
@@ -1,0 +1,23 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test8">
+            <parameter type="java.util.List" />
+            <return-value>
+                <containerElementType typeArgumentIndex="0">
+                    <constraint annotation="javax.validation.constraints.Size">
+                        <element name="max">
+                            <value>5</value>
+                        </element>
+                    </constraint>
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-configuringSameContainerElementTwiceCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-configuringSameContainerElementTwiceCausesException-mapping.xml
@@ -1,0 +1,28 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test3">
+            <return-value>
+                <containerElementType typeArgumentIndex="0">
+                    <containerElementType typeArgumentIndex="1">
+                        <containerElementType typeArgumentIndex="0">
+                            <constraint annotation="javax.validation.constraints.NotNull" />
+                        </containerElementType>
+                    </containerElementType>
+                </containerElementType>
+                <containerElementType typeArgumentIndex="0">
+                    <containerElementType typeArgumentIndex="1">
+                        <containerElementType typeArgumentIndex="0">
+                        </containerElementType>
+                    </containerElementType>
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnReturnValueCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-declaringContainerElementTypeConstraintForNonExistingNestedTypeArgumentIndexOnReturnValueCausesException-mapping.xml
@@ -1,0 +1,19 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test2">
+            <return-value>
+                <containerElementType typeArgumentIndex="1">
+                    <containerElementType typeArgumentIndex="2">
+                    </containerElementType>
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnReturnValueCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-declaringContainerElementTypeConstraintForNonExistingTypeArgumentIndexOnReturnValueCausesException-mapping.xml
@@ -1,0 +1,17 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test1">
+            <return-value>
+                <containerElementType typeArgumentIndex="2">
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-declaringContainerElementTypeConstraintOnNonGenericReturnValueCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-declaringContainerElementTypeConstraintOnNonGenericReturnValueCausesException-mapping.xml
@@ -1,0 +1,17 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="getSize">
+            <return-value>
+                <containerElementType typeArgumentIndex="1">
+                </containerElementType>
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-omittingTypeArgumentForMultiTypeArgumentTypeOnReturnValueCausesException-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/containerelementtype/returnvalue-omittingTypeArgumentForMultiTypeArgumentTypeOnReturnValueCausesException-mapping.xml
@@ -1,0 +1,16 @@
+<constraint-mappings
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/mapping validation-mapping-2.0.xsd"
+        version="2.0">
+
+    <default-package>org.hibernate.validator.internal.xml.containerelementtype</default-package>
+
+    <bean class="org.hibernate.validator.test.internal.xml.containerelementtype.ContainerElementTypeConstraintsForReturnValueXmlMappingTest$IFishTank" ignore-annotations="false">
+        <method name="test1">
+            <return-value>
+                <containerElementType />
+            </return-value>
+        </method>
+    </bean>
+</constraint-mappings>


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1291

@gunnarmorling so this is my progress on container element type constraints definition via XML. I updated the validation-mapping-2.0.xsd here. Once we agree on it, I'll push a PR to beanvalidation-api.

I think it's feature and test complete (the tests are the same as for the programmatic API) except for the discussion we had about throwing an exception if XML constraints are defined and we try to define programmatic API or annotation based constraints. I think this can be treated as a follow-up. If you agree, I'll open a specific JIRA.