### PR TITLE
HV-1334 Follow-up to-dos around value extractor implementation

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine.path;
 
 import java.io.Serializable;
+import java.time.temporal.TemporalAccessor;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +24,7 @@ import javax.validation.Path.PropertyNode;
 import javax.validation.Path.ReturnValueNode;
 
 import org.hibernate.validator.internal.util.Contracts;
+import org.hibernate.validator.internal.util.TypeHelper;
 import org.hibernate.validator.internal.util.TypeVariables;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -405,12 +407,22 @@ public class NodeImpl
 				builder.append( index );
 			}
 			else if ( key != null ) {
-				builder.append( key );
+				builder.append( getKeyStringRepresentation( key ) );
 			}
 			builder.append( INDEX_CLOSE );
 		}
 
 		return builder.toString();
+	}
+
+	private static String getKeyStringRepresentation(Object key) {
+		if ( TypeHelper.isAssignable( Number.class, key.getClass() )
+				|| TypeHelper.isAssignable( Boolean.class, key.getClass() )
+				|| TypeHelper.isAssignable( TemporalAccessor.class, key.getClass() )
+				) {
+			return key.toString();
+		}
+		return String.format( "key('%s')", key );
 	}
 
 	// TODO: this is used to reduce the number of differences until we agree on the string representation

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CascadedIterableMapPropertiesTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CascadedIterableMapPropertiesTest.java
@@ -67,7 +67,7 @@ public class CascadedIterableMapPropertiesTest {
 		assertCorrectPropertyPaths(
 				constraintViolations,
 				"mapExt.value",
-				"mapExt[second].number"
+				"mapExt[key('second')].number"
 		);
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
@@ -83,7 +83,7 @@ public class CustomValueExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithMultimap>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType<V>[work].email", "addressByType<V>[work].email" );
+		assertCorrectPropertyPaths( violations, "addressByType<V>[key('work')].email", "addressByType<V>[key('work')].email" );
 	}
 
 	@Test
@@ -99,7 +99,7 @@ public class CustomValueExtractorTest {
 
 				Set<ConstraintViolation<CustomerWithMultimap>> violations = validator.validate( bob );
 
-				assertCorrectPropertyPaths( violations, "addressByType<V>[work].email", "addressByType<V>[work].email" );
+				assertCorrectPropertyPaths( violations, "addressByType<V>[key('work')].email", "addressByType<V>[key('work')].email" );
 		} );
 	}
 
@@ -114,7 +114,7 @@ public class CustomValueExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithStringStringMultimap>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType<V>[work].multimap_value", "addressByType<V>[work].multimap_value" );
+		assertCorrectPropertyPaths( violations, "addressByType<V>[key('work')].multimap_value", "addressByType<V>[key('work')].multimap_value" );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/MapExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/MapExtractorTest.java
@@ -24,6 +24,7 @@ import javax.validation.constraints.Size;
 import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.testutils.CandidateForTck;
