### PR TITLE
HV-1365 Creating common classes of property path example;

### DIFF
--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Author.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Author.java
@@ -31,6 +31,11 @@ public class Author {
 		this.lastName = lastName;
 	}
 
+	public Author(String lastName, String company) {
+		this.lastName = lastName;
+		this.company = company;
+	}
+
 	public String getFirstName() {
 		return firstName;
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Author.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Author.java
@@ -1,0 +1,57 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+
+@SecurityChecking
+public class Author {
+
+	private String firstName;
+
+	@NotEmpty(message = "lastname must not be null")
+	private String lastName;
+
+	@Size(max = 30)
+	private String company;
+
+	@OldAndNewPasswordsDifferent
+	@NewPasswordsIdentical
+	public void renewPassword(String oldPassword, String newPassword, String retypedNewPassword) {
+	}
+
+	// [...]
+
+	public Author(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	public String getCompany() {
+		return company;
+	}
+
+	public void setCompany(String company) {
+		this.company = company;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Availability.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Availability.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+/**
+ * @author Gunnar Morling
+ */
+public interface Availability {
+
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/AvailableInStore.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/AvailableInStore.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.test.internal.engine.customerror.IsValid;
+
+/**
+ * @author Gunnar Morling
+ */
+@NotNull
+@Target(TYPE)
+@Retention(RUNTIME)
+@Constraint(validatedBy = AvailableInStore.Validator.class)
+@ReportAsSingleViolation
+public @interface AvailableInStore {
+
+	Class<?>[] groups() default { };
+
+	String message() default "Default error message";
+
+	Class<? extends Payload>[] payload() default { };
+
+	class Validator implements ConstraintValidator<IsValid, Author> {
+
+		@Override
+		public boolean isValid(Author value, ConstraintValidatorContext constraintValidatorContext) {
+			return false;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/AvailableInStore.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/AvailableInStore.java
@@ -19,8 +19,6 @@ import javax.validation.Payload;
 import javax.validation.ReportAsSingleViolation;
 import javax.validation.constraints.NotNull;
 
-import org.hibernate.validator.test.internal.engine.customerror.IsValid;
-
 /**
  * @author Gunnar Morling
  */
@@ -37,7 +35,7 @@ public @interface AvailableInStore {
 
 	Class<? extends Payload>[] payload() default { };
 
-	class Validator implements ConstraintValidator<IsValid, Author> {
+	class Validator implements ConstraintValidator<AvailableInStore, Author> {
 
 		@Override
 		public boolean isValid(Author value, ConstraintValidatorContext constraintValidatorContext) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Book.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Book.java
@@ -1,0 +1,107 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.groups.Default;
+
+@AvailableInStore(groups = { Availability.class })
+public class Book {
+
+	@NotEmpty(groups = { FirstLevelCheck.class, Default.class })
+	private String title;
+
+	@Valid
+	@NotNull
+	private List<Author> authors;
+
+	@Valid
+	private Map<String, Review> reviewsPerSource;
+
+	@Valid
+	private Review pickedReview;
+
+	private List<@NotBlank String> tags;
+
+	private Map<Integer, List<@NotBlank String>> tagsByChapter;
+
+	private List<@Valid Category> categories;
+
+	private Map<Integer, List<@Valid Author>> authorsByChapter;
+
+	// [...]
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public List<Author> getAuthors() {
+		return authors;
+	}
+
+	public void setAuthors(List<Author> authors) {
+		this.authors = authors;
+	}
+
+	public Map<String, Review> getReviewsPerSource() {
+		return reviewsPerSource;
+	}
+
+	public void setReviewsPerSource(Map<String, Review> reviewsPerSource) {
+		this.reviewsPerSource = reviewsPerSource;
+	}
+
+	public Review getPickedReview() {
+		return pickedReview;
+	}
+
+	public void setPickedReview(Review pickedReview) {
+		this.pickedReview = pickedReview;
+	}
+
+	public List<String> getTags() {
+		return tags;
+	}
+
+	public void setTags(List<String> tags) {
+		this.tags = tags;
+	}
+
+	public Map<Integer, List<String>> getTagsByChapter() {
+		return tagsByChapter;
+	}
+
+	public void setTagsByChapter(Map<Integer, List<String>> tagsByChapter) {
+		this.tagsByChapter = tagsByChapter;
+	}
+
+	public List<Category> getCategories() {
+		return categories;
+	}
+
+	public void setCategories(List<Category> categories) {
+		this.categories = categories;
+	}
+
+	public Map<Integer, List<Author>> getAuthorsByChapter() {
+		return authorsByChapter;
+	}
+
+	public void setAuthorsByChapter(Map<Integer, List<Author>> authorsByChapter) {
+		this.authorsByChapter = authorsByChapter;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Category.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Category.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+import javax.validation.constraints.Size;
+
+public class Category {
+
+	// [...]
+
+	@Size(min = 3)
+	private String name;
+
+	public Category(String name) {
+		this.name = name;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/FirstLevelCheck.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/FirstLevelCheck.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+/**
+ * @author Gunnar Morling
+ */
+public interface FirstLevelCheck {
+
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/NewPasswordsIdentical.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/NewPasswordsIdentical.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+/**
+ * @author Gunnar Morling
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Constraint(validatedBy = NewPasswordsIdentical.Validator.class)
+@ReportAsSingleViolation
+public @interface NewPasswordsIdentical {
+
+	Class<?>[] groups() default { };
+
+	String message() default "Default error message";
+
+	Class<? extends Payload>[] payload() default { };
+
+	@SupportedValidationTarget(ValidationTarget.PARAMETERS)
+	class Validator implements ConstraintValidator<NewPasswordsIdentical, Object[]> {
+
+		@Override
+		public boolean isValid(Object[] args, ConstraintValidatorContext constraintValidatorContext) {
+			return false;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/OldAndNewPasswordsDifferent.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/OldAndNewPasswordsDifferent.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+/**
+ * @author Gunnar Morling
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Constraint(validatedBy = OldAndNewPasswordsDifferent.Validator.class)
+@ReportAsSingleViolation
+public @interface OldAndNewPasswordsDifferent {
+
+	Class<?>[] groups() default { };
+
+	String message() default "Default error message";
+
+	Class<? extends Payload>[] payload() default { };
+
+	@SupportedValidationTarget(ValidationTarget.PARAMETERS)
+	class Validator implements ConstraintValidator<OldAndNewPasswordsDifferent, Object[]> {
+
+		@Override
+		public boolean isValid(Object[] args, ConstraintValidatorContext constraintValidatorContext) {
+			return false;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Review.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/Review.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+import javax.validation.constraints.Min;
+
+public class Review {
+
+	@Min(0) private int rating;
+
+	// [...]
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/SecurityChecking.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/SecurityChecking.java
@@ -1,0 +1,47 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.test.internal.engine.customerror.IsValid;
+
+/**
+ * @author Gunnar Morling
+ */
+@NotNull
+@Target(TYPE)
+@Retention(RUNTIME)
+@Constraint(validatedBy = SecurityChecking.Validator.class)
+@ReportAsSingleViolation
+public @interface SecurityChecking {
+
+	Class<?>[] groups() default { };
+
+	String message() default "Default error message";
+
+	Class<? extends Payload>[] payload() default { };
+
+	class Validator implements ConstraintValidator<IsValid, Author> {
+
+		@Override
+		public boolean isValid(Author value, ConstraintValidatorContext constraintValidatorContext) {
+			return true;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/SpecExamplePropertyPathTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/SpecExamplePropertyPathTest.java
@@ -39,6 +39,48 @@ import org.testng.annotations.Test;
 public class SpecExamplePropertyPathTest {
 
 	/**
+	 * 5.) book.author.lastname
+	 */
+	@Test
+	public void cascadedValidationWithPropertyConstraintLegacyStyle() throws Exception {
+		Validator validator = getValidator();
+
+		Book book = new Book();
+		book.setTitle( "A book" );
+		book.setAuthors( Arrays.asList( new Author( "West" ), new Author( "Wayne" ), new Author( "Hood" ), new Author( "" ) ) );
+
+		Set<ConstraintViolation<Book>> constraintViolations = validator.validate( book );
+		assertThat( constraintViolations ).containsOnlyViolations( violationOf( NotEmpty.class ) );
+
+		Path path = constraintViolations.iterator().next().getPropertyPath();
+
+		for ( Path.Node node : path ) {
+			printNode( node );
+		}
+	}
+
+	/**
+	 * 6.) book.author.company
+	 */
+	@Test
+	public void cascadedValidationWithPropertyConstraintLegacyStyle2() throws Exception {
+		Validator validator = getValidator();
+
+		Book book = new Book();
+		book.setTitle( "A book" );
+		book.setAuthors( Arrays.asList( new Author( "West", "A Company Name That Is Way Too Long" ) ) );
+
+		Set<ConstraintViolation<Book>> constraintViolations = validator.validate( book );
+		assertThat( constraintViolations ).containsOnlyViolations( violationOf( Size.class ) );
+
+		Path path = constraintViolations.iterator().next().getPropertyPath();
+
+		for ( Path.Node node : path ) {
+			printNode( node );
+		}
+	}
+
+	/**
 	 * 9.) book.tags
 	 */
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/SpecExamplePropertyPathTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/specexample/SpecExamplePropertyPathTest.java
@@ -1,0 +1,206 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.specexample;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ElementKind;
+import javax.validation.Path;
+import javax.validation.Path.BeanNode;
+import javax.validation.Path.ContainerElementNode;
+import javax.validation.Path.PropertyNode;
+import javax.validation.Validator;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Size;
+
+import org.testng.annotations.Test;
+
+/**
+ * Used to print the assertions shown in table 6.1/6.2 of the spec.
+ *
+ * @author Gunnar Morling
+ *
+ */
+public class SpecExamplePropertyPathTest {
+
+	/**
+	 * 9.) book.tags
+	 */
+	@Test
+	public void containerElementConstraint() throws Exception {
+		Validator validator = getValidator();
+
+		Book book = new Book();
+		book.setTitle( "A book" );
+		book.setAuthors( Collections.emptyList() );
+		book.setTags( Arrays.asList( "some tag", "", "another tag" ) );
+
+		Set<ConstraintViolation<Book>> constraintViolations = validator.validate( book );
+		assertThat( constraintViolations ).containsOnlyViolations( violationOf( NotBlank.class ) );
+
+		Path path = constraintViolations.iterator().next().getPropertyPath();
+
+		for ( Path.Node node : path ) {
+			printNode( node );
+		}
+	}
+
+	/**
+	 * 10.) book.tagsByChapter
+	 */
+	@Test
+	public void nestedContainerElementConstraint() throws Exception {
+		Validator validator = getValidator();
+
+		Book book = new Book();
+		book.setTitle( "A book" );
+		book.setAuthors( Collections.emptyList() );
+
+		Map<Integer, List<String>> tagsByChapter = new HashMap<>();
+		tagsByChapter.put( 4, Arrays.asList( "some tag", "another tag", "" ) );
+		book.setTagsByChapter( tagsByChapter  );
+
+		Set<ConstraintViolation<Book>> constraintViolations = validator.validate( book );
+		assertThat( constraintViolations ).containsOnlyViolations( violationOf( NotBlank.class ) );
+
+		Path path = constraintViolations.iterator().next().getPropertyPath();
+
+		for ( Path.Node node : path ) {
+			printNode( node );
+		}
+	}
+
+	/**
+	 * 11.) book.categories.name
+	 */
+	@Test
+	public void cascadedValidationWithPropertyConstraint() throws Exception {
+		Validator validator = getValidator();
+
+		Book book = new Book();
+		book.setTitle( "A book" );
+		book.setAuthors( Collections.emptyList() );
+		book.setCategories( Arrays.asList( new Category( "long enough" ), new Category( "a" ), new Category( "long enough" ) ) );
+
+		Set<ConstraintViolation<Book>> constraintViolations = validator.validate( book );
+		assertThat( constraintViolations ).containsOnlyViolations( violationOf( Size.class ) );
+
+		Path path = constraintViolations.iterator().next().getPropertyPath();
+
+		for ( Path.Node node : path ) {
+			printNode( node );
+		}
+	}
+
+	/**
+	 * 12.) book.authorsByChapter.name
+	 */
+	@Test
+	public void nestedCascadedValidationWithPropertyConstraint() throws Exception {
+		Validator validator = getValidator();
+
+		Book book = new Book();
+		book.setTitle( "A book" );
+		book.setAuthors( Collections.emptyList() );
+
+		Map<Integer, List<Author>> authorsByChapter = new HashMap<>();
+		authorsByChapter.put( 4, Arrays.asList( new Author( "Bob" ), new Author( "Bruce" ), new Author( "" ) ) );
+		book.setAuthorsByChapter( authorsByChapter  );
+
+		Set<ConstraintViolation<Book>> constraintViolations = validator.validate( book );
+		assertThat( constraintViolations ).containsOnlyViolations( violationOf( NotEmpty.class ) );
+
+		Path path = constraintViolations.iterator().next().getPropertyPath();
+
+		for ( Path.Node node : path ) {
+			printNode( node );
+		}
+	}
+
+	private void printNode(Path.Node node) {
+		StringBuilder sb = new StringBuilder();
+
+		switch ( node.getKind() ) {
+			case BEAN:
+				sb.append( "BeanNode" );
+				break;
+			case CONSTRUCTOR:
+				sb.append( "ConstructorNode" );
+				break;
+			case CONTAINER_ELEMENT:
+				sb.append( "ContainerElementNode" );
+				break;
+			case CROSS_PARAMETER:
+				sb.append( "CrossParameterNode" );
+				break;
+			case METHOD:
+				sb.append( "MethodNode" );
+				break;
+			case PARAMETER:
+				sb.append( "ParameterNode" );
+				break;
+			case PROPERTY:
+				sb.append( "PropertyNode" );
+				break;
+			case RETURN_VALUE:
+				sb.append( "ReturnValueNode" );
+				break;
+			default:
+				break;
+
+		}
+		sb.append( "(" );
+		sb.append( "name=" );
+		sb.append( node.getName() );
+		sb.append( ", inIterable=" );
+		sb.append( node.isInIterable() );
+		sb.append( ", index=" );
+		sb.append( node.getIndex() );
+		sb.append( ", key=" );
+		sb.append( node.getKey() );
+
+		if ( node.getKind() == ElementKind.BEAN ) {
+			sb.append( ", containerClass=" );
+			sb.append( toString( ( (BeanNode) node ).getContainerClass() ) );
+			sb.append( ", typeArgumentIndex=" );
+			sb.append( ( (BeanNode) node ).getTypeArgumentIndex() );
+		}
+		else if ( node.getKind() == ElementKind.PROPERTY ) {
+			sb.append( ", containerClass=" );
+			sb.append( toString( ( (PropertyNode) node ).getContainerClass() ) );
+			sb.append( ", typeArgumentIndex=" );
+			sb.append( ( (PropertyNode) node ).getTypeArgumentIndex() );
+		}
+		else if ( node.getKind() == ElementKind.CONTAINER_ELEMENT ) {
+			sb.append( ", containerClass=" );
+			sb.append( toString( ( (ContainerElementNode) node ).getContainerClass() ) );
+			sb.append( ", typeArgumentIndex=" );
+			sb.append( ( (ContainerElementNode) node ).getTypeArgumentIndex() );
+		}
+		sb.append( ", kind=ElementKind." );
+		sb.append( node.getKind() );
+		sb.append( ")" );
+		sb.append( System.lineSeparator() );
+
+		System.out.println( sb.toString() );
+	}
+
+	private String toString(Class<?> optionalClass) {
+		return optionalClass != null ? optionalClass.getSimpleName() + ".class" : null;
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -534,15 +534,6 @@
                         <suppressAnnotations>
                             <annotation>**.IgnoreForbiddenApisErrors</annotation>
                         </suppressAnnotations>
-                        <bundledSignatures>
-                            <!--
-                              this will automatically choose the right
-                              signatures based on 'maven.compiler.target'
-                            -->
-                            <bundledSignature>jdk-deprecated</bundledSignature>
-                            <!-- disallow printing to System.out or System.err -->
-                            <bundledSignature>jdk-system-out</bundledSignature>
-                        </bundledSignatures>
                         <signaturesArtifacts>
                             <signaturesArtifact>
                                 <groupId>org.hibernate.validator</groupId>
@@ -562,11 +553,38 @@
                     </configuration>
                     <executions>
                         <execution>
+                            <id>check-main</id>
                             <goals>
                                 <goal>check</goal>
+                            </goals>
+                            <phase>verify</phase>
+                            <configuration>
+                                <bundledSignatures>
+                                    <!--
+                                      this will automatically choose the right
+                                      signatures based on 'maven.compiler.target'
+                                    -->
+                                    <bundledSignature>jdk-deprecated</bundledSignature>
+                                    <!-- disallow printing to System.out or System.err -->
+                                    <bundledSignature>jdk-system-out</bundledSignature>
+                                </bundledSignatures>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>check-test</id>
+                            <goals>
                                 <goal>testCheck</goal>
                             </goals>
                             <phase>verify</phase>
+                            <configuration>
+                                <bundledSignatures>
+                                    <!--
+                                      this will automatically choose the right
+                                      signatures based on 'maven.compiler.target'
+                                    -->
+                                    <bundledSignature>jdk-deprecated</bundledSignature>
+                                </bundledSignatures>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>


### PR DESCRIPTION
Adding examples for containerClass and getTypeArgumentIndex()

@gsmet This adds executable examples for the newly added cases. I suggest to open a follow up issue to add the missing ones for the existing cases, too.

https://hibernate.atlassian.net/browse/HV-1365

Btw. one should be careful when taking the output from the RI because it could be erroneous or not what's intended in the spec actually. So what I did was to add the expected output manually and then verified by replacing it with the actual output from the RI.