### PR TITLE
HV-1303 @SafeHtml should support relative URLs

### DIFF
--- a/documentation/src/main/asciidoc/ch02.asciidoc
+++ b/documentation/src/main/asciidoc/ch02.asciidoc
@@ -598,7 +598,7 @@ With one exception also these constraints apply to the field/property level, onl
 	Supported data types::: `BigDecimal`, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types
 	Hibernate metadata impact::: None
 
-`@SafeHtml(whitelistType= , additionalTags=, additionalTagsWithAttributes=)`:: Checks whether the annotated value contains potentially malicious fragments such as `<script/>`. In order to use this constraint, the link:$$http://jsoup.org/$$[jsoup] library must be part of the class path. With the `whitelistType` attribute a predefined whitelist type can be chosen which can be refined via `additionalTags` or `additionalTagsWithAttributes`. The former allows to add tags without any attributes, whereas the latter allows to specify tags and optionally allowed attributes using the annotation `@SafeHtml.Tag`.
+`@SafeHtml(whitelistType= , additionalTags=, additionalTagsWithAttributes=)`:: Checks whether the annotated value contains potentially malicious fragments such as `<script/>`. In order to use this constraint, the link:$$http://jsoup.org/$$[jsoup] library must be part of the class path. With the `whitelistType` attribute a predefined whitelist type can be chosen which can be refined via `additionalTags` or `additionalTagsWithAttributes`. The former allows to add tags without any attributes, whereas the latter allows to specify tags and optionally allowed attributes, as well as additional protocols for parameters of those attributes using the annotation `@SafeHtml.Tag`.
 	Supported data types::: `CharSequence`
 	Hibernate metadata impact::: None
 

--- a/documentation/src/main/asciidoc/ch02.asciidoc
+++ b/documentation/src/main/asciidoc/ch02.asciidoc
@@ -598,7 +598,8 @@ With one exception also these constraints apply to the field/property level, onl
 	Supported data types::: `BigDecimal`, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types
 	Hibernate metadata impact::: None
 
-`@SafeHtml(whitelistType= , additionalTags=, additionalTagsWithAttributes=)`:: Checks whether the annotated value contains potentially malicious fragments such as `<script/>`. In order to use this constraint, the link:$$http://jsoup.org/$$[jsoup] library must be part of the class path. With the `whitelistType` attribute a predefined whitelist type can be chosen which can be refined via `additionalTags` or `additionalTagsWithAttributes`. The former allows to add tags without any attributes, whereas the latter allows to specify tags and optionally allowed attributes, as well as additional protocols for parameters of those attributes using the annotation `@SafeHtml.Tag`.
+`@SafeHtml(whitelistType= , additionalTags=, additionalTagsWithAttributes=, baseURI=)`:: Checks whether the annotated value contains potentially malicious fragments such as `<script/>`. In order to use this constraint, the link:$$http://jsoup.org/$$[jsoup] library must be part of the class path. With the `whitelistType` attribute a predefined whitelist type can be chosen which can be refined via `additionalTags` or `additionalTagsWithAttributes`. The former allows to add tags without any attributes, whereas the latter allows to specify tags and optionally allowed attributes, as well as additional protocols for parameters of those attributes using the annotation `@SafeHtml.Tag`.
+In addition `baseURI` allows to specify the base URI to be used to resolve relative URIs.
 	Supported data types::: `CharSequence`
 	Hibernate metadata impact::: None
 

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/SafeHtmlDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/SafeHtmlDef.java
@@ -33,4 +33,9 @@ public class SafeHtmlDef extends ConstraintDef<SafeHtmlDef, SafeHtml> {
 		return this;
 	}
 
+	public SafeHtmlDef baseURI(String baseURI) {
+		addParameter( "baseURI", baseURI );
+		return this;
+	}
+
 }

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/SafeHtmlDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/SafeHtmlDef.java
@@ -34,4 +34,3 @@ public class SafeHtmlDef extends ConstraintDef<SafeHtmlDef, SafeHtml> {
 	}
 
 }
-

