### PR TITLE
HV-1305 Use HTML5 doclet when generating JavaDoc with Java 9

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -174,7 +174,7 @@
                 <jdk>9</jdk>
             </activation>
             <properties>
-                <javadoc.additional.param>--add-modules=${maven-javadoc-plugin.jigsaw.modules}</javadoc.additional.param>
+                <javadoc.additional.param>-html5 --add-modules=${maven-javadoc-plugin.jigsaw.modules}</javadoc.additional.param>
             </properties>
         </profile>
     </profiles>

--- a/engine/src/main/java/org/hibernate/validator/internal/util/ConcurrentReferenceHashMap.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/ConcurrentReferenceHashMap.java
@@ -51,8 +51,8 @@ import java.util.concurrent.locks.ReentrantLock;
  * discarded by the garbage collector. Once a key has been discarded by the
  * collector, the corresponding entry is no longer visible to this table;
  * however, the entry may occupy space until a future table operation decides to
- * reclaim it. For this reason, summary functions such as <tt>size</tt> and
- * <tt>isEmpty</tt> might return a value greater than the observed number of
+ * reclaim it. For this reason, summary functions such as {@code size} and
+ * {@code isEmpty} might return a value greater than the observed number of
  * entries. In order to support a high level of concurrency, stale entries are
  * only reclaimed during blocking (usually mutating) operations.
  *
@@ -77,19 +77,19 @@ import java.util.concurrent.locks.ReentrantLock;
  * Just like {@link java.util.concurrent.ConcurrentHashMap}, this class obeys
  * the same functional specification as {@link java.util.Hashtable}, and
  * includes versions of methods corresponding to each method of
- * <tt>Hashtable</tt>. However, even though all operations are thread-safe,
+ * {@code Hashtable}. However, even though all operations are thread-safe,
  * retrieval operations do <em>not</em> entail locking, and there is
  * <em>not</em> any support for locking the entire table in a way that
  * prevents all access. This class is fully interoperable with
- * <tt>Hashtable</tt> in programs that rely on its thread safety but not on
+ * {@code Hashtable} in programs that rely on its thread safety but not on
  * its synchronization details.
  *
  * <p>
- * Retrieval operations (including <tt>get</tt>) generally do not block, so
- * may overlap with update operations (including <tt>put</tt> and
- * <tt>remove</tt>). Retrievals reflect the results of the most recently
+ * Retrieval operations (including {@code get}) generally do not block, so
+ * may overlap with update operations (including {@code put} and
+ * {@code remove}). Retrievals reflect the results of the most recently
  * <em>completed</em> update operations holding upon their onset. For
- * aggregate operations such as <tt>putAll</tt> and <tt>clear</tt>,
+ * aggregate operations such as {@code putAll} and {@code clear},
  * concurrent retrievals may reflect insertion or removal of only some entries.
  * Similarly, Iterators and Enumerations return elements reflecting the state of
  * the hash table at some point at or since the creation of the
@@ -99,7 +99,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * <p>
  * The allowed concurrency among update operations is guided by the optional
- * <tt>concurrencyLevel</tt> constructor argument (default <tt>16</tt>),
+ * {@code concurrencyLevel} constructor argument (default {@code 16}),
  * which is used as a hint for internal sizing. The table is internally
  * partitioned to try to permit the indicated number of concurrent updates
  * without contention. Because placement in hash tables is essentially random,
@@ -120,7 +120,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * <p>
  * Like {@link Hashtable} but unlike {@link HashMap}, this class does
- * <em>not</em> allow <tt>null</tt> to be used as a key or value.
+ * <em>not</em> allow {@code null} to be used as a key or value.
  *
  * <p>
  * This class is a member of the <a href="{@docRoot}/../technotes/guides/collections/index.html">
@@ -490,8 +490,8 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 
 		/**
 		 * The table is rehashed when its size exceeds this threshold.
-		 * (The value of this field is always <tt>(int)(capacity *
-		 * loadFactor)</tt>.)
+		 * (The value of this field is always {@code (int)(capacity *
+		 * loadFactor)}.)
 		 */
 		transient int threshold;
 