+
 import org.testng.annotations.Test;
 
 /**
@@ -43,7 +44,7 @@ public class MapExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithCascadingKeys>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType<K>[too short].type", "addressByType<K>[too small].type" );
+		assertCorrectPropertyPaths( violations, "addressByType<K>[key('too short')].type", "addressByType<K>[key('too small')].type" );
 	}
 
 	@Test
@@ -57,7 +58,7 @@ public class MapExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithConstrainedKeys>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType<K>[too short].<map key>", "addressByType<K>[too small].<map key>" );
+		assertCorrectPropertyPaths( violations, "addressByType<K>[key('too short')].<map key>", "addressByType<K>[key('too small')].<map key>" );
 	}
 
 	@Test
@@ -71,7 +72,7 @@ public class MapExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithCascadingKeyAndValueMap>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType[too small].email", "addressByType[long enough].email", "addressByType<K>[too small].type", "addressByType<K>[too short].type" );
+		assertCorrectPropertyPaths( violations, "addressByType[key('too small')].email", "addressByType[key('long enough')].email", "addressByType<K>[key('too small')].type", "addressByType<K>[key('too short')].type" );
 	}
 
 	@Test
@@ -85,7 +86,7 @@ public class MapExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithConstrainedKeysAndValues>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType<K>[too short].<map key>", "addressByType<K>[too small].<map key>", "addressByType[long enough].<map value>" );
+		assertCorrectPropertyPaths( violations, "addressByType<K>[key('too short')].<map key>", "addressByType<K>[key('too small')].<map key>", "addressByType[key('long enough')].<map value>" );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/NestedCascadedConstraintsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/NestedCascadedConstraintsTest.java
@@ -50,8 +50,8 @@ public class NestedCascadedConstraintsTest {
 
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[invalid].<map value>[1].email",
-				"map[invalid].<map value>[2].email"
+				"map[key('invalid')].<map value>[1].email",
+				"map[key('invalid')].<map value>[2].email"
 		);
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Email.class )
@@ -86,9 +86,9 @@ public class NestedCascadedConstraintsTest {
 
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[Optional[Cinema<cinema2>]].<map value>[1].email",
-				"map[Optional[Cinema<cinema2>]].<map value>[2].email",
-				"map[Optional[Cinema<cinema3>]].<map value>[0].<list element>"
+				"map[key('Optional[Cinema<cinema2>]')].<map value>[1].email",
+				"map[key('Optional[Cinema<cinema2>]')].<map value>[2].email",
+				"map[key('Optional[Cinema<cinema3>]')].<map value>[0].<list element>"
 		);
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Email.class )
@@ -122,7 +122,7 @@ public class NestedCascadedConstraintsTest {
 
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map<K>[Optional[Cinema<cinema4>]].<map key>.visitor.name"
+				"map<K>[key('Optional[Cinema<cinema4>]')].<map key>.visitor.name"
 		);
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( NotNull.class )

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractMethodValidationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractMethodValidationTest.java
@@ -274,7 +274,7 @@ public abstract class AbstractMethodValidationTest {
 			assertMethodValidationType( constraintViolation, ElementKind.PARAMETER );
 			assertEquals(
 					constraintViolation.getPropertyPath().toString(),
-					"cascadingMapParameter.customer[Bob].name"
+					"cascadingMapParameter.customer[key('Bob')].name"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
 			assertEquals( constraintViolation.getRootBean(), customerRepository );
@@ -623,7 +623,7 @@ public abstract class AbstractMethodValidationTest {
 			assertMethodValidationType( constraintViolation, ElementKind.RETURN_VALUE );
 			assertEquals(
 					constraintViolation.getPropertyPath().toString(),
-					"cascadingMapReturnValue.<return value>[Bob].name"
+					"cascadingMapReturnValue.<return value>[key('Bob')].name"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
 			assertEquals( constraintViolation.getRootBean(), customerRepository );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/SameElementContainedSeveralTimesInCollectionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/SameElementContainedSeveralTimesInCollectionTest.java
@@ -62,7 +62,7 @@ public class SameElementContainedSeveralTimesInCollectionTest {
 
 		Set<ConstraintViolation<MapContainer>> constraintViolations = validator.validate( withMap );
 
-		assertCorrectPropertyPaths( constraintViolations, "values[EMPTY_1].<map value>", "values[EMPTY_2].<map value>" );
+		assertCorrectPropertyPaths( constraintViolations, "values[key('EMPTY_1')].<map value>", "values[key('EMPTY_2')].<map value>" );
 	}
 
 	private static class ListContainer {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/NestedTypeArgumentsValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/NestedTypeArgumentsValueExtractorTest.java
@@ -56,7 +56,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		constraintViolations = validator.validate( MapOfLists.invalidKey() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map<K>[k].<map key>" );
+				"map<K>[key('k')].<map key>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -68,7 +68,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		constraintViolations = validator.validate( MapOfLists.invalidList() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[key1].<map value>" );
+				"map[key('key1')].<map value>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -80,8 +80,8 @@ public class NestedTypeArgumentsValueExtractorTest {
 		constraintViolations = validator.validate( MapOfLists.invalidString() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[key1].<map value>[0].<list element>",
-				"map[key1].<map value>[1].<list element>" );
+				"map[key('key1')].<map value>[0].<list element>",
+				"map[key('key1')].<map value>[1].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -100,9 +100,9 @@ public class NestedTypeArgumentsValueExtractorTest {
 		constraintViolations = validator.validate( MapOfLists.reallyInvalid() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map<K>[k].<map key>",
-				"map[k].<map value>",
-				"map[k].<map value>[0].<list element>" );
+				"map<K>[key('k')].<map key>",
+				"map[key('k')].<map value>",
+				"map[key('k')].<map value>[0].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -131,7 +131,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		constraintViolations = validator.validate( MapOfListsWithAutomaticUnwrapping.invalidStringProperty() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[key].<map value>[1].<list element>" );
+				"map[key('key')].<map value>[1].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -144,7 +144,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		constraintViolations = validator.validate( MapOfListsWithAutomaticUnwrapping.invalidListElement() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[key].<map value>[0].<list element>" );
+				"map[key('key')].<map value>[0].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( NotNull.class )
 						.withPropertyPath( pathWith()
@@ -184,8 +184,8 @@ public class NestedTypeArgumentsValueExtractorTest {
 		Set<ConstraintViolation<MapOfListsUsingGetter>> constraintViolations = validator.validate( MapOfListsUsingGetter.invalidString() );
 		assertCorrectPropertyPaths(
 				constraintViolations,
-				"map[key1].<map value>[0].<list element>",
-				"map[key1].<map value>[1].<list element>"
+				"map[key('key1')].<map value>[0].<list element>",
+				"map[key('key1')].<map value>[1].<list element>"
 		);
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1334

This one only addresses the part about node keys:

> Revisit formats for node keys (from Emmanuel Bernard: I would have preferred something like "addressByType[key('too short')].value", At least for strings and any type that we don't know and will be toStringed. We make exceptions for numbers, booleans, dates

There's no exclusion for `java.util.Date` and `java.util.Calendar` at this moment. Let me know if that's needed and I'll make the updates.