### PR TITLE
HV-1294 Fix OSGi configuration of the cdi module

### DIFF
--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -141,6 +141,15 @@
                         <goals>
                             <goal>jar</goal>
                         </goals>
+                        <configuration>
+                            <archive>
+                                <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                                <manifestEntries>
+                                    <Specification-Title>Bean Validation</Specification-Title>
+                                    <Specification-Version>2.0</Specification-Version>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -156,8 +165,8 @@
                             javax.interceptor.*;version="[1.2,2.0)",
                             javax.enterprise.*;version="[1.2,2.0)"
                         </Import-Package>
-                        <Export-Package>org.hibernate.validator.cdi</Export-Package>
-                        <Private-Package>org.hibernate.validator.internal.*</Private-Package>
+                        <Export-Package>org.hibernate.validator.cdi;version="${project.version}"</Export-Package>
+                        <Private-Package>org.hibernate.validator.internal.*;version="${project.version}"</Private-Package>
                     </instructions>
                 </configuration>
                 <executions>


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1294

Looks like the configuration of the manifest in the jar section was necessary to include the OSGi information in the manifest. Don't exactly know why but, this way, we are consistent with the engine module.

Probably something we should backport at least to 5.4, maybe to the other supported versions.