### PR TITLE
HV-1376 Check that @Positive/@Negative and OrZero versions are taken into account in the annotation processor

### DIFF
--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/util/ConstraintHelper.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/util/ConstraintHelper.java
@@ -259,6 +259,8 @@ public class ConstraintHelper {
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.MIN, JavaMoneyTypes.MONETARY_AMOUNT );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NEGATIVE, Number.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NEGATIVE, JavaMoneyTypes.MONETARY_AMOUNT );
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NEGATIVE_OR_ZERO, Number.class );
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NEGATIVE_OR_ZERO, JavaMoneyTypes.MONETARY_AMOUNT );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NOT_BLANK, CharSequence.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NOT_EMPTY, TYPES_SUPPORTED_BY_SIZE_AND_NOT_EMPTY_ANNOTATIONS );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.NOT_NULL, Object.class );
@@ -269,6 +271,8 @@ public class ConstraintHelper {
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.PATTERN, String.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.POSITIVE, Number.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.POSITIVE, JavaMoneyTypes.MONETARY_AMOUNT );
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.POSITIVE_OR_ZERO, Number.class );
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.POSITIVE_OR_ZERO, JavaMoneyTypes.MONETARY_AMOUNT );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.SIZE, TYPES_SUPPORTED_BY_SIZE_AND_NOT_EMPTY_ANNOTATIONS );
 
 		//register HV-specific constraints

--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/util/TypeNames.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/util/TypeNames.java
@@ -38,6 +38,7 @@ public class TypeNames {
 		public static final String MAX = JAVAX_VALIDATION_CONSTRAINTS + ".Max";
 		public static final String MIN = JAVAX_VALIDATION_CONSTRAINTS + ".Min";
 		public static final String NEGATIVE = JAVAX_VALIDATION_CONSTRAINTS + ".Negative";
+		public static final String NEGATIVE_OR_ZERO = JAVAX_VALIDATION_CONSTRAINTS + ".NegativeOrZero";
 		public static final String NOT_BLANK = JAVAX_VALIDATION_CONSTRAINTS + ".NotBlank";
 		public static final String NOT_EMPTY = JAVAX_VALIDATION_CONSTRAINTS + ".NotEmpty";
 		public static final String NOT_NULL = JAVAX_VALIDATION_CONSTRAINTS + ".NotNull";
@@ -45,6 +46,7 @@ public class TypeNames {
 		public static final String PAST = JAVAX_VALIDATION_CONSTRAINTS + ".Past";
 		public static final String PATTERN = JAVAX_VALIDATION_CONSTRAINTS + ".Pattern";
 		public static final String POSITIVE = JAVAX_VALIDATION_CONSTRAINTS + ".Positive";
+		public static final String POSITIVE_OR_ZERO = JAVAX_VALIDATION_CONSTRAINTS + ".PositiveOrZero";
 		public static final String SIZE = JAVAX_VALIDATION_CONSTRAINTS + ".Size";
 
 		public static final String CONSTRAINTVALIDATION = "javax.validation.constraintvalidation";

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorTest.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorTest.java
@@ -184,14 +184,16 @@ public class ConstraintValidationProcessorTest extends ConstraintValidationProce
 		assertFalse( compilationResult );
 		assertThatDiagnosticsMatch(
 				diagnostics,
-				new DiagnosticExpectation( Kind.ERROR, 39 ),
-				new DiagnosticExpectation( Kind.ERROR, 40 ),
-				new DiagnosticExpectation( Kind.ERROR, 41 ),
-				new DiagnosticExpectation( Kind.ERROR, 42 ),
+				new DiagnosticExpectation( Kind.ERROR, 43 ),
+				new DiagnosticExpectation( Kind.ERROR, 44 ),
 				new DiagnosticExpectation( Kind.ERROR, 45 ),
 				new DiagnosticExpectation( Kind.ERROR, 46 ),
 				new DiagnosticExpectation( Kind.ERROR, 47 ),
-				new DiagnosticExpectation( Kind.ERROR, 50 )
+				new DiagnosticExpectation( Kind.ERROR, 50 ),
+				new DiagnosticExpectation( Kind.ERROR, 51 ),
+				new DiagnosticExpectation( Kind.ERROR, 52 ),
+				new DiagnosticExpectation( Kind.ERROR, 55 ),
+				new DiagnosticExpectation( Kind.ERROR, 56 )
 		);
 	}
 

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/ModelWithJavaMoneyTypes.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/ModelWithJavaMoneyTypes.java
@@ -12,7 +12,9 @@ import javax.validation.constraints.DecimalMin;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Negative;
+import javax.validation.constraints.NegativeOrZero;
 import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
 
 import org.hibernate.validator.constraints.Currency;
 
@@ -20,11 +22,13 @@ public class ModelWithJavaMoneyTypes {
 
 	@Currency("EUR")
 	@Negative
+	@NegativeOrZero
 	public MonetaryAmount monetaryAmountEuro;
 
 	@DecimalMax("1000.00")
 	@DecimalMin("0.00")
 	@Positive
+	@PositiveOrZero
 	public MonetaryAmount monetaryAmount;
 
 	@Max(1000L)

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/customconstraints/BeanValidationConstraints.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/customconstraints/BeanValidationConstraints.java
@@ -10,9 +10,11 @@ import java.util.Collection;
 import java.util.List;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Negative;
+import javax.validation.constraints.NegativeOrZero;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
 
 public class BeanValidationConstraints {
 
@@ -25,9 +27,11 @@ public class BeanValidationConstraints {
 	public String string;
 
 	@Positive
+	@PositiveOrZero
 	public int number;
 
 	@Negative
+	@NegativeOrZero
 	public Double otherNumber;
 
 	@NotEmpty
@@ -38,6 +42,7 @@ public class BeanValidationConstraints {
 	 */
 	@Email
 	@Negative
+	@NegativeOrZero
 	@NotEmpty
 	@NotBlank
 	public Object property;
@@ -48,5 +53,6 @@ public class BeanValidationConstraints {
 	public int badInt;
 
 	@Positive
+	@PositiveOrZero
 	public Collection collection;
 }


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1376

`@Positive` and `@Negative` were already added some time ago. So I've added support for `*OrZero` ones only.