### PR TITLE
HV-1324 Changing the way AP issue is reported

### DIFF
--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/AnnotationTypeValidationTest.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/AnnotationTypeValidationTest.java
@@ -293,7 +293,7 @@ public class AnnotationTypeValidationTest extends ConstraintValidationProcessorT
 		assertFalse( compilationResult );
 		assertThatDiagnosticsMatch(
 				diagnostics,
-				new DiagnosticExpectation( Kind.ERROR, 37 )
+				new DiagnosticExpectation( Kind.ERROR, 32 )
 		);
 	}
 

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/crossparameters/MixDirectAnnotationAndListContainerAnnotation.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/crossparameters/MixDirectAnnotationAndListContainerAnnotation.java
@@ -29,7 +29,7 @@ import org.hibernate.validator.constraints.Length;
  */
 
 @Length(min = 5)
-@Length.List(@Length(min = 45))
+@Length.List({ @Length(min = 45) })
 @Target({ ANNOTATION_TYPE, METHOD, CONSTRUCTOR })
 @Retention(RUNTIME)
 @Constraint(validatedBy = MixDirectAnnotationAndListContainerAnnotation.MixDirectAnnotationAndListContainerAnnotationValidator.class)


### PR DESCRIPTION
Hi @gsmet, @gunnarmorling!

Finally had a chance to look into that AP problem. First approach that I took a few days ago is in this PR. We don't have a way to distinguish when the error should be reported on List annotation or on an element of that list (because if it's a list annotation it is passed to `MultiValuedChecks` and checks receive list elements and know nothing about the wrapping annotation).

I don't really like the way I've changed the code to support such possibility (to choose on which annotation to report on). But more cleaner ways required much more refactoring so I didn't want to do that (as maybe you don't think that such thing is needed (possibility to report on either list or element annotation)).

I think that for this particular case it will be more suitable to report an error on List annotation rather than on the list element. 

But this got me thinking more - we do have other tests with list annotations and they are working just fine. So why would this one behave like that ? The only difference that I've found is that in other cases list annotations are using arrays to declare list elements. And when I changed `MixDirectAnnotationAndListContainerAnnotation` to do the same - it helped 
```
@Length.List(
		{ @Length(min = 45) }
)
```
instead of 
```
@Length.List(@Length(min = 45))
```

the error is reported on correct line (well on the line where the list element is located)

So maybe we would not need to support "multiple error lines" ...