@@ -1008,9 +1008,9 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	}
 
 	/**
-	 * Returns <tt>true</tt> if this map contains no key-value mappings.
+	 * Returns {@code true} if this map contains no key-value mappings.
 	 *
-	 * @return <tt>true</tt> if this map contains no key-value mappings
+	 * @return {@code true} if this map contains no key-value mappings
 	 */
 	@Override
 	public boolean isEmpty() {
@@ -1047,8 +1047,8 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 
 	/**
 	 * Returns the number of key-value mappings in this map.  If the
-	 * map contains more than <tt>Integer.MAX_VALUE</tt> elements, returns
-	 * <tt>Integer.MAX_VALUE</tt>.
+	 * map contains more than {@link Integer#MAX_VALUE} elements, returns
+	 * {@link Integer#MAX_VALUE}.
 	 *
 	 * @return the number of key-value mappings in this map
 	 */
@@ -1116,9 +1116,9 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * Tests if the specified object is a key in this table.
 	 *
 	 * @param  key   possible key
-	 * @return <tt>true</tt> if and only if the specified object
+	 * @return {@code true} if and only if the specified object
 	 *         is a key in this table, as determined by the
-	 *         <tt>equals</tt> method; <tt>false</tt> otherwise.
+	 *         {@code equals} method; {@code false} otherwise.
 	 * @throws NullPointerException if the specified key is null
 	 */
 	@Override
@@ -1128,13 +1128,13 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	}
 
 	/**
-	 * Returns <tt>true</tt> if this map maps one or more keys to the
+	 * Returns {@code true} if this map maps one or more keys to the
 	 * specified value. Note: This method requires a full internal
 	 * traversal of the hash table, and so is much slower than
-	 * method <tt>containsKey</tt>.
+	 * method {@code containsKey}.
 	 *
 	 * @param value value whose presence in this map is to be tested
-	 * @return <tt>true</tt> if this map maps one or more keys to the
+	 * @return {@code true} if this map maps one or more keys to the
 	 *         specified value
 	 * @throws NullPointerException if the specified value is null
 	 */
@@ -1195,10 +1195,10 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * Java Collections framework.
 
 	 * @param  value a value to search for
