### PR TITLE
HV-1307 SafeHtmlDef programmatic API should not use annotation proxies

### DIFF
--- a/documentation/src/main/asciidoc/ch02.asciidoc
+++ b/documentation/src/main/asciidoc/ch02.asciidoc
@@ -598,7 +598,7 @@ With one exception also these constraints apply to the field/property level, onl
 	Supported data types::: `BigDecimal`, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types
 	Hibernate metadata impact::: None
 
-`@SafeHtml(whitelistType= , additionalTags=, additionalTagsWithAttributes=, baseURI=)`:: Checks whether the annotated value contains potentially malicious fragments such as `<script/>`. In order to use this constraint, the http://jsoup.org/[jsoup] library must be part of the class path. With the `whitelistType` attribute a predefined whitelist type can be chosen which can be refined via `additionalTags` or `additionalTagsWithAttributes`. The former allows to add tags without any attributes, whereas the latter allows to specify tags and optionally allowed attributes using the annotation `@SafeHtml.Tag`.
+`@SafeHtml(whitelistType= , additionalTags=, additionalTagsWithAttributes=, baseURI=)`:: Checks whether the annotated value contains potentially malicious fragments such as `<script/>`. In order to use this constraint, the http://jsoup.org/[jsoup] library must be part of the class path. With the `whitelistType` attribute a predefined whitelist type can be chosen which can be refined via `additionalTags` or `additionalTagsWithAttributes`. The former allows to add tags without any attributes, whereas the latter allows to specify tags and optionally allowed attributes, as well as additional protocols for parameters of those attributes using the annotation `@SafeHtml.Tag`.
 In addition, `baseURI` allows to specify the base URI used to resolve relative URIs.
 	Supported data types::: `CharSequence`
 	Hibernate metadata impact::: None

--- a/documentation/src/main/asciidoc/ch02.asciidoc
+++ b/documentation/src/main/asciidoc/ch02.asciidoc
@@ -598,7 +598,7 @@ With one exception also these constraints apply to the field/property level, onl
 	Supported data types::: `BigDecimal`, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types
 	Hibernate metadata impact::: None
 
-`@SafeHtml(whitelistType= , additionalTags=, additionalTagsWithAttributes=, baseURI=)`:: Checks whether the annotated value contains potentially malicious fragments such as `<script/>`. In order to use this constraint, the http://jsoup.org/[jsoup] library must be part of the class path. With the `whitelistType` attribute a predefined whitelist type can be chosen which can be refined via `additionalTags` or `additionalTagsWithAttributes`. The former allows to add tags without any attributes, whereas the latter allows to specify tags and optionally allowed attributes, as well as additional protocols for parameters of those attributes using the annotation `@SafeHtml.Tag`.
+`@SafeHtml(whitelistType= , additionalTags=, additionalTagsWithAttributes=, baseURI=)`:: Checks whether the annotated value contains potentially malicious fragments such as `<script/>`. In order to use this constraint, the http://jsoup.org/[jsoup] library must be part of the class path. With the `whitelistType` attribute a predefined whitelist type can be chosen which can be refined via `additionalTags` or `additionalTagsWithAttributes`. The former allows to add tags without any attributes, whereas the latter allows to specify tags and optionally allowed attributes as well as accepted protocols for the attributes using the annotation `@SafeHtml.Tag`.
 In addition, `baseURI` allows to specify the base URI used to resolve relative URIs.
 	Supported data types::: `CharSequence`
 	Hibernate metadata impact::: None

--- a/engine/src/main/java/org/hibernate/validator/cfg/AnnotationDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/AnnotationDef.java
@@ -132,10 +132,12 @@ public abstract class AnnotationDef<C extends AnnotationDef<C, A>, A extends Ann
 		}
 	}
 
+	@SuppressWarnings("unchecked")
 	private <T> T[] toAnnotationParameterArray(List<AnnotationDef<?, ?>> list, Class<T> aClass) {
 		return list.stream().map( AnnotationDef::createAnnotationProxy ).toArray( n -> (T[]) Array.newInstance( aClass, n ) );
 	}
 
+	@SuppressWarnings("unchecked")
 	protected <T> T toAnnotationParameter(AnnotationDef<?, ?> annotationDef, Class<T> aClass) {
 		return (T) annotationDef.createAnnotationProxy();
 	}

