### PR TITLE
HV-1367 Being unable to instantiate a value extractor should throw a ValueExtractorDeclarationException

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -712,7 +712,7 @@ public interface Log extends BasicLogger {
 	ConstraintDefinitionException getInvalidUnwrappingConfigurationForConstraintException(Member member, @FormatWith(ClassObjectFormatter.class) Class<? extends Annotation> constraint);
 
 	@Message(id = 206, value = "Unable to instantiate value extractor class %s.")
-	ValidationException getUnableToInstantiateValueExtractorClassException(String valueExtractorClassName, @Cause ValidationException e);
+	ValueExtractorDeclarationException getUnableToInstantiateValueExtractorClassException(String valueExtractorClassName, @Cause ValidationException e);
 
 	@LogMessage(level = INFO)
 	@Message(id = 207, value = "Adding value extractor %s.")


### PR DESCRIPTION
Test is in the TCK.

 * https://hibernate.atlassian.net/browse/HV-1367