--- a/engine/src/main/java/org/hibernate/validator/constraints/SafeHtml.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/SafeHtml.java
@@ -65,6 +65,14 @@ public @interface SafeHtml {
 	Tag[] additionalTagsWithAttributes() default { };
 
 	/**
+	 * @return Base URI used to resolve relative URIs to absolute ones. If not set, validation
+	 * of HTML containing relative URIs will fail.
+	 *
+	 * @since 6.0
+	 */
+	String baseURI() default "";
+
+	/**
 	 * Allows to specify whitelist tags with specified optional attributes. Adding a tag with a given attribute also
 	 * whitelists the tag itself without any attribute.
 	 */

--- a/engine/src/main/java/org/hibernate/validator/constraints/SafeHtml.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/SafeHtml.java
@@ -60,7 +60,7 @@ public @interface SafeHtml {
 	String[] additionalTags() default { };
 
 	/**
-	 * @return Allows to specify additional whitelist tags with optional attributes.
+	 * @return Allows to specify additional whitelist tags with optional attributes and protocols.
 	 */
 	Tag[] additionalTagsWithAttributes() default { };
 
@@ -81,6 +81,12 @@ public @interface SafeHtml {
 		 * @return list of tag attributes which are whitelisted.
 		 */
 		String[] attributes() default { };
+
+		/**
+		 * @return list of valid protocols.
+		 * @since 6.0
+		 */
+		String[] protocols() default { };
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java
@@ -53,6 +53,11 @@ public class SafeHtmlValidator implements ConstraintValidator<SafeHtml, CharSequ
 
 		for ( SafeHtml.Tag tag : safeHtmlAnnotation.additionalTagsWithAttributes() ) {
 			whitelist.addAttributes( tag.name(), tag.attributes() );
+			if ( tag.protocols().length > 0 ) {
+				for ( String attribute : tag.attributes() ) {
+					whitelist.addProtocols( tag.name(), attribute, tag.protocols() );
+				}
+			}
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java
@@ -26,9 +26,12 @@ import org.hibernate.validator.constraints.SafeHtml;
  *
  * @author George Gastaldi
  * @author Hardy Ferentschik
+ * @author Marko Bekhta
  */
 public class SafeHtmlValidator implements ConstraintValidator<SafeHtml, CharSequence> {
 	private Whitelist whitelist;
+
+	private String baseUri;
 
 	@Override
 	public void initialize(SafeHtml safeHtmlAnnotation) {
@@ -49,6 +52,7 @@ public class SafeHtmlValidator implements ConstraintValidator<SafeHtml, CharSequ
 				whitelist = Whitelist.simpleText();
 				break;
 		}
+		baseUri = safeHtmlAnnotation.baseURI();
 		whitelist.addTags( safeHtmlAnnotation.additionalTags() );
 
 		for ( SafeHtml.Tag tag : safeHtmlAnnotation.additionalTagsWithAttributes() ) {
@@ -77,8 +81,8 @@ public class SafeHtmlValidator implements ConstraintValidator<SafeHtml, CharSequ
 		// using the XML parser ensures that all elements in the input are retained, also if they actually are not allowed at the given
 		// location; E.g. a <td> element isn't allowed directly within the <body> element, so it would be used by the default HTML parser.
 		// we need to retain it though to apply the given white list properly; See HV-873
-		Document fragment = Jsoup.parse( value.toString(), "", Parser.xmlParser() );
-		Document document = Document.createShell( "" );
+		Document fragment = Jsoup.parse( value.toString(), baseUri, Parser.xmlParser() );
+		Document document = Document.createShell( baseUri );
 
 		// add the fragment's nodes to the body of resulting document
 		Iterator<Element> nodes = fragment.children().iterator();

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
@@ -33,6 +33,8 @@ import org.hibernate.validator.cfg.defs.pl.NIPDef;
 import org.hibernate.validator.cfg.defs.pl.PESELDef;
 import org.hibernate.validator.cfg.defs.pl.REGONDef;
 import org.hibernate.validator.constraints.SafeHtml;
+import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor;
+import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory;
 import org.hibernate.validator.testutil.PrefixableParameterNameProvider;
 
 import org.testng.annotations.Test;
@@ -61,6 +63,19 @@ public class ProgrammaticConstraintDefinitionsTest {
 		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE ), "test", 0 );
 		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.RELAXED ), "<td>1234qwer</td>", 0 );
 		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE ).additionalTags( "td" ), "<td>1234qwer</td>", 0 );
+
+		AnnotationDescriptor<SafeHtml.Tag> tagDescriptor = new AnnotationDescriptor( SafeHtml.Tag.class );
+		tagDescriptor.setValue( "name", "td" );
+		tagDescriptor.setValue( "attributes", new String[]{ "class", "id" } );
+		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+				.additionalTagsWithAttributes( AnnotationFactory.create( tagDescriptor ) ), "<td class='class' id='tableId'>1234qwer</td>", 0 );
+
+		AnnotationDescriptor<SafeHtml.Tag> protocolDescriptor = new AnnotationDescriptor( SafeHtml.Tag.class );
+		protocolDescriptor.setValue( "name", "img" );
+		protocolDescriptor.setValue( "attributes", new String[]{ "src" } );
+		protocolDescriptor.setValue( "protocols", new String[]{ "data" } );
+		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+				.additionalTagsWithAttributes( AnnotationFactory.create( protocolDescriptor ) ), "<img src='data:image/png;base64,100101' />", 0 );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
@@ -76,6 +76,11 @@ public class ProgrammaticConstraintDefinitionsTest {
 		protocolDescriptor.setValue( "protocols", new String[]{ "data" } );
 		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
 				.additionalTagsWithAttributes( AnnotationFactory.create( protocolDescriptor ) ), "<img src='data:image/png;base64,100101' />", 0 );
