### PR TITLE
HV-1320 Replace <iterable element> by <list element> in the node path of Lists

### DIFF
--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter02/typeargument/list/CarTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter02/typeargument/list/CarTest.java
@@ -39,7 +39,7 @@ public class CarTest {
 				"'null' is not a valid car part.",
 				constraintViolations.iterator().next().getMessage()
 		);
-		assertEquals( "parts[1].<iterable element>",
+		assertEquals( "parts[1].<list element>",
 				constraintViolations.iterator().next().getPropertyPath().toString() );
 		//end::validateListTypeArgumentConstraint[]
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LegacyListValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/LegacyListValueExtractor.java
@@ -25,7 +25,7 @@ class LegacyListValueExtractor implements ValueExtractor<@ExtractedValue List<?>
 		receiver.value( null, originalValue );
 
 		for ( int i = 0; i < originalValue.size(); i++ ) {
-			receiver.indexedValue( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, i, originalValue.get( i ) );
+			receiver.indexedValue( NodeImpl.LIST_ELEMENT_NODE_NAME, i, originalValue.get( i ) );
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ListPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ListPropertyValueExtractor.java
@@ -35,7 +35,7 @@ public class ListPropertyValueExtractor implements ValueExtractor<ListProperty<@
 	@Override
 	public void extractValues(ListProperty<?> originalValue, ValueExtractor.ValueReceiver receiver) {
 		for ( int i = 0; i < originalValue.size(); i++ ) {
-			receiver.indexedValue( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, i, originalValue.get( i ) );
+			receiver.indexedValue( NodeImpl.LIST_ELEMENT_NODE_NAME, i, originalValue.get( i ) );
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ListValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ListValueExtractor.java
@@ -23,7 +23,7 @@ class ListValueExtractor implements ValueExtractor<List<@ExtractedValue ?>> {
 	@Override
 	public void extractValues(List<?> originalValue, ValueReceiver receiver) {
 		for ( int i = 0; i < originalValue.size(); i++ ) {
-			receiver.indexedValue( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, i, originalValue.get( i ) );
+			receiver.indexedValue( NodeImpl.LIST_ELEMENT_NODE_NAME, i, originalValue.get( i ) );
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ReadOnlyListPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/cascading/ReadOnlyListPropertyValueExtractor.java
@@ -35,7 +35,7 @@ public class ReadOnlyListPropertyValueExtractor implements ValueExtractor<ReadOn
 	@Override
 	public void extractValues(ReadOnlyListProperty<?> originalValue, ValueExtractor.ValueReceiver receiver) {
 		for ( int i = 0; i < originalValue.size(); i++ ) {
-			receiver.indexedValue( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, i, originalValue.get( i ) );
+			receiver.indexedValue( NodeImpl.LIST_ELEMENT_NODE_NAME, i, originalValue.get( i ) );
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
@@ -50,6 +50,7 @@ public class NodeImpl
 	public static final String RETURN_VALUE_NODE_NAME = "<return value>";
 	public static final String CROSS_PARAMETER_NODE_NAME = "<cross-parameter>";
 	public static final String ITERABLE_ELEMENT_NODE_NAME = "<iterable element>";
+	public static final String LIST_ELEMENT_NODE_NAME = "<list element>";
 	public static final String MAP_KEY_NODE_NAME = "<map key>";
 	public static final String MAP_VALUE_NODE_NAME = "<map value>";
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/NestedCascadedConstraintsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/NestedCascadedConstraintsTest.java
@@ -82,7 +82,7 @@ public class NestedCascadedConstraintsTest {
 				constraintViolations,
 				"map[Optional[Cinema<cinema2>]].<map value>[1].email",
 				"map[Optional[Cinema<cinema2>]].<map value>[2].email",
-				"map[Optional[Cinema<cinema3>]].<map value>[0].<iterable element>"
+				"map[Optional[Cinema<cinema3>]].<map value>[0].<list element>"
 		);
 		assertCorrectConstraintTypes( constraintViolations, Email.class, Email.class, NotNull.class );
 		assertThat( constraintViolations ).containsOnlyPaths(
@@ -97,7 +97,7 @@ public class NestedCascadedConstraintsTest {
 				pathWith()
 						.property( "map" )
 						.containerElement( NodeImpl.MAP_VALUE_NODE_NAME, true, invalidCinemaEmailAddresses.map.keySet().toArray()[2], null, Map.class, 1 )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 )
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 )
 		);
 
 		CinemaEmailAddresses invalidKeyCinemaEmailAddresses = CinemaEmailAddresses.invalidKey();
@@ -133,7 +133,7 @@ public class NestedCascadedConstraintsTest {
 
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"array[0].<iterable element>[0].<iterable element>",
+				"array[0].<iterable element>[0].<list element>",
 				"array[0].<iterable element>[1].visitor.name"
 		);
 		assertCorrectConstraintTypes( constraintViolations, NotNull.class, NotNull.class );
@@ -141,7 +141,7 @@ public class NestedCascadedConstraintsTest {
 				pathWith()
 						.property( "array" )
 						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 0, Object[].class, null )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 ),
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 ),
 				pathWith()
 						.property( "array" )
 						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 0, Object[].class, null )

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/SameElementContainedSeveralTimesInCollectionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/SameElementContainedSeveralTimesInCollectionTest.java
@@ -44,7 +44,7 @@ public class SameElementContainedSeveralTimesInCollectionTest {
 
 		Set<ConstraintViolation<ListContainer>> constraintViolations = validator.validate( listContainer );
 
-		assertCorrectPropertyPaths( constraintViolations, "values[0].<iterable element>", "values[2].<iterable element>" );
+		assertCorrectPropertyPaths( constraintViolations, "values[0].<list element>", "values[2].<list element>" );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/TypeAnnotationConstraintTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/TypeAnnotationConstraintTest.java
@@ -78,7 +78,7 @@ public class TypeAnnotationConstraintTest {
 
 		Set<ConstraintViolation<TypeWithList1>> constraintViolations = validator.validate( l );
 
-		assertCorrectPropertyPaths( constraintViolations, "names[1].<iterable element>", "names[2].<iterable element>", "names[2].<iterable element>" );
+		assertCorrectPropertyPaths( constraintViolations, "names[1].<list element>", "names[2].<list element>", "names[2].<list element>" );
 		assertCorrectConstraintTypes(
 				constraintViolations,
 				NotBlank.class,
@@ -93,7 +93,7 @@ public class TypeAnnotationConstraintTest {
 		l.bars = Arrays.asList( new Bar( 2 ), null );
 		Set<ConstraintViolation<TypeWithList3>> constraintViolations = validator.validate( l );
 		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectPropertyPaths( constraintViolations, "bars[1].<iterable element>", "bars[0].number" );
+		assertCorrectPropertyPaths( constraintViolations, "bars[1].<list element>", "bars[0].number" );
 		assertCorrectConstraintTypes( constraintViolations, Min.class, NotNull.class );
 	}
 
@@ -104,7 +104,7 @@ public class TypeAnnotationConstraintTest {
 		l.names = Arrays.asList( "First", "", null );
 		Set<ConstraintViolation<TypeWithList4>> constraintViolations = validator.validate( l );
 		assertNumberOfViolations( constraintViolations, 2 );
-		assertCorrectPropertyPaths( constraintViolations, "names[1].<iterable element>", "names[2].<iterable element>" );
+		assertCorrectPropertyPaths( constraintViolations, "names[1].<list element>", "names[2].<list element>" );
 		assertCorrectConstraintTypes( constraintViolations, NotBlank.class, NotBlank.class );
 
 		l = new TypeWithList4();
@@ -123,7 +123,7 @@ public class TypeAnnotationConstraintTest {
 		Set<ConstraintViolation<TypeWithList5>> constraintViolations = validator.validate( l );
 
 		assertNumberOfViolations( constraintViolations, 3 );
-		assertCorrectPropertyPaths( constraintViolations, "strings[0].<iterable element>", "strings[2].<iterable element>", "strings[2].<iterable element>" );
+		assertCorrectPropertyPaths( constraintViolations, "strings[0].<list element>", "strings[2].<list element>", "strings[2].<list element>" );
 		assertCorrectConstraintTypes(
 				constraintViolations,
 				NotBlank.class,
@@ -143,9 +143,9 @@ public class TypeAnnotationConstraintTest {
 		assertNumberOfViolations( constraintViolations, 3 );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"returnStrings.<return value>[1].<iterable element>",
-				"returnStrings.<return value>[2].<iterable element>",
-				"returnStrings.<return value>[2].<iterable element>"
+				"returnStrings.<return value>[1].<list element>",
+				"returnStrings.<return value>[2].<list element>",
+				"returnStrings.<return value>[2].<list element>"
 		);
 		assertCorrectConstraintTypes(
 				constraintViolations,
@@ -168,7 +168,7 @@ public class TypeAnnotationConstraintTest {
 		assertThat( constraintViolations ).containsOnlyPaths(
 				pathWith()
 						.property( "names" )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 )
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 )
 		);
 	}
 
@@ -185,9 +185,9 @@ public class TypeAnnotationConstraintTest {
 		assertNumberOfViolations( constraintViolations, 3 );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"setValues.listParameter[0].<iterable element>",
-				"setValues.listParameter[2].<iterable element>",
-				"setValues.listParameter[2].<iterable element>"
+				"setValues.listParameter[0].<list element>",
+				"setValues.listParameter[2].<list element>",
+				"setValues.listParameter[2].<list element>"
 		);
 		assertCorrectConstraintTypes(
 				constraintViolations,
@@ -209,9 +209,9 @@ public class TypeAnnotationConstraintTest {
 		assertNumberOfViolations( constraintViolations, 3 );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"TypeWithList8.listParameter[0].<iterable element>",
-				"TypeWithList8.listParameter[2].<iterable element>",
-				"TypeWithList8.listParameter[2].<iterable element>"
+				"TypeWithList8.listParameter[0].<list element>",
+				"TypeWithList8.listParameter[2].<list element>",
+				"TypeWithList8.listParameter[2].<list element>"
 		);
 		assertCorrectConstraintTypes(
 				constraintViolations,

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/JavaFXValueExtractorsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/JavaFXValueExtractorsTest.java
@@ -24,7 +24,6 @@ import javax.validation.constraints.Size;
 import javax.validation.valueextraction.Unwrapping;
 import javax.validation.valueextraction.ValueExtractor;
 
-import org.hibernate.validator.internal.engine.path.NodeImpl;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -89,7 +88,7 @@ public class JavaFXValueExtractorsTest {
 		assertCorrectConstraintTypes( constraintViolations, Size.class );
 
 		constraintViolations = validator.validate( ListPropertyEntity.invalidListElement() );
-		assertCorrectPropertyPaths( constraintViolations, "listProperty[0]." + NodeImpl.ITERABLE_ELEMENT_NODE_NAME );
+		assertCorrectPropertyPaths( constraintViolations, "listProperty[0].<list element>" );
 		assertCorrectConstraintTypes( constraintViolations, Size.class );
 	}
 
@@ -103,7 +102,7 @@ public class JavaFXValueExtractorsTest {
 		assertCorrectConstraintTypes( constraintViolations, Size.class );
 
 		constraintViolations = validator.validate( SetPropertyEntity.invalidSetElement() );
-		assertCorrectPropertyPaths( constraintViolations, "setProperty[]." + NodeImpl.ITERABLE_ELEMENT_NODE_NAME );
+		assertCorrectPropertyPaths( constraintViolations, "setProperty[].<iterable element>" );
 		assertCorrectConstraintTypes( constraintViolations, Size.class );
 	}
 
@@ -117,11 +116,11 @@ public class JavaFXValueExtractorsTest {
 		assertCorrectConstraintTypes( constraintViolations, Size.class );
 
 		constraintViolations = validator.validate( MapPropertyEntity.invalidMapKey() );
-		assertCorrectPropertyPaths( constraintViolations, "mapProperty<K>[app]." + NodeImpl.MAP_KEY_NODE_NAME );
+		assertCorrectPropertyPaths( constraintViolations, "mapProperty<K>[app].<map key>" );
 		assertCorrectConstraintTypes( constraintViolations, Size.class );
 
 		constraintViolations = validator.validate( MapPropertyEntity.invalidMapValue() );
-		assertCorrectPropertyPaths( constraintViolations, "mapProperty[pear]." + NodeImpl.MAP_VALUE_NODE_NAME );
+		assertCorrectPropertyPaths( constraintViolations, "mapProperty[pear].<map value>" );
 		assertCorrectConstraintTypes( constraintViolations, Email.class );
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/NestedTypeArgumentsValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/NestedTypeArgumentsValueExtractorTest.java
@@ -76,18 +76,18 @@ public class NestedTypeArgumentsValueExtractorTest {
 		constraintViolations = validator.validate( MapOfLists.invalidString() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[key1].<map value>[0].<iterable element>",
-				"map[key1].<map value>[1].<iterable element>" );
+				"map[key1].<map value>[0].<list element>",
+				"map[key1].<map value>[1].<list element>" );
 		assertCorrectConstraintTypes( constraintViolations, Size.class, Size.class );
 		assertThat( constraintViolations ).containsOnlyPaths(
 				pathWith()
 						.property( "map" )
 						.containerElement( NodeImpl.MAP_VALUE_NODE_NAME, true, "key1", null, Map.class, 1 )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 ),
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 ),
 				pathWith()
 						.property( "map" )
 						.containerElement( NodeImpl.MAP_VALUE_NODE_NAME, true, "key1", null, Map.class, 1 )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 1, List.class, 0 )
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 1, List.class, 0 )
 		);
 
 		constraintViolations = validator.validate( MapOfLists.reallyInvalid() );
@@ -95,7 +95,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 				constraintViolations,
 				"map<K>[k].<map key>",
 				"map[k].<map value>",
-				"map[k].<map value>[0].<iterable element>" );
+				"map[k].<map value>[0].<list element>" );
 		assertCorrectConstraintTypes( constraintViolations, Size.class, Size.class, Size.class );
 		assertThat( constraintViolations ).containsOnlyPaths(
 				pathWith()
@@ -107,7 +107,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 				pathWith()
 						.property( "map" )
 						.containerElement( NodeImpl.MAP_VALUE_NODE_NAME, true, "k", null, Map.class, 1 )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 )
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 )
 		);
 	}
 
@@ -119,23 +119,23 @@ public class NestedTypeArgumentsValueExtractorTest {
 		constraintViolations = validator.validate( MapOfListsWithAutomaticUnwrapping.invalidStringProperty() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[key].<map value>[1].<iterable element>" );
+				"map[key].<map value>[1].<list element>" );
 		assertThat( constraintViolations ).containsOnlyPaths(
 				pathWith()
 						.property( "map" )
 						.containerElement( NodeImpl.MAP_VALUE_NODE_NAME, true, "key", null, Map.class, 1 )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 1, List.class, 0 )
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 1, List.class, 0 )
 		);
 
 		constraintViolations = validator.validate( MapOfListsWithAutomaticUnwrapping.invalidListElement() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[key].<map value>[0].<iterable element>" );
+				"map[key].<map value>[0].<list element>" );
 		assertThat( constraintViolations ).containsOnlyPaths(
 				pathWith()
 						.property( "map" )
 						.containerElement( NodeImpl.MAP_VALUE_NODE_NAME, true, "key", null, Map.class, 1 )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 )
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 )
 		);
 	}
 
