### PR TITLE
HV-1327 Using custom numbering extension for examples and tables in documentation

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -202,6 +202,11 @@
                             <backend>html5</backend>
                             <outputDirectory>${asciidoctor.base-output-dir}/html_single</outputDirectory>
                             <sourceHighlighter>prettify</sourceHighlighter>
+                            <extensions>
+                                <extension>
+                                    <className>org.hibernate.infra.asciidoctor.extensions.customnumbering.CustomNumberingProcessor</className>
+                                </extension>
+                            </extensions>
                             <attributes>
                                 <stylesdir>css</stylesdir>
                                 <iconfont-remote>false</iconfont-remote>
@@ -247,6 +252,11 @@
                                     <backend>pdf</backend>
                                     <outputDirectory>${asciidoctor.base-output-dir}/pdf</outputDirectory>
                                     <sourceHighlighter>coderay</sourceHighlighter>
+                                    <extensions>
+                                        <extension>
+                                            <className>org.hibernate.infra.asciidoctor.extensions.customnumbering.CustomNumberingProcessor</className>
+                                        </extension>
+                                    </extensions>
                                     <attributes>
                                         <imagesDir>${asciidoctor.aggregated-resources-dir}/images/</imagesDir>
                                         <pdf-stylesdir>${asciidoctor.aggregated-resources-dir}/theme</pdf-stylesdir>

--- a/pom.xml
+++ b/pom.xml
@@ -153,10 +153,11 @@
 
         <!-- Asciidoctor -->
         <hibernate-asciidoctor-theme.version>1.0.1.Final</hibernate-asciidoctor-theme.version>
-        <asciidoctor-maven-plugin.version>1.5.3</asciidoctor-maven-plugin.version>
-        <jruby.version>1.7.26</jruby.version>
-        <asciidoctorj.version>1.5.4.1</asciidoctorj.version>
-        <asciidoctorj-pdf.version>1.5.0-alpha.11</asciidoctorj-pdf.version>
+        <hibernate-asciidoctor-extensions.version>1.0.1.Final</hibernate-asciidoctor-extensions.version>
+        <asciidoctor-maven-plugin.version>1.5.5</asciidoctor-maven-plugin.version>
+        <jruby.version>9.1.8.0</jruby.version>
+        <asciidoctorj.version>1.6.0-alpha.3</asciidoctorj.version>
+        <asciidoctorj-pdf.version>1.5.0-alpha.15</asciidoctorj-pdf.version>
 
         <!--
         Do not upgrade Surefire and Failsafe to 2.19+.
@@ -716,6 +717,11 @@
                             <groupId>org.asciidoctor</groupId>
                             <artifactId>asciidoctorj-pdf</artifactId>
                             <version>${asciidoctorj-pdf.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.hibernate.infra</groupId>
+                            <artifactId>hibernate-asciidoctor-extensions</artifactId>
+                            <version>${hibernate-asciidoctor-extensions.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
Used that `CustomNumberingProcessor` for HV documentation. This will fail until 1.0.1.Final version for extensions is not released and available.

After discussion on asciidoctor issue, they suggested to update to 1.6 version of asciidoctor and latest pdf version as well. Otherwise pdf version was not generated and an exception was thrown.

Here's a generated pdf:
[hibernate_validator_reference.pdf](https://github.com/hibernate/hibernate-validator/files/968568/hibernate_validator_reference.pdf)
