### PR TITLE
HV-1352 Incorrect value handler on trace logging

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -582,6 +582,8 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 
 		// reset the unwrapping mode
 		valueContext.setUnwrapMode( UnwrapMode.AUTOMATIC );
+		// reset ValidatedValueHandler to prevent HV-1352
+		valueContext.setValidatedValueHandler( null );
 		return validationSuccessful;
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/TraceLoggingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/TraceLoggingTest.java
@@ -1,0 +1,63 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNumberOfViolations;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+
+import java.util.Optional;
+
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.valuehandling.UnwrapValidatedValue;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.LogManager;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class TraceLoggingTest {
+
+	private Level currentLevel;
+
+	@BeforeMethod
+	public void setUp() throws Exception {
+		currentLevel = LogManager.getRootLogger().getLevel();
+		LogManager.getRootLogger().setLevel( Level.TRACE );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1352")
+	public void testLoggingIsNotFailing() {
+		assertNumberOfViolations( getValidator().validate( new Foo( Optional.of( 1 ), 1 ) ), 0 );
+	}
+
+	@AfterMethod
+	public void tearDown() throws Exception {
+		LogManager.getRootLogger().setLevel( currentLevel );
+	}
+
+	private static class Foo {
+
+		@NotNull
+		@UnwrapValidatedValue
+		private final Optional<Integer> optInt;
+		@NotNull
+		private final Integer integer;
+
+		public Foo(@NotNull Optional<Integer> optInt, @NotNull Integer integer) {
+			this.optInt = optInt;
+			this.integer = integer;
+		}
+	}
+
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1352

`ValidatedValueHandler` was left in the ValueContext after validation of one constraint was finished and then when next constraint was validated in case of `TRACE` logging it was trying to use that handler even though it was not needed. So I've just set it to `null` at the same time when `UnwrapMode` was reseted. I believe that this one is only for HV 5.* as in 6 this part is implemented differently. 