@@ -164,18 +164,18 @@ public class NestedTypeArgumentsValueExtractorTest {
 		Set<ConstraintViolation<MapOfListsUsingGetter>> constraintViolations = validator.validate( MapOfListsUsingGetter.invalidString() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[key1].<map value>[0].<iterable element>",
-				"map[key1].<map value>[1].<iterable element>" );
+				"map[key1].<map value>[0].<list element>",
+				"map[key1].<map value>[1].<list element>" );
 		assertCorrectConstraintTypes( constraintViolations, Size.class, Size.class );
 		assertThat( constraintViolations ).containsOnlyPaths(
 				pathWith()
 						.property( "map" )
 						.containerElement( NodeImpl.MAP_VALUE_NODE_NAME, true, "key1", null, Map.class, 1 )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 ),
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 ),
 				pathWith()
 						.property( "map" )
 						.containerElement( NodeImpl.MAP_VALUE_NODE_NAME, true, "key1", null, Map.class, 1 )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 1, List.class, 0 )
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 1, List.class, 0 )
 		);
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/PropertyPathAndStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/PropertyPathAndStringRepresentationTest.java
@@ -187,12 +187,12 @@ public class PropertyPathAndStringRepresentationTest {
 
 		Set<ConstraintViolation<Block>> constraintViolations = validator.validate( block );
 
-		assertCorrectPropertyPaths( constraintViolations, "addresses[0].<iterable element>" );
+		assertCorrectPropertyPaths( constraintViolations, "addresses[0].<list element>" );
 		assertCorrectConstraintTypes( constraintViolations, NotNull.class );
 		assertThat( constraintViolations ).containsOnlyPaths(
 				pathWith()
 						.property( "addresses" )
-						.containerElement( NodeImpl.ITERABLE_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 )
+						.containerElement( NodeImpl.LIST_ELEMENT_NODE_NAME, true, null, 0, List.class, 0 )
 		);
 	}
 


### PR DESCRIPTION
In passing, be consistent in the tests: when we test the property path,
we don't use the constants so that it is more readable and we have a
clear vision of the obtained property path.

 * https://hibernate.atlassian.net/browse/HV-1320