### PR TITLE
HV-1297 Annotation processor support for @NotEmpty, @NotBlank, @Email, @Positive, @Negative

### DIFF
--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/util/ConstraintHelper.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/util/ConstraintHelper.java
@@ -193,6 +193,23 @@ public class ConstraintHelper {
 		YearMonth.class,
 		ZonedDateTime.class
 	};
+	/**
+	 * Types supported by {@code @Size} and {@NotEmpty} annotations.
+	 */
+	private static final Class<?>[] JAVA_TIME_TYPES_SUPPORTED_BY_SIZE_AND_NOT_EMPTY_ANNOTATIONS = new Class<?>[] {
+		Object[].class,
+		boolean[].class,
+		byte[].class,
+		char[].class,
+		double[].class,
+		float[].class,
+		int[].class,
+		long[].class,
+		short[].class,
+		Collection.class,
+		Map.class,
+		CharSequence.class
+	};
 
 	/**
 	 * Contains the supported types for given constraints. Keyed by constraint
@@ -231,6 +248,7 @@ public class ConstraintHelper {
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.DECIMAL_MIN, Number.class, String.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.DECIMAL_MIN, JavaMoneyTypes.MONETARY_AMOUNT );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.DIGITS, Number.class, String.class );
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.EMAIL, CharSequence.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.FUTURE, Calendar.class, Date.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.FUTURE, JodaTypes.READABLE_PARTIAL, JodaTypes.READABLE_INSTANT );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.FUTURE, JAVA_TIME_TYPES_SUPPORTED_BY_FUTURE_AND_PAST_ANNOTATIONS );
@@ -238,27 +256,17 @@ public class ConstraintHelper {
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.MAX, JavaMoneyTypes.MONETARY_AMOUNT );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.MIN, Number.class, String.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.MIN, JavaMoneyTypes.MONETARY_AMOUNT );
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NEGATIVE, Number.class );
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NOT_BLANK, CharSequence.class );
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NOT_EMPTY, JAVA_TIME_TYPES_SUPPORTED_BY_SIZE_AND_NOT_EMPTY_ANNOTATIONS );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NOT_NULL, Object.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NULL, Object.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.PAST, Calendar.class, Date.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.PAST, JodaTypes.READABLE_PARTIAL, JodaTypes.READABLE_INSTANT );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.PAST, JAVA_TIME_TYPES_SUPPORTED_BY_FUTURE_AND_PAST_ANNOTATIONS );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.PATTERN, String.class );
-		registerAllowedTypesForBuiltInConstraint(
-				BeanValidationTypes.SIZE,
-				Object[].class,
-				boolean[].class,
-				byte[].class,
-				char[].class,
-				double[].class,
-				float[].class,
-				int[].class,
-				long[].class,
-				short[].class,
-				Collection.class,
-				Map.class,
-				String.class
-		);
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.POSITIVE, Number.class );
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.SIZE, JAVA_TIME_TYPES_SUPPORTED_BY_SIZE_AND_NOT_EMPTY_ANNOTATIONS );
 
 		//register HV-specific constraints
 		registerAllowedTypesForBuiltInConstraint( HibernateValidatorTypes.CURRENCY, JavaMoneyTypes.MONETARY_AMOUNT );
@@ -274,6 +282,7 @@ public class ConstraintHelper {
 		registerAllowedTypesForBuiltInConstraint( HibernateValidatorTypes.NIP_CHECK, CharSequence.class );
 		registerAllowedTypesForBuiltInConstraint( HibernateValidatorTypes.PESEL_CHECK, CharSequence.class );
 		registerAllowedTypesForBuiltInConstraint( HibernateValidatorTypes.NOT_BLANK, CharSequence.class );
+		registerAllowedTypesForBuiltInConstraint( HibernateValidatorTypes.NOT_EMPTY, JAVA_TIME_TYPES_SUPPORTED_BY_SIZE_AND_NOT_EMPTY_ANNOTATIONS );
 		registerAllowedTypesForBuiltInConstraint( HibernateValidatorTypes.SAFE_HTML, CharSequence.class );
 		registerAllowedTypesForBuiltInConstraint( HibernateValidatorTypes.SCRIPT_ASSERT, Object.class );
 		registerAllowedTypesForBuiltInConstraint( HibernateValidatorTypes.URL, CharSequence.class );

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/util/TypeNames.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/util/TypeNames.java
@@ -33,13 +33,18 @@ public class TypeNames {
 		public static final String DECIMAL_MAX = JAVAX_VALIDATION_CONSTRAINTS + ".DecimalMax";
 		public static final String DECIMAL_MIN = JAVAX_VALIDATION_CONSTRAINTS + ".DecimalMin";
 		public static final String DIGITS = JAVAX_VALIDATION_CONSTRAINTS + ".Digits";
+		public static final String EMAIL = JAVAX_VALIDATION_CONSTRAINTS + ".Email";
 		public static final String FUTURE = JAVAX_VALIDATION_CONSTRAINTS + ".Future";
 		public static final String MAX = JAVAX_VALIDATION_CONSTRAINTS + ".Max";
 		public static final String MIN = JAVAX_VALIDATION_CONSTRAINTS + ".Min";
+		public static final String NEGATIVE = JAVAX_VALIDATION_CONSTRAINTS + ".Negative";
+		public static final String NOT_BLANK = JAVAX_VALIDATION_CONSTRAINTS + ".NotBlank";
+		public static final String NOT_EMPTY = JAVAX_VALIDATION_CONSTRAINTS + ".NotEmpty";
 		public static final String NOT_NULL = JAVAX_VALIDATION_CONSTRAINTS + ".NotNull";
 		public static final String NULL = JAVAX_VALIDATION_CONSTRAINTS + ".Null";
 		public static final String PAST = JAVAX_VALIDATION_CONSTRAINTS + ".Past";
 		public static final String PATTERN = JAVAX_VALIDATION_CONSTRAINTS + ".Pattern";
+		public static final String POSITIVE = JAVAX_VALIDATION_CONSTRAINTS + ".Positive";
 		public static final String SIZE = JAVAX_VALIDATION_CONSTRAINTS + ".Size";
 
 		public static final String CONSTRAINTVALIDATION = "javax.validation.constraintvalidation";
@@ -68,6 +73,7 @@ public class TypeNames {
 		public static final String NIP_CHECK = ORG_HIBERNATE_VALIDATOR_CONSTRAINTS + ".pl.NIP";
 		public static final String PESEL_CHECK = ORG_HIBERNATE_VALIDATOR_CONSTRAINTS + ".pl.PESEL";
 		public static final String NOT_BLANK = ORG_HIBERNATE_VALIDATOR_CONSTRAINTS + ".NotBlank";
+		public static final String NOT_EMPTY = ORG_HIBERNATE_VALIDATOR_CONSTRAINTS + ".NotEmpty";
 		public static final String SAFE_HTML = ORG_HIBERNATE_VALIDATOR_CONSTRAINTS + ".SafeHtml";
 		public static final String SCRIPT_ASSERT = ORG_HIBERNATE_VALIDATOR_CONSTRAINTS + ".ScriptAssert";
 		public static final String URL = ORG_HIBERNATE_VALIDATOR_CONSTRAINTS + ".URL";

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorTest.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorTest.java
@@ -51,6 +51,7 @@ import org.hibernate.validator.ap.testmodel.crossparameters.GenericNormalValidat
 import org.hibernate.validator.ap.testmodel.crossparameters.MethodLevelValidationUsingCrossParameterConstraints;
 import org.hibernate.validator.ap.testmodel.crossparameters.ValidCrossParameterAndNormalConstraint;
 import org.hibernate.validator.ap.testmodel.crossparameters.ValidCrossParameterConstraint;
+import org.hibernate.validator.ap.testmodel.customconstraints.BeanValidationConstraints;
 import org.hibernate.validator.ap.testmodel.customconstraints.CaseMode;
 import org.hibernate.validator.ap.testmodel.customconstraints.CheckCase;
 import org.hibernate.validator.ap.testmodel.customconstraints.CheckCaseValidator;
@@ -169,6 +170,28 @@ public class ConstraintValidationProcessorTest extends ConstraintValidationProce
 				new DiagnosticExpectation( Kind.ERROR, 85 ),
 				new DiagnosticExpectation( Kind.ERROR, 86 ),
 				new DiagnosticExpectation( Kind.ERROR, 87 )
+		);
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HV-1297" )
+	public void beanValidationConstraints() {
+		File sourceFile = compilerHelper.getSourceFile( BeanValidationConstraints.class );
+
+		boolean compilationResult =
+				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics, sourceFile );
+
+		assertFalse( compilationResult );
+		assertThatDiagnosticsMatch(
+				diagnostics,
+				new DiagnosticExpectation( Kind.ERROR, 39 ),
+				new DiagnosticExpectation( Kind.ERROR, 40 ),
+				new DiagnosticExpectation( Kind.ERROR, 41 ),
+				new DiagnosticExpectation( Kind.ERROR, 42 ),
+				new DiagnosticExpectation( Kind.ERROR, 45 ),
+				new DiagnosticExpectation( Kind.ERROR, 46 ),
+				new DiagnosticExpectation( Kind.ERROR, 47 ),
+				new DiagnosticExpectation( Kind.ERROR, 50 )
 		);
 	}
 

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/customconstraints/BeanValidationConstraints.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/customconstraints/BeanValidationConstraints.java
@@ -1,0 +1,52 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.ap.testmodel.customconstraints;
+
+import java.util.Collection;
+import java.util.List;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.Negative;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Positive;
+
+public class BeanValidationConstraints {
+
+	/**
+	 * Allowed.
+	 */
+	@Email
+	@NotEmpty
+	@NotBlank
+	public String string;
+
+	@Positive
+	public int number;
+
+	@Negative
+	public Double otherNumber;
+
+	@NotEmpty
+	public List list;
+
+	/**
+	 * Not allowed.
+	 */
+	@Email
+	@Negative
+	@NotEmpty
+	@NotBlank
+	public Object property;
+
+	@NotEmpty
+	@NotBlank
+	@Email
+	public int badInt;
+
+	@Positive
+	public Collection collection;
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1297

There seems to be no additional checks needed for these new annotations. So I've added them only to `ConstraintHelper` so AP will be happy to see them on allowed types.