### PR TITLE
HV-1377 StackOverflowError during compilation with annotation-processor enabled

### DIFF
--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/ClassVisitor.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/ClassVisitor.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
@@ -33,6 +34,8 @@ import org.hibernate.validator.ap.util.MessagerAdapter;
  */
 public class ClassVisitor extends AbstractElementVisitor<Void, Void> {
 
+	private final Set<Name> processedTypes;
+
 	private final ClassCheckFactory factory;
 
 	private final Elements elementUtils;
@@ -54,6 +57,8 @@ public class ClassVisitor extends AbstractElementVisitor<Void, Void> {
 						)
 				)
 		);
+
+		this.processedTypes = CollectionHelper.newHashSet();
 	}
 
 	/**
@@ -101,8 +106,12 @@ public class ClassVisitor extends AbstractElementVisitor<Void, Void> {
 	 * @param typeElement inner elements of which you want to visit
 	 */
 	private void visitAllMyElements(TypeElement typeElement) {
-		for ( Element element : elementUtils.getAllMembers( typeElement ) ) {
-			visit( element );
+		Name qualifiedName = typeElement.getQualifiedName();
+		if ( !processedTypes.contains( qualifiedName ) ) {
+			processedTypes.add( qualifiedName );
+			for ( Element element : elementUtils.getAllMembers( typeElement ) ) {
+				visit( element );
+			}
 		}
 	}
 

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/CircularNestedTypesTest.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/CircularNestedTypesTest.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.ap;
+
+import static org.testng.Assert.assertTrue;
+
+import org.hibernate.validator.ap.testmodel.ciruclar.Property;
+import org.hibernate.validator.ap.testmodel.ciruclar.PropertyImpl;
+
+import org.testng.annotations.Test;
+
+/**
+ * Tests that in case of circular nested types there's no infinite loop during analysis.
+ *
+ * @author Marko Bekhta
+ */
+public class CircularNestedTypesTest extends ConstraintValidationProcessorTestBase {
+
+	@Test
+	public void testNoInfiniteLoop() {
+		boolean compilationResult =
+				compilerHelper.compile( new ConstraintValidationProcessor(), diagnostics,
+						compilerHelper.getSourceFile( PropertyImpl.class ),
+						compilerHelper.getSourceFile( Property.class )
+				);
+
+		assertTrue( compilationResult );
+	}
+
+}

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/ciruclar/Property.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/ciruclar/Property.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.ap.testmodel.ciruclar;
+
+/**
+ * @author Marko Bekhta
+ */
+public interface Property {
+
+	void doSomething();
+
+	interface ImprovedProperty extends Property {
+
+		void maybeDoSomething();
+	}
+
+}

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/ciruclar/PropertyImpl.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/ciruclar/PropertyImpl.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.ap.testmodel.ciruclar;
+
+public class PropertyImpl implements Property {
+
+	@Override
+	public void doSomething() {
+		//nothing here
+	}
+
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1377

I've added a check if the type was already processed, and a test case that reflects the problem similar to the one in the test case project provided in the issue. In that case the loop was caused by the interface `com.vaadin.data.Property` : 
```java
public interface Property<T> extends Serializable {
   // .....
   public interface Transactional<T> extends Property<T> {
      // .....
   }
   // .....
}
```

The problem was that when a type is passed to `org.hibernate.validator.ap.ClassVisitor#visitAllMyElements`  there's a loop over all members -
 `elementUtils.getAllMembers( typeElement )` returns inner classes and interfaces from all extended classes and implemented interfaces. As a result the loop occurs:
```
    Field -(contains)> Property -(contains)> Transactional -(contains)> Property -(contains)> Transactional ....
```