--- a/engine/src/main/java/org/hibernate/validator/cfg/AnnotationDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/AnnotationDef.java
@@ -1,0 +1,152 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.cfg;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.internal.util.StringHelper;
+import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor;
+import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory;
+import org.hibernate.validator.internal.util.logging.Log;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
+
+/**
+ * Base class for all annotation definition types.
+ *
+ * @param <C> The type of a concrete sub type. Following to the
+ * "self referencing generic type" pattern each sub type has to be
+ * parametrized with itself.
+ * @param <A> The constraint annotation type represented by a concrete sub type.
+ *
+ * @author Hardy Ferentschik
+ * @author Gunnar Morling
+ * @author Marko Bekhta
+ */
+public abstract class AnnotationDef<C extends AnnotationDef<C, A>, A extends Annotation> {
+
+	private static final Log LOG = LoggerFactory.make();
+
+	// Note on visibility of members: These members are intentionally made
+	// protected and published by a sub-class for internal use. There aren't
+	// public getters as they would pollute the fluent definition API.
+
+	/**
+	 * The constraint annotation type of this definition.
+	 */
+	protected final Class<A> annotationType;
+
+	/**
+	 * A map with the annotation parameters of this definition. Contains only parameters
+	 * of non annotation types. Keys are property names of this definition's annotation
+	 * type, values are annotation parameter values of the appropriate types.
+	 */
+	protected final Map<String, Object> parameters;
+
+	/**
+	 * A map with annotation parameters of this definition which are annotations
+	 * on their own. Keys are property names of this definition's annotation
+	 * type, values are annotation parameter values of the appropriate annotation
+	 * types described via {@link AnnotationDef}. If an array of annotations is
+	 * needed it should be represented via {@link java.util.List} of corresponding
+	 * {@link AnnotationDef}s.
+	 */
+	protected final Map<String, List<AnnotationDef<?, ?>>> annotationsAsParameters;
+
+	/**
+	 * A map of annotation types that are added to {@link AnnotationDef#annotationsAsParameters}.
+	 * For the same key form {@link AnnotationDef#annotationsAsParameters} you'll get an annotation
+	 * type represented by corresponding {@link AnnotationDef}
+	 */
+	private final Map<String, Class<?>> annotationsAsParametersTypes;
+
+	protected AnnotationDef(Class<A> annotationType) {
+		this.annotationType = annotationType;
+		this.parameters = new HashMap<>();
+		this.annotationsAsParameters = new HashMap<>();
+		this.annotationsAsParametersTypes = new HashMap<>();
+	}
+
+	protected AnnotationDef(AnnotationDef<?, A> original) {
+		this.annotationType = original.annotationType;
+		this.parameters = original.parameters;
+		this.annotationsAsParameters = original.annotationsAsParameters;
+		this.annotationsAsParametersTypes = original.annotationsAsParametersTypes;
+	}
+
+	@SuppressWarnings("unchecked")
+	private C getThis() {
+		return (C) this;
+	}
+
+	protected C addParameter(String key, Object value) {
+		parameters.put( key, value );
+		return getThis();
+	}
+
+	protected C addAnnotationAsParameter(String key, AnnotationDef<?, ?> value) {
+		annotationsAsParameters.compute( key, ( k, oldValue ) -> {
+			if ( oldValue == null ) {
+				return Arrays.asList( value );
+			}
+			else {
+				List<AnnotationDef<?, ?>> resultingList = CollectionHelper.newArrayList( oldValue );
+				resultingList.add( value );
+				return resultingList;
+			}
+		} );
+		annotationsAsParametersTypes.putIfAbsent( key, value.annotationType );
+		return getThis();
+	}
+
+	protected A createAnnotationProxy() {
+		AnnotationDescriptor<A> annotationDescriptor = new AnnotationDescriptor<>( annotationType );
+		for ( Map.Entry<String, Object> parameter : parameters.entrySet() ) {
+			annotationDescriptor.setValue( parameter.getKey(), parameter.getValue() );
+		}
+
+		for ( Map.Entry<String, List<AnnotationDef<?, ?>>> annotationAsParameter : annotationsAsParameters.entrySet() ) {
+			annotationDescriptor.setValue(
+					annotationAsParameter.getKey(),
+							toAnnotationParameterArray(
+									annotationAsParameter.getValue(),
+									annotationsAsParametersTypes.get( annotationAsParameter.getKey() )
+							)
+			);
+		}
+
+		try {
+			return AnnotationFactory.create( annotationDescriptor );
+		}
+		catch (RuntimeException e) {
+			throw LOG.getUnableToCreateAnnotationForConfiguredConstraintException( e );
+		}
+	}
+
+	private <T> T[] toAnnotationParameterArray(List<AnnotationDef<?, ?>> list, Class<T> aClass) {
+		return list.stream().map( AnnotationDef::createAnnotationProxy ).toArray( n -> (T[]) Array.newInstance( aClass, n ) );
+	}
+
+	protected <T> T toAnnotationParameter(AnnotationDef<?, ?> annotationDef, Class<T> aClass) {
+		return (T) annotationDef.createAnnotationProxy();
+	}
+
+	@Override
+	public String toString() {
+		final StringBuilder sb = new StringBuilder();
+		sb.append( this.getClass().getName() );
+		sb.append( ", annotationType=" ).append( StringHelper.toShortString( annotationType ) );
+		sb.append( ", parameters=" ).append( parameters );
+		sb.append( '}' );
+		return sb.toString();
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/cfg/ConstraintDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/ConstraintDef.java
@@ -7,8 +7,6 @@
 package org.hibernate.validator.cfg;
 
 import java.lang.annotation.Annotation;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.validation.Payload;
 
@@ -28,42 +26,19 @@ import org.hibernate.validator.internal.util.StringHelper;
  * @author Hardy Ferentschik
  * @author Gunnar Morling
  */
-public abstract class ConstraintDef<C extends ConstraintDef<C, A>, A extends Annotation> {
-
-	// Note on visibility of members: These members are intentionally made
-	// protected and published by a sub-class for internal use. There aren't
-	// public getters as they would pollute the fluent definition API.
-
-	/**
-	 * The constraint annotation type of this definition.
-	 */
-	protected final Class<A> constraintType;
-
-	/**
-	 * A map with the annotation parameters of this definition. Keys are
-	 * property names of this definition's annotation type, values are
-	 * annotation parameter values of the appropriate types.
-	 */
-	protected final Map<String, Object> parameters;
+public abstract class ConstraintDef<C extends ConstraintDef<C, A>, A extends Annotation> extends AnnotationDef<C, A> {
 
 	protected ConstraintDef(Class<A> constraintType) {
-		this.constraintType = constraintType;
-		this.parameters = new HashMap<>();
+		super( constraintType );
 	}
 
 	protected ConstraintDef(ConstraintDef<?, A> original) {
-		this.constraintType = original.constraintType;
-		this.parameters = original.parameters;
+		super( original );
 	}
 
 	@SuppressWarnings("unchecked")
 	private C getThis() {
 		return (C) this;
-	}
-
-	protected C addParameter(String key, Object value) {
-		parameters.put( key, value );
-		return getThis();
 	}
 
 	public C message(String message) {
@@ -86,7 +61,7 @@ public abstract class ConstraintDef<C extends ConstraintDef<C, A>, A extends Ann
 	public String toString() {
 		final StringBuilder sb = new StringBuilder();
 		sb.append( this.getClass().getName() );
-		sb.append( ", constraintType=" ).append( StringHelper.toShortString( constraintType ) );
+		sb.append( ", constraintType=" ).append( StringHelper.toShortString( annotationType ) );
 		sb.append( ", parameters=" ).append( parameters );
 		sb.append( '}' );
 		return sb.toString();

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/SafeHtmlDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/SafeHtmlDef.java
@@ -6,16 +6,32 @@
  */
 package org.hibernate.validator.cfg.defs;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.SafeHtml;
+import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor;
+import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory;
 
 /**
  * @author Marko Bekta
  */
 public class SafeHtmlDef extends ConstraintDef<SafeHtmlDef, SafeHtml> {
 
+	private final Set<TagWithAttributes> tags;
+
 	public SafeHtmlDef() {
 		super( SafeHtml.class );
+		tags = CollectionHelper.newHashSet();
+	}
+
+	private SafeHtmlDef(ConstraintDef<?, SafeHtml> original) {
+		super( original );
+		tags = CollectionHelper.newHashSet();
 	}
 
 	public SafeHtmlDef whitelistType(SafeHtml.WhiteListType whitelistType) {
@@ -28,6 +44,10 @@ public class SafeHtmlDef extends ConstraintDef<SafeHtmlDef, SafeHtml> {
 		return this;
 	}
 
+	/**
+	 * @deprecated Use {@link SafeHtmlDef#additionalTag(String)} instead.
+	 */
+	@Deprecated
 	public SafeHtmlDef additionalTagsWithAttributes(SafeHtml.Tag... additionalTagsWithAttributes) {
 		addParameter( "additionalTagsWithAttributes", additionalTagsWithAttributes );
 		return this;
@@ -38,4 +58,123 @@ public class SafeHtmlDef extends ConstraintDef<SafeHtmlDef, SafeHtml> {
 		return this;
 	}
 
+	public SafeHtmlTagDef additionalTag(String tag) {
+		return new SafeHtmlTagDef( tag, this );
+	}
+
+	public class SafeHtmlTagDef extends SafeHtmlDef {
+		private final TagWithAttributes tag;
+
+		public SafeHtmlTagDef(String tag, SafeHtmlDef safeHtmlDef) {
+			super( safeHtmlDef );
+			this.tag = new TagWithAttributes( tag );
+			SafeHtmlDef.this.tags.add( this.tag );
+		}
+
+		public SafeHtmlTagDef(TagWithAttributes tag, SafeHtmlDef safeHtmlDef) {
+			super( safeHtmlDef );
+			this.tag = tag;
+		}
+
+		public SafeHtmlTagWithAttributeDef attribute(String attribute) {
+			tag.getSimpleAttributes().add( attribute );
+			updateDef();
+			return new SafeHtmlTagWithAttributeDef( tag, attribute, this );
+		}
+
+		public SafeHtmlTagDef attributes(String... attributes) {
+			tag.getSimpleAttributes().addAll( Stream.of( attributes ).collect( Collectors.toSet() ) );
+			updateDef();
+			return this;
+		}
+
+		public class SafeHtmlTagWithAttributeDef extends SafeHtmlTagDef {
+
+			private final Attribute attribute;
+
+			public SafeHtmlTagWithAttributeDef(TagWithAttributes tag, String attribute, SafeHtmlDef safeHtmlDef) {
+				super( tag, safeHtmlDef );
+				this.attribute = new Attribute( attribute );
+				tag.getAttributes().add( this.attribute );
+			}
+
+			public SafeHtmlTagWithAttributeDef protocol(String protocol) {
+				attribute.getProtocols().add( protocol );
+				updateDef();
+				return this;
+			}
+
+			public SafeHtmlTagWithAttributeDef protocols(String... protocols) {
+				attribute.getProtocols().addAll( Stream.of( protocols ).collect( Collectors.toSet() ) );
+				updateDef();
+				return this;
+			}
+
+		}
+	}
+
+	private void updateDef() {
+		addParameter( "additionalTagsWithAttributes", SafeHtmlDef.this.tags.stream().map( TagWithAttributes::toTagAnnotationProxy )
+				.toArray( n -> new SafeHtml.Tag[n] ) );
+	}
+
+	private static class TagWithAttributes {
+		private final String name;
+		private final Set<String> simpleAttributes;
+		private final List<Attribute> attributes;
+
+		public TagWithAttributes(String name) {
+			this.name = name;
+			simpleAttributes = CollectionHelper.newHashSet();
+			attributes = CollectionHelper.newArrayList();
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Set<String> getSimpleAttributes() {
+			return simpleAttributes;
+		}
+
+		public List<Attribute> getAttributes() {
+			return attributes;
+		}
+
+		public SafeHtml.Tag toTagAnnotationProxy() {
+			AnnotationDescriptor<SafeHtml.Tag> tagDescriptor = new AnnotationDescriptor( SafeHtml.Tag.class );
+			tagDescriptor.setValue( "name", this.getName() );
+			tagDescriptor.setValue( "attributes", this.getSimpleAttributes().stream().toArray( n -> new String[n] ) );
+			tagDescriptor.setValue( "additionalAttributesWithProtocols", this.getAttributes()
+					.stream().map( Attribute::toAttributeAnnotationProxy ).toArray( n -> new SafeHtml.Tag.Attribute[n] ) );
+			return AnnotationFactory.create( tagDescriptor );
+		}
+
+	}
+
+	private static class Attribute {
+		private final String name;
+		private final Set<String> protocols;
+
+		public Attribute(String name, String... protocols) {
+			this.name = name;
+			this.protocols = Stream.of( protocols ).collect( Collectors.toSet() );
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Set<String> getProtocols() {
+			return protocols;
+		}
+
+		public SafeHtml.Tag.Attribute toAttributeAnnotationProxy() {
+			AnnotationDescriptor<SafeHtml.Tag.Attribute> attributeDescriptor = new AnnotationDescriptor( SafeHtml.Tag.Attribute.class );
+			attributeDescriptor.setValue( "name", this.getName() );
+			attributeDescriptor.setValue( "protocols", this.getProtocols()
+					.toArray( new String[this.getProtocols().size()] ) );
+			return AnnotationFactory.create( attributeDescriptor );
+		}
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/SafeHtmlDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/SafeHtmlDef.java
@@ -39,4 +39,3 @@ public class SafeHtmlDef extends ConstraintDef<SafeHtmlDef, SafeHtml> {
 	}
 
 }
-

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/SafeHtmlDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/SafeHtmlDef.java
@@ -51,7 +51,7 @@ public class SafeHtmlDef extends ConstraintDef<SafeHtmlDef, SafeHtml> {
 		return new SafeHtmlTagDef( tag, this );
 	}
 
-	public class SafeHtmlTagDef extends SafeHtmlDef {
+	public static class SafeHtmlTagDef extends SafeHtmlDef {
 
 		private final TagWithAttributes tag;
 
@@ -75,43 +75,34 @@ public class SafeHtmlDef extends ConstraintDef<SafeHtmlDef, SafeHtml> {
 			tag.addAttributes( attributes );
 			return this;
 		}
+	}
 
-		public class SafeHtmlTagWithAttributeDef extends SafeHtmlTagDef {
+	public static class SafeHtmlTagWithAttributeDef extends SafeHtmlTagDef {
 
-			private final Attribute attribute;
+		private final Attribute attribute;
 
-			public SafeHtmlTagWithAttributeDef(TagWithAttributes tag, String attribute, SafeHtmlDef safeHtmlDef) {
-				super( tag, safeHtmlDef );
-				this.attribute = new Attribute( attribute );
-				tag.addAdditionalAttributesWithProtocols( this.attribute );
-			}
+		public SafeHtmlTagWithAttributeDef(TagWithAttributes tag, String attribute, SafeHtmlDef safeHtmlDef) {
+			super( tag, safeHtmlDef );
+			this.attribute = new Attribute( attribute );
+			tag.addAdditionalAttributesWithProtocols( this.attribute );
+		}
 
-			public SafeHtmlTagWithAttributeDef protocol(String protocol) {
-				attribute.addProtocol( protocol );
-				return this;
-			}
+		public SafeHtmlTagWithAttributeDef protocol(String protocol) {
+			attribute.addProtocol( protocol );
+			return this;
+		}
 
-			public SafeHtmlTagWithAttributeDef protocols(String... protocols) {
-				attribute.addProtocols( protocols );
-				return this;
-			}
-
+		public SafeHtmlTagWithAttributeDef protocols(String... protocols) {
+			attribute.addProtocols( protocols );
+			return this;
 		}
 	}
 
 	private static class TagWithAttributes extends AnnotationDef<TagWithAttributes, SafeHtml.Tag> {
 
-		private final String name;
-
 		public TagWithAttributes(String name) {
 			super( SafeHtml.Tag.class );
-			this.name = name;
 			addParameter( "name", name );
-
-		}
-
-		public String getName() {
-			return name;
 		}
 
 		public TagWithAttributes addAttributes(String... attributes) {
@@ -123,7 +114,6 @@ public class SafeHtmlDef extends ConstraintDef<SafeHtmlDef, SafeHtml> {
 			addAnnotationAsParameter( "additionalAttributesWithProtocols", attribute );
 			return this;
 		}
-
 	}
 
 	private static class Attribute extends AnnotationDef<Attribute, SafeHtml.Tag.Attribute> {

--- a/engine/src/main/java/org/hibernate/validator/constraints/SafeHtml.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/SafeHtml.java
@@ -91,10 +91,29 @@ public @interface SafeHtml {
 		String[] attributes() default { };
 
 		/**
-		 * @return list of valid protocols.
+		 * @return list of tag attributes with corresponding allowed protocols which are whitelisted.
 		 * @since 6.0
 		 */
-		String[] protocols() default { };
+		Attribute[] additionalAttributesWithProtocols() default { };
+
+		/**
+		 * Allows to specify attribute with whitelisted protocols.
+		 * @since 6.0
+		 */
+		@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
+		@Retention(RUNTIME)
+		@Documented @interface Attribute {
+			/**
+			 * @return the attribute name to whitelist.
+			 */
+			String name();
+
+			/**
+			 * @return list of attribute protocols which are whitelisted.
+			 */
+			String[] protocols() default { };
+
+		}
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/constraints/SafeHtml.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/SafeHtml.java
@@ -60,7 +60,7 @@ public @interface SafeHtml {
 	String[] additionalTags() default { };
 
 	/**
-	 * @return Allows to specify additional whitelist tags with optional attributes.
+	 * @return Allows to specify additional whitelist tags with optional attributes and protocols.
 	 */
 	Tag[] additionalTagsWithAttributes() default { };
 
@@ -89,6 +89,12 @@ public @interface SafeHtml {
 		 * @return list of tag attributes which are whitelisted.
 		 */
 		String[] attributes() default { };
+
+		/**
+		 * @return list of valid protocols.
+		 * @since 6.0
+		 */
+		String[] protocols() default { };
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConfiguredConstraint.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConfiguredConstraint.java
@@ -14,15 +14,10 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
-import java.util.Map;
 
 import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.util.ExecutableHelper;
-import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor;
-import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory;
-import org.hibernate.validator.internal.util.logging.Log;
-import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
 /**
  * Represents a programmatically configured constraint and meta-data
@@ -31,8 +26,6 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
  * @author Gunnar Morling
  */
 class ConfiguredConstraint<A extends Annotation> {
-
-	private static final Log log = LoggerFactory.make();
 
 	private final ConstraintDefAccessor<A> constraint;
 	private final ConstraintLocation location;
@@ -99,27 +92,8 @@ class ConfiguredConstraint<A extends Annotation> {
 		return location;
 	}
 
-	public Class<A> getConstraintType() {
-		return constraint.getConstraintType();
-	}
-
-	public Map<String, Object> getParameters() {
-		return constraint.getParameters();
-	}
-
 	public A createAnnotationProxy() {
-
-		AnnotationDescriptor<A> annotationDescriptor = new AnnotationDescriptor<>( getConstraintType() );
-		for ( Map.Entry<String, Object> parameter : getParameters().entrySet() ) {
-			annotationDescriptor.setValue( parameter.getKey(), parameter.getValue() );
-		}
-
-		try {
-			return AnnotationFactory.create( annotationDescriptor );
-		}
-		catch (RuntimeException e) {
-			throw log.getUnableToCreateAnnotationForConfiguredConstraintException( e );
-		}
+		return constraint.createAnnotationProxy();
 	}
 
 	@Override
@@ -137,12 +111,9 @@ class ConfiguredConstraint<A extends Annotation> {
 			super( original );
 		}
 
-		private Class<A> getConstraintType() {
-			return constraintType;
-		}
-
-		private Map<String, Object> getParameters() {
-			return parameters;
+		@Override
+		protected A createAnnotationProxy() {
+			return super.createAnnotationProxy();
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java
@@ -57,6 +57,11 @@ public class SafeHtmlValidator implements ConstraintValidator<SafeHtml, CharSequ
 
 		for ( SafeHtml.Tag tag : safeHtmlAnnotation.additionalTagsWithAttributes() ) {
 			whitelist.addAttributes( tag.name(), tag.attributes() );
+			if ( tag.protocols().length > 0 ) {
+				for ( String attribute : tag.attributes() ) {
+					whitelist.addProtocols( tag.name(), attribute, tag.protocols() );
+				}
+			}
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java
@@ -56,10 +56,14 @@ public class SafeHtmlValidator implements ConstraintValidator<SafeHtml, CharSequ
 		whitelist.addTags( safeHtmlAnnotation.additionalTags() );
 
 		for ( SafeHtml.Tag tag : safeHtmlAnnotation.additionalTagsWithAttributes() ) {
-			whitelist.addAttributes( tag.name(), tag.attributes() );
-			if ( tag.protocols().length > 0 ) {
-				for ( String attribute : tag.attributes() ) {
-					whitelist.addProtocols( tag.name(), attribute, tag.protocols() );
+			whitelist.addTags( tag.name() );
+			if ( tag.attributes().length > 0 ) {
+				whitelist.addAttributes( tag.name(), tag.attributes() );
+			}
+			if ( tag.additionalAttributesWithProtocols().length > 0 ) {
+				for ( SafeHtml.Tag.Attribute attribute : tag.additionalAttributesWithProtocols() ) {
+					whitelist.addAttributes( tag.name(), attribute.name() );
+					whitelist.addProtocols( tag.name(), attribute.name(), attribute.protocols() );
 				}
 			}
 		}

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
@@ -85,6 +85,16 @@ public class ProgrammaticConstraintDefinitionsTest {
 
 		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
 				.additionalTagsWithAttributes( AnnotationFactory.create( tagDescriptor ) ), "<img src='data:image/png;base64,100101' />", 0 );
+		doProgrammaticTest(
+				new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+						.additionalTag( "img" ).attribute( "src" ).protocols( "data" ),
+				"<img src='data:image/png;base64,100101' />", 0
+		);
+		doProgrammaticTest(
+				new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+						.additionalTag( "td" ).attributes( "class", "id" ),
+				"<td class='class' id='tableId'>1234qwer</td>", 0
+		);
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
@@ -75,12 +75,16 @@ public class ProgrammaticConstraintDefinitionsTest {
 		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
 				.additionalTagsWithAttributes( AnnotationFactory.create( tagDescriptor ) ), "<td class='class' id='tableId'>1234qwer</td>", 0 );
 
-		AnnotationDescriptor<SafeHtml.Tag> protocolDescriptor = new AnnotationDescriptor( SafeHtml.Tag.class );
-		protocolDescriptor.setValue( "name", "img" );
-		protocolDescriptor.setValue( "attributes", new String[]{ "src" } );
-		protocolDescriptor.setValue( "protocols", new String[]{ "data" } );
+		AnnotationDescriptor<SafeHtml.Tag.Attribute> attributeDescriptor = new AnnotationDescriptor( SafeHtml.Tag.Attribute.class );
+		attributeDescriptor.setValue( "name",  "src"  );
+		attributeDescriptor.setValue( "protocols", new String[]{ "data" } );
+
+		tagDescriptor = new AnnotationDescriptor( SafeHtml.Tag.class );
+		tagDescriptor.setValue( "name", "img" );
+		tagDescriptor.setValue( "additionalAttributesWithProtocols", new SafeHtml.Tag.Attribute[]{ AnnotationFactory.create( attributeDescriptor ) } );
+
 		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
-				.additionalTagsWithAttributes( AnnotationFactory.create( protocolDescriptor ) ), "<img src='data:image/png;base64,100101' />", 0 );
+				.additionalTagsWithAttributes( AnnotationFactory.create( tagDescriptor ) ), "<img src='data:image/png;base64,100101' />", 0 );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
@@ -69,6 +69,33 @@ public class ProgrammaticConstraintDefinitionsTest {
 				"<img src='/some/relative/url/image.png' />", 0
 		);
 
+		doProgrammaticTest(
+				new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+						.additionalTag( "img" ).attribute( "src" ),
+				"<img src='data:image/png;base64,100101' />", 1
+		);
+		doProgrammaticTest(
+				new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+						.additionalTag( "img" ).attribute( "src" ).protocols( "data" ),
+				"<img src='data:image/png;base64,100101' />", 0
+		);
+		doProgrammaticTest(
+				new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+						.additionalTag( "img" ).attribute( "src" ).protocols( "data" ),
+				"<img src='not_data:image/png;base64,100101' />", 1
+		);
+		doProgrammaticTest(
+				new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+						.additionalTag( "td" ).attributes( "class", "id" ),
+				"<td class='class' id='tableId'>1234qwer</td>", 0
+		);
+		doProgrammaticTest(
+				new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+						.additionalTag( "td" ).attributes( "class", "id" ),
+				"<td class='class' id='tableId' otherAttribute='value'>1234qwer</td>", 1
+		);
+
+		// Deprecated, kept to ensure backwards compatibility (or at least ensure we are aware we break something if we decide to do so)
 		AnnotationDescriptor<SafeHtml.Tag> tagDescriptor = new AnnotationDescriptor( SafeHtml.Tag.class );
 		tagDescriptor.setValue( "name", "td" );
 		tagDescriptor.setValue( "attributes", new String[]{ "class", "id" } );
@@ -85,16 +112,6 @@ public class ProgrammaticConstraintDefinitionsTest {
 
 		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
 				.additionalTagsWithAttributes( AnnotationFactory.create( tagDescriptor ) ), "<img src='data:image/png;base64,100101' />", 0 );
-		doProgrammaticTest(
-				new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
-						.additionalTag( "img" ).attribute( "src" ).protocols( "data" ),
-				"<img src='data:image/png;base64,100101' />", 0
-		);
-		doProgrammaticTest(
-				new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
-						.additionalTag( "td" ).attributes( "class", "id" ),
-				"<td class='class' id='tableId'>1234qwer</td>", 0
-		);
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
@@ -33,6 +33,8 @@ import org.hibernate.validator.cfg.defs.pl.NIPDef;
 import org.hibernate.validator.cfg.defs.pl.PESELDef;
 import org.hibernate.validator.cfg.defs.pl.REGONDef;
 import org.hibernate.validator.constraints.SafeHtml;
+import org.hibernate.validator.internal.util.annotationfactory.AnnotationDescriptor;
+import org.hibernate.validator.internal.util.annotationfactory.AnnotationFactory;
 import org.hibernate.validator.testutil.PrefixableParameterNameProvider;
 
 import org.testng.annotations.Test;
@@ -66,6 +68,19 @@ public class ProgrammaticConstraintDefinitionsTest {
 		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.RELAXED ).baseURI( "http://localhost" ),
 				"<img src='/some/relative/url/image.png' />", 0
 		);
+
+		AnnotationDescriptor<SafeHtml.Tag> tagDescriptor = new AnnotationDescriptor( SafeHtml.Tag.class );
+		tagDescriptor.setValue( "name", "td" );
+		tagDescriptor.setValue( "attributes", new String[]{ "class", "id" } );
+		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+				.additionalTagsWithAttributes( AnnotationFactory.create( tagDescriptor ) ), "<td class='class' id='tableId'>1234qwer</td>", 0 );
+
+		AnnotationDescriptor<SafeHtml.Tag> protocolDescriptor = new AnnotationDescriptor( SafeHtml.Tag.class );
+		protocolDescriptor.setValue( "name", "img" );
+		protocolDescriptor.setValue( "attributes", new String[]{ "src" } );
+		protocolDescriptor.setValue( "protocols", new String[]{ "data" } );
+		doProgrammaticTest( new SafeHtmlDef().whitelistType( SafeHtml.WhiteListType.NONE )
+				.additionalTagsWithAttributes( AnnotationFactory.create( protocolDescriptor ) ), "<img src='data:image/png;base64,100101' />", 0 );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/SafeHtmlValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/SafeHtmlValidatorTest.java
@@ -166,13 +166,20 @@ public class SafeHtmlValidatorTest {
 		assertNumberOfViolations( validator.validate( new Bar( "<div src='data:image/png;base64,100101' />" ) ), 1 );
 		assertNumberOfViolations( validator.validate( new Bar(
 				"<custom>" +
-				"  <img src='data:image/png;base64,100101' />" +
-				"  <custom attr1='strange_protocol:some_text' />" +
-				"  <custom attr3='some_protocol:some_text' />" +
-				"  <custom><img /></custom>" +
-				"  <section id='sec1' attr='val'></section>" +
-				"  <custom attr1='dataprotocol:some_text' attr2='strange_protocol:some_text' />" +
-				"</custom>" ) ), 0 );
+						"  <img src='data:image/png;base64,100101' />" +
+						"  <custom attr1='strange_protocol:some_text' />" +
+						"  <custom attr3='some_protocol:some_text' />" +
+						"  <custom><img /></custom>" +
+						"  <section id='sec1' attr='val'></section>" +
+						"  <custom attr1='dataprotocol:some_text' attr2='strange_protocol:some_text' />" +
+						"</custom>" ) ), 0 );
+		assertNumberOfViolations( validator.validate( new Bar(
+				"<div>" +
+						"<img src='not_data:image/png;base64,100101' />" +
+						"<custom attr1='strange_protocol:some_text' />" +
+						"/<div>"
+
+		) ), 1 );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/SafeHtmlValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/SafeHtmlValidatorTest.java
@@ -166,12 +166,13 @@ public class SafeHtmlValidatorTest {
 		assertNumberOfViolations( validator.validate( new Bar( "<div src='data:image/png;base64,100101' />" ) ), 1 );
 		assertNumberOfViolations( validator.validate( new Bar(
 				"<custom>" +
-						"  <img src='data:image/png;base64,100101' />" +
-						"  <custom attr1='strange_protocol:some_text' />" +
-						"  <custom><img /></custom>" +
-						"  <section id='sec1' attr='val'></section>" +
-						"  <custom attr1='dataprotocol:some_text' attr2='strange_protocol:some_text' />" +
-						"</custom>" ) ), 0 );
+				"  <img src='data:image/png;base64,100101' />" +
+				"  <custom attr1='strange_protocol:some_text' />" +
+				"  <custom attr3='some_protocol:some_text' />" +
+				"  <custom><img /></custom>" +
+				"  <section id='sec1' attr='val'></section>" +
+				"  <custom attr1='dataprotocol:some_text' attr2='strange_protocol:some_text' />" +
+				"</custom>" ) ), 0 );
 	}
 
 	@Test
@@ -211,8 +212,12 @@ public class SafeHtmlValidatorTest {
 		@SafeHtml(
 				whitelistType = WhiteListType.BASIC,
 				additionalTagsWithAttributes = {
-						@SafeHtml.Tag(name = "img", attributes = "src", protocols = { "data" }),
-						@SafeHtml.Tag(name = "custom", attributes = { "attr1", "attr2" }, protocols = { "dataprotocol", "strange_protocol" }),
+						@SafeHtml.Tag(name = "img", additionalAttributesWithProtocols = @SafeHtml.Tag.Attribute(name = "src", protocols = { "data" })),
+						@SafeHtml.Tag(name = "custom", additionalAttributesWithProtocols = {
+								@SafeHtml.Tag.Attribute(name = "attr1", protocols = { "dataprotocol", "strange_protocol" }),
+								@SafeHtml.Tag.Attribute(name = "attr2", protocols = { "dataprotocol", "strange_protocol" }),
+								@SafeHtml.Tag.Attribute(name = "attr3", protocols = "some_protocol")
+						}),
 						@SafeHtml.Tag(name = "section", attributes = { "attr", "id" })
 				}
 		)


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1307

this one goes on top of HV-1302 as the corresponding changes to annotations are there.