-	 * @return <tt>true</tt> if and only if some key maps to the
-	 *         <tt>value</tt> argument in this table as
-	 *         determined by the <tt>equals</tt> method;
-	 *         <tt>false</tt> otherwise
+	 * @return {@code true} if and only if some key maps to the
+	 *         {@code value} argument in this table as
+	 *         determined by the {@code equals} method;
+	 *         {@code false} otherwise
 	 * @throws NullPointerException if the specified value is null
 	 */
 	public boolean contains(Object value) {
@@ -1209,13 +1209,13 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * Maps the specified key to the specified value in this table.
 	 * Neither the key nor the value can be null.
 	 *
-	 * <p> The value can be retrieved by calling the <tt>get</tt> method
+	 * <p> The value can be retrieved by calling the {@code get} method
 	 * with a key that is equal to the original key.
 	 *
 	 * @param key key with which the specified value is to be associated
 	 * @param value value to be associated with the specified key
-	 * @return the previous value associated with <tt>key</tt>, or
-	 *         <tt>null</tt> if there was no mapping for <tt>key</tt>
+	 * @return the previous value associated with {@code key}, or
+	 *         {@code null} if there was no mapping for {@code key}
 	 * @throws NullPointerException if the specified key or value is null
 	 */
 	@Override
@@ -1230,7 +1230,7 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * {@inheritDoc}
 	 *
 	 * @return the previous value associated with the specified key,
-	 *         or <tt>null</tt> if there was no mapping for the key
+	 *         or {@code null} if there was no mapping for the key
 	 * @throws NullPointerException if the specified key or value is null
 	 */
 	@Override
@@ -1259,8 +1259,8 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * This method does nothing if the key is not in the map.
 	 *
 	 * @param  key the key that needs to be removed
-	 * @return the previous value associated with <tt>key</tt>, or
-	 *         <tt>null</tt> if there was no mapping for <tt>key</tt>
+	 * @return the previous value associated with {@code key}, or
+	 *         {@code null} if there was no mapping for {@code key}
 	 * @throws NullPointerException if the specified key is null
 	 */
 	@Override
@@ -1299,7 +1299,7 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * {@inheritDoc}
 	 *
 	 * @return the previous value associated with the specified key,
-	 *         or <tt>null</tt> if there was no mapping for the key
+	 *         or {@code null} if there was no mapping for the key
 	 * @throws NullPointerException if the specified key or value is null
 	 */
 	@Override
@@ -1341,12 +1341,12 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * The set is backed by the map, so changes to the map are
 	 * reflected in the set, and vice-versa.  The set supports element
 	 * removal, which removes the corresponding mapping from this map,
-	 * via the <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
-	 * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-	 * operations.  It does not support the <tt>add</tt> or
-	 * <tt>addAll</tt> operations.
+	 * via the {@link Iterator#remove}, {@link Set#remove},
+	 * {@code removeAll}, {@code retainAll}, and {@code clear}
+	 * operations. It does not support the {@code add} or
+	 * {@code addAll} operations.
 	 *
-	 * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator
+	 * <p>The view's {@code iterator} is a "weakly consistent" iterator
 	 * that will never throw {@link ConcurrentModificationException},
 	 * and guarantees to traverse elements as they existed upon
 	 * construction of the iterator, and may (but is not guaranteed to)
@@ -1363,12 +1363,12 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * The collection is backed by the map, so changes to the map are
 	 * reflected in the collection, and vice-versa.  The collection
 	 * supports element removal, which removes the corresponding
-	 * mapping from this map, via the <tt>Iterator.remove</tt>,
-	 * <tt>Collection.remove</tt>, <tt>removeAll</tt>,
-	 * <tt>retainAll</tt>, and <tt>clear</tt> operations.  It does not
-	 * support the <tt>add</tt> or <tt>addAll</tt> operations.
+	 * mapping from this map, via the {@link Iterator#remove},
+	 * {@link Collection#remove}, {@code removeAll},
+	 * {@code retainAll}, and {@code clear} operations.  It does not
+	 * support the {@code add} or {@code addAll} operations.
 	 *
-	 * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator
+	 * <p>The view's {@code iterator} is a "weakly consistent" iterator
 	 * that will never throw {@link ConcurrentModificationException},
 	 * and guarantees to traverse elements as they existed upon
 	 * construction of the iterator, and may (but is not guaranteed to)
@@ -1385,12 +1385,12 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	 * The set is backed by the map, so changes to the map are
 	 * reflected in the set, and vice-versa.  The set supports element
 	 * removal, which removes the corresponding mapping from the map,
-	 * via the <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
-	 * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-	 * operations.  It does not support the <tt>add</tt> or
-	 * <tt>addAll</tt> operations.
+	 * via the {@link Iterator#remove}, {@link Set#remove},
+	 * {@code removeAll}, {@code retainAll}, and {@code clear}
+	 * operations. It does not support the {@code add} or
+	 * {@code addAll} operations.
 	 *
-	 * <p>The view's <tt>iterator</tt> is a "weakly consistent" iterator
+	 * <p>The view's {@code iterator} is a "weakly consistent" iterator
 	 * that will never throw {@link ConcurrentModificationException},
 	 * and guarantees to traverse elements as they existed upon
 	 * construction of the iterator, and may (but is not guaranteed to)
@@ -1704,7 +1704,7 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	/* ---------------- Serialization Support -------------- */
 
 	/**
-	 * Save the state of the <tt>ConcurrentReferenceHashMap</tt> instance to a
+	 * Save the state of the {@code ConcurrentReferenceHashMap} instance to a
 	 * stream (i.e., serialize it).
 	 * @param s the stream
 	 * @serialData
@@ -1741,7 +1741,7 @@ final public class ConcurrentReferenceHashMap<K, V> extends AbstractMap<K, V>
 	}
 
 	/**
-	 * Reconstitute the <tt>ConcurrentReferenceHashMap</tt> instance from a
+	 * Reconstitute the {@code ConcurrentReferenceHashMap} instance from a
 	 * stream (i.e., deserialize it).
 	 * @param s the stream
 	 *


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1305

Using HTML5 for JavaDoc generation with JDK 9. I've added `-html5` to parameters and also replaced a couple of `<tt>...</tt>` with `{@code}` or `{@link}` as otherwise it will give a next error:

```
error: tag not supported in the generated HTML version: tt
```

https://www.w3schools.com/tags/tag_tt.asp