+
+		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.RELAXED ), "<img src='/some/relative/url/image.png' />", 1 );
+		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.RELAXED ).baseURI( "http://localhost" ),
+				"<img src='/some/relative/url/image.png' />", 0
+		);
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/SafeHtmlValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/SafeHtmlValidatorTest.java
@@ -173,6 +173,20 @@ public class SafeHtmlValidatorTest {
 				"</custom>" ) ), 0 );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HV-1303")
+	public void testPreserveRelativeLinks() throws Exception {
+		descriptor.setValue( "whitelistType", WhiteListType.RELAXED );
+		descriptor.setValue( "baseURI", "http://127.0.0.1" );
+
+		assertTrue( getSafeHtmlValidator().isValid( "<img src='/some/relative/url/image.png' />", null ) );
+
+		descriptor.setValue( "whitelistType", WhiteListType.RELAXED );
+		descriptor.setValue( "baseURI", "" );
+
+		assertFalse( getSafeHtmlValidator().isValid( "<img src='/some/relative/url/image.png' />", null ) );
+	}
+
 	private SafeHtmlValidator getSafeHtmlValidator() {
 		SafeHtml p = AnnotationFactory.create( descriptor );
 		SafeHtmlValidator validator = new SafeHtmlValidator();

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/SafeHtmlValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/SafeHtmlValidatorTest.java
@@ -6,12 +6,14 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.hv;
 
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
 import java.util.Set;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
-
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 import org.hibernate.validator.constraints.SafeHtml;
 import org.hibernate.validator.constraints.SafeHtml.WhiteListType;
@@ -20,10 +22,8 @@ import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescrip
 import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory;
 import org.hibernate.validator.testutil.TestForIssue;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
-import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * Unit test for {@link SafeHtmlValidator}.
@@ -152,6 +152,27 @@ public class SafeHtmlValidatorTest {
 		assertTrue( getSafeHtmlValidator().isValid( "Foobar", null ) );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HV-1302")
+	public void testAdditionalProtocols() {
+		Validator validator = getValidator();
+
+		assertNumberOfViolations( validator.validate( new Bar( "<img src='data:image/png;base64,100101' />" ) ), 0 );
+		assertNumberOfViolations( validator.validate( new Bar( "<img/>" ) ), 0 );
+		assertNumberOfViolations( validator.validate( new Bar( "<img src='not_data:image/png;base64,100101' />" ) ), 1 );
+		assertNumberOfViolations( validator.validate( new Bar( "<img not_src='data:image/png;base64,100101' />" ) ), 1 );
+		assertNumberOfViolations( validator.validate( new Bar( "<div src='data:image/png;base64,100101' />" ) ), 1 );
+		assertNumberOfViolations( validator.validate( new Bar( "<div src='data:image/png;base64,100101' />" ) ), 1 );
+		assertNumberOfViolations( validator.validate( new Bar(
+				"<custom>" +
+				"  <img src='data:image/png;base64,100101' />" +
+				"  <custom attr1='strange_protocol:some_text' />" +
+				"  <custom><img /></custom>" +
+				"  <section id='sec1' attr='val'></section>" +
+				"  <custom attr1='dataprotocol:some_text' attr2='strange_protocol:some_text' />" +
+				"</custom>" ) ), 0 );
+	}
+
 	private SafeHtmlValidator getSafeHtmlValidator() {
 		SafeHtml p = AnnotationFactory.create( descriptor );
 		SafeHtmlValidator validator = new SafeHtmlValidator();
@@ -167,6 +188,22 @@ public class SafeHtmlValidatorTest {
 		String source;
 
 		public Foo(String source) {
+			this.source = source;
+		}
+	}
+
+	public static class Bar {
+		@SafeHtml(
+				whitelistType = WhiteListType.BASIC,
+				additionalTagsWithAttributes = {
+						@SafeHtml.Tag(name = "img", attributes = "src", protocols = { "data" }),
+						@SafeHtml.Tag(name = "custom", attributes = { "attr1", "attr2" }, protocols = { "dataprotocol", "strange_protocol" }),
+						@SafeHtml.Tag(name = "section", attributes = { "attr", "id" })
+				}
+		)
+		String source;
+
+		public Bar(String source) {
 			this.source = source;
 		}
 	}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1303

I've added `baseUri` to `@SafeHtml`. I defaulted it to blank string so it will not change the behaviour of any existing usages.

This PR goes on top of the previous one for `@SafeHtml`.