### PR TITLE
HV-1387 Add tests for the string representation of the property path

### DIFF
--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ScriptAssertDefTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ScriptAssertDefTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.cfg;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.testng.Assert.assertTrue;
 
 import java.time.Instant;
@@ -88,7 +88,7 @@ public class ScriptAssertDefTest {
 				)
 		);
 
-		assertCorrectPropertyPaths( violations, propertyPath );
+		assertCorrectPropertyPathStringRepresentations( violations, propertyPath );
 	}
 
 	/**

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/ClockProviderFutureTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/ClockProviderFutureTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv.time;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 
 import java.time.Clock;
@@ -63,7 +63,7 @@ public class ClockProviderFutureTest {
 		Order order = new Order();
 		order.shipmentDateAsReadableInstant = new DateTime( 2099, 2, 15, 4, 0, 0 );
 
-		assertCorrectPropertyPaths( validator.validate( order ), "shipmentDateAsReadableInstant" );
+		assertCorrectPropertyPathStringRepresentations( validator.validate( order ), "shipmentDateAsReadableInstant" );
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class ClockProviderFutureTest {
 		Order order = new Order();
 		order.shipmentDateAsReadablePartial = new org.joda.time.LocalDateTime( 2099, 2, 15, 4, 0, 0 );
 
-		assertCorrectPropertyPaths( validator.validate( order ), "shipmentDateAsReadablePartial" );
+		assertCorrectPropertyPathStringRepresentations( validator.validate( order ), "shipmentDateAsReadablePartial" );
 	}
 
 	private static class Order {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/ClockProviderPastTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/ClockProviderPastTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv.time;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 
 import java.time.Clock;
@@ -63,7 +63,7 @@ public class ClockProviderPastTest {
 		Order order = new Order();
 		order.orderDateAsReadableInstant = new DateTime( 1901, 2, 15, 4, 0, 0 );
 
-		assertCorrectPropertyPaths( validator.validate( order ), "orderDateAsReadableInstant" );
+		assertCorrectPropertyPathStringRepresentations( validator.validate( order ), "orderDateAsReadableInstant" );
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class ClockProviderPastTest {
 		Order order = new Order();
 		order.orderDateAsReadablePartial = new org.joda.time.LocalDateTime( 1901, 2, 15, 4, 0, 0 );
 
-		assertCorrectPropertyPaths( validator.validate( order ), "orderDateAsReadablePartial" );
+		assertCorrectPropertyPathStringRepresentations( validator.validate( order ), "orderDateAsReadablePartial" );
 	}
 
 	private static class Order {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CascadedClassConstraintTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CascadedClassConstraintTest.java
@@ -8,7 +8,7 @@ package org.hibernate.validator.test.internal.engine.cascaded;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -41,7 +41,7 @@ public class CascadedClassConstraintTest {
 		Validator validator = ValidatorUtil.getValidator();
 		Set<ConstraintViolation<Bar>> violations = validator.validate( new Bar() );
 
-		assertCorrectPropertyPaths( violations, "foos[0]", "foos[1]" );
+		assertCorrectPropertyPathStringRepresentations( violations, "foos[0]", "foos[1]" );
 	}
 
 	@Test
@@ -49,7 +49,7 @@ public class CascadedClassConstraintTest {
 		Validator validator = ValidatorUtil.getValidator();
 		Set<ConstraintViolation<BarUsingTypeParameterOnField>> violations = validator.validate( new BarUsingTypeParameterOnField() );
 
-		assertCorrectPropertyPaths( violations, "foos[0]", "foos[1]" );
+		assertCorrectPropertyPathStringRepresentations( violations, "foos[0]", "foos[1]" );
 	}
 
 	@Test
@@ -57,7 +57,7 @@ public class CascadedClassConstraintTest {
 		Validator validator = ValidatorUtil.getValidator();
 		Set<ConstraintViolation<BarUsingTypeParameterOnGetter>> violations = validator.validate( new BarUsingTypeParameterOnGetter() );
 
-		assertCorrectPropertyPaths( violations, "foos[0]", "foos[1]" );
+		assertCorrectPropertyPathStringRepresentations( violations, "foos[0]", "foos[1]" );
 	}
 
 	@ValidFoo

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CascadedIterableMapPropertiesTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CascadedIterableMapPropertiesTest.java
@@ -22,7 +22,7 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.CandidateForTck;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
 /**
@@ -40,7 +40,7 @@ public class CascadedIterableMapPropertiesTest {
 	public void testValidateCustomIterableType() {
 		Validator validator = getValidator();
 		Set<ConstraintViolation<IterableExtHolder>> constraintViolations = validator.validate( new IterableExtHolder() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"iterableExt.value",
 				"iterableExt[].number"
@@ -52,7 +52,7 @@ public class CascadedIterableMapPropertiesTest {
 	public void testValidateCustomListType() {
 		Validator validator = getValidator();
 		Set<ConstraintViolation<ListExtHolder>> constraintViolations = validator.validate( new ListExtHolder() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"listExt.value",
 				"listExt[1].number"
@@ -64,7 +64,7 @@ public class CascadedIterableMapPropertiesTest {
 	public void testValidateCustomMapType() {
 		Validator validator = getValidator();
 		Set<ConstraintViolation<MapExtHolder>> constraintViolations = validator.validate( new MapExtHolder() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"mapExt.value",
 				"mapExt[second].number"

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CustomValueExtractorTest.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.test.internal.engine.cascaded;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 import java.lang.reflect.TypeVariable;
 import java.util.Map;
@@ -68,7 +68,7 @@ public class CustomValueExtractorTest {
 
 		Set<ConstraintViolation<Cinema>> violations = validator.validate( cinema );
 
-		assertCorrectPropertyPaths( violations, "visitor.name" );
+		assertCorrectPropertyPathStringRepresentations( violations, "visitor.name" );
 	}
 
 	@Test
@@ -83,7 +83,7 @@ public class CustomValueExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithMultimap>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType<V>[work].email", "addressByType<V>[work].email" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addressByType<V>[work].email", "addressByType<V>[work].email" );
 	}
 
 	@Test
@@ -99,7 +99,7 @@ public class CustomValueExtractorTest {
 
 				Set<ConstraintViolation<CustomerWithMultimap>> violations = validator.validate( bob );
 
-				assertCorrectPropertyPaths( violations, "addressByType<V>[work].email", "addressByType<V>[work].email" );
+				assertCorrectPropertyPathStringRepresentations( violations, "addressByType<V>[work].email", "addressByType<V>[work].email" );
 		} );
 	}
 
@@ -114,7 +114,7 @@ public class CustomValueExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithStringStringMultimap>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType<V>[work].multimap_value", "addressByType<V>[work].multimap_value" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addressByType<V>[work].multimap_value", "addressByType<V>[work].multimap_value" );
 	}
 
 	@Test
@@ -127,7 +127,7 @@ public class CustomValueExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithOptionalAddress>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "address" );
+		assertCorrectPropertyPathStringRepresentations( violations, "address" );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class, expectedExceptionsMessageRegExp = "HV000197.*")
@@ -156,7 +156,7 @@ public class CustomValueExtractorTest {
 				Set<ConstraintViolation<CustomerWithOptionalAddress>> violations = validator.validate( bob );
 
 				// validation.xml overrides service loader
-				assertCorrectPropertyPaths( violations, "address.1" );
+				assertCorrectPropertyPathStringRepresentations( violations, "address.1" );
 
 				ValidatorFactory validatorFactory = Validation.byDefaultProvider()
 						.configure()
@@ -168,7 +168,7 @@ public class CustomValueExtractorTest {
 				violations = validator.validate( bob );
 
 				// VF overrides validation.xml
-				assertCorrectPropertyPaths( violations, "address.2" );
+				assertCorrectPropertyPathStringRepresentations( violations, "address.2" );
 
 				validator = validatorFactory.usingContext()
 						.addValueExtractor( new GuavaOptionalValueExtractor3() )
@@ -177,7 +177,7 @@ public class CustomValueExtractorTest {
 				violations = validator.validate( bob );
 
 				// V overrides VF
-				assertCorrectPropertyPaths( violations, "address.3" );
+				assertCorrectPropertyPathStringRepresentations( violations, "address.3" );
 			}
 		);
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/MapExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/MapExtractorTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.engine.cascaded;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
 
@@ -43,7 +43,7 @@ public class MapExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithCascadingKeys>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType<K>[too short].type", "addressByType<K>[too small].type" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addressByType<K>[too short].type", "addressByType<K>[too small].type" );
 	}
 
 	@Test
@@ -57,7 +57,7 @@ public class MapExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithConstrainedKeys>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType<K>[too short].<map key>", "addressByType<K>[too small].<map key>" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addressByType<K>[too short].<map key>", "addressByType<K>[too small].<map key>" );
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class MapExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithCascadingKeyAndValueMap>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType[too small].email", "addressByType[long enough].email", "addressByType<K>[too small].type", "addressByType<K>[too short].type" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addressByType[too small].email", "addressByType[long enough].email", "addressByType<K>[too small].type", "addressByType<K>[too short].type" );
 	}
 
 	@Test
@@ -85,7 +85,7 @@ public class MapExtractorTest {
 
 		Set<ConstraintViolation<CustomerWithConstrainedKeysAndValues>> violations = validator.validate( bob );
 
-		assertCorrectPropertyPaths( violations, "addressByType<K>[too short].<map key>", "addressByType<K>[too small].<map key>", "addressByType[long enough].<map value>" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addressByType<K>[too short].<map key>", "addressByType<K>[too small].<map key>", "addressByType[long enough].<map value>" );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/NestedCascadedConstraintsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/NestedCascadedConstraintsTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.engine.cascaded;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
@@ -48,7 +48,7 @@ public class NestedCascadedConstraintsTest {
 
 		constraintViolations = validator.validate( EmailAddressMap.invalidEmailAddressMap() );
 
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"map[invalid].<map value>[1].email",
 				"map[invalid].<map value>[2].email"
@@ -84,7 +84,7 @@ public class NestedCascadedConstraintsTest {
 		CinemaEmailAddresses invalidCinemaEmailAddresses = CinemaEmailAddresses.invalidCinemaEmailAddresses();
 		constraintViolations = validator.validate( invalidCinemaEmailAddresses );
 
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"map[Optional[Cinema<cinema2>]].<map value>[1].email",
 				"map[Optional[Cinema<cinema2>]].<map value>[2].email",
@@ -120,7 +120,7 @@ public class NestedCascadedConstraintsTest {
 		CinemaEmailAddresses invalidKeyCinemaEmailAddresses = CinemaEmailAddresses.invalidKey();
 		constraintViolations = validator.validate( invalidKeyCinemaEmailAddresses );
 
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"map<K>[Optional[Cinema<cinema4>]].<map key>.visitor.name"
 		);
@@ -151,7 +151,7 @@ public class NestedCascadedConstraintsTest {
 
 		constraintViolations = validator.validate( CinemaArray.invalidCinemaArray() );
 
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"array[0].<iterable element>[0].<list element>",
 				"array[0].<iterable element>[1].visitor.name"
@@ -189,7 +189,7 @@ public class NestedCascadedConstraintsTest {
 
 		constraintViolations = validator.validate( NestedCascadingListWithValidAllAlongTheWay.withNullList() );
 
-		assertCorrectPropertyPaths( constraintViolations, "list[0].<list element>" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "list[0].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( NotNull.class )
 						.withPropertyPath( pathWith()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/conversion/AbstractGroupConversionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/conversion/AbstractGroupConversionTest.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.test.internal.engine.groups.conversion;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.asSet;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
 import java.util.Arrays;
@@ -44,13 +44,13 @@ public abstract class AbstractGroupConversionTest {
 	@Test
 	public void groupConversionOnField() {
 		Set<ConstraintViolation<User1>> violations = validator.validate( new User1() );
-		assertCorrectPropertyPaths( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].street1", "addresses[].zipCode" );
 	}
 
 	@Test
 	public void groupConversionOnGetter() {
 		Set<ConstraintViolation<User2>> violations = validator.validate( new User2() );
-		assertCorrectPropertyPaths( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].street1", "addresses[].zipCode" );
 	}
 
 	@Test
@@ -61,7 +61,7 @@ public abstract class AbstractGroupConversionTest {
 				new List<?>[] { Arrays.asList( new Address() ) }
 		);
 
-		assertCorrectPropertyPaths( violations, "setAddresses.addresses[0].street1", "setAddresses.addresses[0].zipCode" );
+		assertCorrectPropertyPathStringRepresentations( violations, "setAddresses.addresses[0].street1", "setAddresses.addresses[0].zipCode" );
 	}
 
 	@Test
@@ -72,7 +72,7 @@ public abstract class AbstractGroupConversionTest {
 				Arrays.asList( new Address() )
 		);
 
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				violations,
 				"findAddresses.<return value>[0].street1",
 				"findAddresses.<return value>[0].zipCode"
@@ -82,28 +82,28 @@ public abstract class AbstractGroupConversionTest {
 	@Test
 	public void multipleGroupConversionsOnField() {
 		Set<ConstraintViolation<User3>> violations = validator.validate( new User3() );
-		assertCorrectPropertyPaths( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].street1", "addresses[].zipCode" );
 
 		violations = validator.validate( new User3(), Complete.class );
 		for ( ConstraintViolation<User3> constraintViolation : violations ) {
 			log.info( constraintViolation.getPropertyPath() );
 		}
-		assertCorrectPropertyPaths( violations, "addresses[].doorCode", "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].doorCode", "addresses[].street1", "addresses[].zipCode" );
 	}
 
 	@Test
 	public void multipleGroupConversionsOnGetter() {
 		Set<ConstraintViolation<User4>> violations = validator.validate( new User4() );
-		assertCorrectPropertyPaths( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].street1", "addresses[].zipCode" );
 
 		violations = validator.validate( new User4(), Complete.class );
-		assertCorrectPropertyPaths( violations, "addresses[].doorCode", "addresses[].street1", "addresses[].zipCode" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].doorCode", "addresses[].street1", "addresses[].zipCode" );
 	}
 
 	@Test
 	public void conversionIsEvaluatedPerProperty() {
 		Set<ConstraintViolation<User5>> violations = validator.validate( new User5() );
-		assertCorrectPropertyPaths( violations, "addresses[].street1", "addresses[].zipCode", "phoneNumber.number" );
+		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].street1", "addresses[].zipCode", "phoneNumber.number" );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class,

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/DefaultGroupWithInheritanceTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/DefaultGroupWithInheritanceTest.java
@@ -15,7 +15,7 @@ import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.ValidatorUtil;
 import org.testng.annotations.Test;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 /**
  * @author Gunnar Morling
@@ -28,7 +28,7 @@ public class DefaultGroupWithInheritanceTest {
 		Validator validator = ValidatorUtil.getValidator();
 
 		Set<ConstraintViolation<A>> violations = validator.validate( new A() );
-		assertCorrectPropertyPaths( violations, "foo", "bar" );
+		assertCorrectPropertyPathStringRepresentations( violations, "foo", "bar" );
 	}
 
 	@Test
@@ -36,6 +36,6 @@ public class DefaultGroupWithInheritanceTest {
 		Validator validator = ValidatorUtil.getValidator();
 
 		Set<ConstraintViolation<B>> violations = validator.validate( new B(), Max.class, Min.class );
-		assertCorrectPropertyPaths( violations, "foo", "bar" );
+		assertCorrectPropertyPathStringRepresentations( violations, "foo", "bar" );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/sequence/SequenceOfSequencesTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/sequence/SequenceOfSequencesTest.java
@@ -23,7 +23,7 @@ import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.ValidatorUtil;
 import org.testng.annotations.Test;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 /**
  * Sequences may comprise other sequences.
@@ -42,19 +42,19 @@ public class SequenceOfSequencesTest {
 		PlushAlligator alligator = new PlushAlligator();
 
 		Set<ConstraintViolation<PlushAlligator>> violations = validator.validate( alligator, AllConstraints.class );
-		assertCorrectPropertyPaths( violations, "name" );
+		assertCorrectPropertyPathStringRepresentations( violations, "name" );
 
 		alligator.name = "Ruben";
 		violations = validator.validate( alligator, AllConstraints.class );
-		assertCorrectPropertyPaths( violations, "highestEducationalDegree" );
+		assertCorrectPropertyPathStringRepresentations( violations, "highestEducationalDegree" );
 
 		alligator.highestEducationalDegree = "PhD";
 		violations = validator.validate( alligator, AllConstraints.class );
-		assertCorrectPropertyPaths( violations, "length" );
+		assertCorrectPropertyPathStringRepresentations( violations, "length" );
 
 		alligator.length = 540;
 		violations = validator.validate( alligator, AllConstraints.class );
-		assertCorrectPropertyPaths( violations, "age" );
+		assertCorrectPropertyPathStringRepresentations( violations, "age" );
 	}
 
 	/**
@@ -68,19 +68,19 @@ public class SequenceOfSequencesTest {
 		PlushCrocodile crocodile = new PlushCrocodile();
 
 		Set<ConstraintViolation<PlushCrocodile>> violations = validator.validate( crocodile );
-		assertCorrectPropertyPaths( violations, "name" );
+		assertCorrectPropertyPathStringRepresentations( violations, "name" );
 
 		crocodile.name = "Ruben";
 		violations = validator.validate( crocodile, AllConstraints.class );
-		assertCorrectPropertyPaths( violations, "highestEducationalDegree" );
+		assertCorrectPropertyPathStringRepresentations( violations, "highestEducationalDegree" );
 
 		crocodile.highestEducationalDegree = "PhD";
 		violations = validator.validate( crocodile, AllConstraints.class );
-		assertCorrectPropertyPaths( violations, "length" );
+		assertCorrectPropertyPathStringRepresentations( violations, "length" );
 
 		crocodile.length = 540;
 		violations = validator.validate( crocodile, AllConstraints.class );
-		assertCorrectPropertyPaths( violations, "age" );
+		assertCorrectPropertyPathStringRepresentations( violations, "age" );
 	}
 
 	public static class PlushAlligator {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/AbstractPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/AbstractPathStringRepresentationTest.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.stringrepresentation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.testng.annotations.BeforeClass;
+
+/**
+ * @author Marko Bekhta
+ */
+public abstract class AbstractPathStringRepresentationTest {
+
+	protected Validator validator;
+
+	@BeforeClass
+	public void setupValidator() {
+		validator = Validation.buildDefaultValidatorFactory().getValidator();
+	}
+
+
+	@ValidLyonZipCode
+	protected static class Address {
+
+		@NotNull
+		private String street;
+		@Valid
+		private City city;
+		private String zipCode;
+
+		public Address(@NotNull String street, @Valid City city) {
+			this.street = street;
+			this.city = city;
+		}
+
+		@Valid
+		public Address(String street, City city, String zipCode) {
+			this.street = street;
+			this.city = city;
+			this.zipCode = zipCode;
+		}
+
+		@Override
+		public String toString() {
+			return street + ", " + city;
+		}
+	}
+
+	protected static class City {
+
+		@Size(min = 3)
+		private String name;
+
+		@Valid
+		public City(@Size(min = 3) String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+	}
+
+	@Target({ TYPE, ANNOTATION_TYPE })
+	@Retention(RUNTIME)
+	@Constraint(validatedBy = { ValidLyonZipCodeValidator.class })
+	@Documented
+	public @interface ValidLyonZipCode {
+
+		String message() default "{org.hibernate.validator.test.internal.engine.valuehandling.ValidLyonZipCode.message}";
+
+		Class<?>[] groups() default { };
+
+		Class<? extends Payload>[] payload() default { };
+	}
+
+	public static class ValidLyonZipCodeValidator implements ConstraintValidator<ValidLyonZipCode, Address> {
+
+		@Override
+		public boolean isValid(Address address, ConstraintValidatorContext context) {
+			if ( address == null || address.zipCode == null || address.city == null || !"Lyon".equals( address.city.name ) ) {
+				return true;
+			}
+
+			return address.zipCode.length() == 5 && address.zipCode.startsWith( "6900" );
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/BeanPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/BeanPathStringRepresentationTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.engine.path.stringrepresentation;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 import java.util.Set;
 
@@ -23,7 +23,7 @@ public class BeanPathStringRepresentationTest extends AbstractPathStringRepresen
 		Address address = new Address( "str", new City( "Lyon" ), "invalid zip" );
 		Set<ConstraintViolation<Address>> constraintViolations = validator.validate( address );
 
-		assertCorrectPropertyPaths( constraintViolations, "" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "" );
 	}
 
 	@Test
@@ -31,7 +31,7 @@ public class BeanPathStringRepresentationTest extends AbstractPathStringRepresen
 		Address address = new Address( null, new City( "" ) );
 		Set<ConstraintViolation<Address>> constraintViolations = validator.validate( address );
 
-		assertCorrectPropertyPaths( constraintViolations, "street", "city.name" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "street", "city.name" );
 	}
 
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/BeanPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/BeanPathStringRepresentationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.stringrepresentation;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class BeanPathStringRepresentationTest extends AbstractPathStringRepresentationTest {
+	@Test
+	public void testBeanPath() throws Exception {
+		Address address = new Address( "str", new City( "Lyon" ), "invalid zip" );
+		Set<ConstraintViolation<Address>> constraintViolations = validator.validate( address );
+
+		assertCorrectPropertyPaths( constraintViolations, "" );
+	}
+
+	@Test
+	public void testBeanPropertyPath() throws Exception {
+		Address address = new Address( null, new City( "" ) );
+		Set<ConstraintViolation<Address>> constraintViolations = validator.validate( address );
+
+		assertCorrectPropertyPaths( constraintViolations, "street", "city.name" );
+	}
+
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ConstructorPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ConstructorPathStringRepresentationTest.java
@@ -5,7 +5,7 @@ package org.hibernate.validator.test.internal.engine.path.stringrepresentation;/
  * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
  */
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 import java.lang.reflect.Constructor;
 import java.util.Set;
@@ -29,7 +29,7 @@ public class ConstructorPathStringRepresentationTest extends AbstractPathStringR
 				constructor,
 				new Object[] { "" }
 		);
-		assertCorrectPropertyPaths( constraintViolations, "City.name" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "City.name" );
 	}
 
 	@Test
@@ -39,7 +39,7 @@ public class ConstructorPathStringRepresentationTest extends AbstractPathStringR
 				constructor,
 				new Object[] { null, new City( "" ) }
 		);
-		assertCorrectPropertyPaths( constraintViolations, "Address.street", "Address.city.name" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "Address.street", "Address.city.name" );
 	}
 
 	@Test
@@ -49,7 +49,7 @@ public class ConstructorPathStringRepresentationTest extends AbstractPathStringR
 				constructor,
 				new City( "" )
 		);
-		assertCorrectPropertyPaths( constraintViolations, "City.<return value>.name" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "City.<return value>.name" );
 	}
 
 	@Test
@@ -59,7 +59,7 @@ public class ConstructorPathStringRepresentationTest extends AbstractPathStringR
 				constructor,
 				new Address( "str", new City( "Lyon" ), "invalid zip" )
 		);
-		assertCorrectPropertyPaths( constraintViolations, "Address.<return value>" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "Address.<return value>" );
 	}
 
 	@Test
@@ -70,7 +70,7 @@ public class ConstructorPathStringRepresentationTest extends AbstractPathStringR
 				new Object[] { "good name", true }
 		);
 
-		assertCorrectPropertyPaths( constraintViolations, "SmartCity.<cross-parameter>" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "SmartCity.<cross-parameter>" );
 	}
 
 	private static class SmartCity extends City {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ConstructorPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ConstructorPathStringRepresentationTest.java
@@ -1,0 +1,87 @@
+package org.hibernate.validator.test.internal.engine.path.stringrepresentation;/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+
+import java.lang.reflect.Constructor;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.Size;
+
+import org.hibernate.validator.constraints.ParameterScriptAssert;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class ConstructorPathStringRepresentationTest extends AbstractPathStringRepresentationTest {
+
+	@Test
+	public void testConstructorParameterPath() throws Exception {
+		Constructor<City> constructor = City.class.getConstructor( String.class );
+		Set<ConstraintViolation<City>> constraintViolations = validator.forExecutables().validateConstructorParameters(
+				constructor,
+				new Object[] { "" }
+		);
+		assertCorrectPropertyPaths( constraintViolations, "City.name" );
+	}
+
+	@Test
+	public void testConstructorMultipleParametersPath() throws Exception {
+		Constructor<Address> constructor = Address.class.getConstructor( String.class, City.class );
+		Set<ConstraintViolation<Address>> constraintViolations = validator.forExecutables().validateConstructorParameters(
+				constructor,
+				new Object[] { null, new City( "" ) }
+		);
+		assertCorrectPropertyPaths( constraintViolations, "Address.street", "Address.city.name" );
+	}
+
+	@Test
+	public void testConstructorReturnValuePath() throws Exception {
+		Constructor<City> constructor = City.class.getConstructor( String.class );
+		Set<ConstraintViolation<City>> constraintViolations = validator.forExecutables().validateConstructorReturnValue(
+				constructor,
+				new City( "" )
+		);
+		assertCorrectPropertyPaths( constraintViolations, "City.<return value>.name" );
+	}
+
+	@Test
+	public void testAnotherConstructorReturnValuePath() throws Exception {
+		Constructor<Address> constructor = Address.class.getConstructor( String.class, City.class, String.class );
+		Set<ConstraintViolation<Address>> constraintViolations = validator.forExecutables().validateConstructorReturnValue(
+				constructor,
+				new Address( "str", new City( "Lyon" ), "invalid zip" )
+		);
+		assertCorrectPropertyPaths( constraintViolations, "Address.<return value>" );
+	}
+
+	@Test
+	public void testConstructorCrossPath() throws Exception {
+		Constructor<SmartCity> constructor = SmartCity.class.getConstructor( String.class, boolean.class );
+		Set<ConstraintViolation<SmartCity>> constraintViolations = validator.forExecutables().validateConstructorParameters(
+				constructor,
+				new Object[] { "good name", true }
+		);
+
+		assertCorrectPropertyPaths( constraintViolations, "SmartCity.<cross-parameter>" );
+	}
+
+	private static class SmartCity extends City {
+
+		private final boolean isSmart;
+
+		@ParameterScriptAssert(lang = "groovy", script = "false")
+		public SmartCity(@Size(min = 3) String name, boolean isSmart) {
+			super( name );
+			this.isSmart = isSmart;
+		}
+	}
+
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ContainerElementPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ContainerElementPathStringRepresentationTest.java
@@ -4,47 +4,26 @@
  * License: Apache License, Version 2.0
  * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
  */
-package org.hibernate.validator.test.internal.engine.valuehandling;
+package org.hibernate.validator.test.internal.engine.path.stringrepresentation;
 
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.validation.Constraint;
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
 import javax.validation.ConstraintViolation;
-import javax.validation.Payload;
 import javax.validation.Valid;
-import javax.validation.Validation;
-import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-public class ContainerElementStringRepresentationTest {
-
-	private Validator validator;
-
-	@BeforeClass
-	public void setupValidator() {
-		validator = Validation.buildDefaultValidatorFactory().getValidator();
-	}
+public class ContainerElementPathStringRepresentationTest extends AbstractPathStringRepresentationTest {
 
 	@Test
 	public void testMapInvalidKeyTypeArgument() {
@@ -204,71 +183,6 @@ public class ContainerElementStringRepresentationTest {
 
 		public void put(City city, Address address) {
 			addressesPerCity.put( city, address );
-		}
-	}
-
-	@ValidLyonZipCode
-	private static class Address {
-		@NotNull
-		private String street;
-		@Valid
-		private City city;
-		private String zipCode;
-
-		public Address(String street, City city) {
-			this.street = street;
-			this.city = city;
-		}
-
-		public Address(String street, City city, String zipCode) {
-			this.street = street;
-			this.city = city;
-			this.zipCode = zipCode;
-		}
-
-		@Override
-		public String toString() {
-			return street + ", " + city;
-		}
-	}
-
-	private static class City {
-		@Size(min = 3)
-		private String name;
-
-		public City(String name) {
-			this.name = name;
-		}
-
-		@Override
-		public String toString() {
-			return name;
-		}
-
-	}
-
-	@Target({ TYPE, ANNOTATION_TYPE })
-	@Retention(RUNTIME)
-	@Constraint(validatedBy = { ValidLyonZipCodeValidator.class })
-	@Documented
-	public @interface ValidLyonZipCode {
-
-		String message() default "{org.hibernate.validator.test.internal.engine.valuehandling.ValidLyonZipCode.message}";
-
-		Class<?>[] groups() default { };
-
-		Class<? extends Payload>[] payload() default { };
-	}
-
-	public static class ValidLyonZipCodeValidator implements ConstraintValidator<ValidLyonZipCode, Address> {
-
-		@Override
-		public boolean isValid(Address address, ConstraintValidatorContext context) {
-			if ( address == null || address.zipCode == null || address.city == null || !"Lyon".equals( address.city.name ) ) {
-				return true;
-			}
-
-			return address.zipCode.length() == 5 && address.zipCode.startsWith( "6900" );
 		}
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ContainerElementPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ContainerElementPathStringRepresentationTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.engine.path.stringrepresentation;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
@@ -32,7 +32,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		Set<ConstraintViolation<DemographicStatistics>> constraintViolations = validator.validate( statistics );
 
-		assertCorrectPropertyPaths( constraintViolations, "inhabitantsPerAddress<K>[].<map key>" ); // the key is null, thus the '[]'
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "inhabitantsPerAddress<K>[].<map key>" ); // the key is null, thus the '[]'
 	}
 
 	@Test
@@ -43,7 +43,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		Set<ConstraintViolation<DemographicStatistics>> constraintViolations = validator.validate( statistics );
 
-		assertCorrectPropertyPaths( constraintViolations, "inhabitantsPerAddress<K>[null, Lyon].street" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "inhabitantsPerAddress<K>[null, Lyon].street" );
 
 		invalidAddress = new Address( "rue Garibaldi", new City( "L" ) );
 		statistics = new DemographicStatistics();
@@ -51,7 +51,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		constraintViolations = validator.validate( statistics );
 
-		assertCorrectPropertyPaths( constraintViolations, "inhabitantsPerAddress<K>[rue Garibaldi, L].city.name" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "inhabitantsPerAddress<K>[rue Garibaldi, L].city.name" );
 	}
 
 	@Test
@@ -62,7 +62,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		Set<ConstraintViolation<DemographicStatistics>> constraintViolations = validator.validate( statistics );
 
-		assertCorrectPropertyPaths( constraintViolations, "inhabitantsPerAddress<K>[rue Garibaldi, Lyon]" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "inhabitantsPerAddress<K>[rue Garibaldi, Lyon]" );
 	}
 
 	@Test
@@ -73,7 +73,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		Set<ConstraintViolation<State>> constraintViolations = validator.validate( state );
 
-		assertCorrectPropertyPaths( constraintViolations, "addressesPerCity[Lyon].<map value>" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "addressesPerCity[Lyon].<map value>" );
 	}
 
 	@Test
@@ -85,7 +85,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		Set<ConstraintViolation<State>> constraintViolations = validator.validate( state );
 
-		assertCorrectPropertyPaths( constraintViolations, "addressesPerCity[Lyon].street" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "addressesPerCity[Lyon].street" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( NotNull.class )
 						.withPropertyPath( pathWith()
@@ -100,7 +100,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		constraintViolations = validator.validate( state );
 
-		assertCorrectPropertyPaths( constraintViolations, "addressesPerCity[Lyon].city.name" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "addressesPerCity[Lyon].city.name" );
 	}
 
 	@Test
@@ -112,7 +112,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		Set<ConstraintViolation<State>> constraintViolations = validator.validate( state );
 
-		assertCorrectPropertyPaths( constraintViolations, "addressesPerCity[Lyon]" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "addressesPerCity[Lyon]" );
 	}
 
 	@Test
@@ -122,7 +122,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		Set<ConstraintViolation<Block>> constraintViolations = validator.validate( block );
 
-		assertCorrectPropertyPaths( constraintViolations, "addresses[0].<list element>" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "addresses[0].<list element>" );
 	}
 
 	@Test
@@ -132,7 +132,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		Set<ConstraintViolation<Block>> constraintViolations = validator.validate( block );
 
-		assertCorrectPropertyPaths( constraintViolations, "addresses[0].street" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "addresses[0].street" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( NotNull.class )
 						.withPropertyPath( pathWith()
@@ -146,7 +146,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		constraintViolations = validator.validate( block );
 
-		assertCorrectPropertyPaths( constraintViolations, "addresses[0].city.name" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "addresses[0].city.name" );
 	}
 
 	@Test
@@ -156,7 +156,7 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		Set<ConstraintViolation<Block>> constraintViolations = validator.validate( block );
 
-		assertCorrectPropertyPaths( constraintViolations, "addresses[0]" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "addresses[0]" );
 	}
 
 	private static class DemographicStatistics {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/MethodPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/MethodPathStringRepresentationTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.engine.path.stringrepresentation;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 import java.lang.reflect.Method;
 import java.util.Set;
@@ -39,7 +39,7 @@ public class MethodPathStringRepresentationTest extends AbstractPathStringRepres
 		Set<ConstraintViolation<CityService>> constraintViolations = validator.forExecutables()
 				.validateParameters( cityService, method, new Object[] { null } );
 
-		assertCorrectPropertyPaths( constraintViolations, "findByName.name" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "findByName.name" );
 	}
 
 	@Test
@@ -48,7 +48,7 @@ public class MethodPathStringRepresentationTest extends AbstractPathStringRepres
 		Set<ConstraintViolation<CityService>> constraintViolations = validator.forExecutables()
 				.validateParameters( cityService, method, new Object[] { null, null } );
 
-		assertCorrectPropertyPaths( constraintViolations, "findByCityAndStreet.city", "findByCityAndStreet.street" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "findByCityAndStreet.city", "findByCityAndStreet.street" );
 	}
 
 	@Test
@@ -57,7 +57,7 @@ public class MethodPathStringRepresentationTest extends AbstractPathStringRepres
 		Set<ConstraintViolation<CityService>> constraintViolations = validator.forExecutables()
 				.validateReturnValue( cityService, method, null );
 
-		assertCorrectPropertyPaths( constraintViolations, "findByName.<return value>" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "findByName.<return value>" );
 	}
 
 	@Test
@@ -66,7 +66,7 @@ public class MethodPathStringRepresentationTest extends AbstractPathStringRepres
 		Set<ConstraintViolation<CityService>> constraintViolations = validator.forExecutables()
 				.validateReturnValue( cityService, method, new Address( null, new City( "" ) ) );
 
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"findByCityAndStreet.<return value>.city.name",
 				"findByCityAndStreet.<return value>.street"
@@ -79,7 +79,7 @@ public class MethodPathStringRepresentationTest extends AbstractPathStringRepres
 		Set<ConstraintViolation<CityService>> constraintViolations = validator.forExecutables()
 				.validateParameters( cityService, method, new Object[] { null, null, null } );
 
-		assertCorrectPropertyPaths( constraintViolations, "findByCityAndStreetAndZip.<cross-parameter>" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "findByCityAndStreetAndZip.<cross-parameter>" );
 	}
 
 	private interface CityService {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/MethodPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/MethodPathStringRepresentationTest.java
@@ -1,0 +1,114 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.path.stringrepresentation;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.hibernate.validator.constraints.ParameterScriptAssert;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class MethodPathStringRepresentationTest extends AbstractPathStringRepresentationTest {
+
+	private CityService cityService;
+
+	@BeforeMethod
+	public void setUp() throws Exception {
+		this.cityService = new CityServiceImpl();
+	}
+
+	@Test
+	public void testMethodParameterPath() throws Exception {
+		Method method = CityService.class.getDeclaredMethod( "findByName", String.class );
+		Set<ConstraintViolation<CityService>> constraintViolations = validator.forExecutables()
+				.validateParameters( cityService, method, new Object[] { null } );
+
+		assertCorrectPropertyPaths( constraintViolations, "findByName.name" );
+	}
+
+	@Test
+	public void testMethodMultipleParametersPath() throws Exception {
+		Method method = CityService.class.getDeclaredMethod( "findByCityAndStreet", City.class, String.class );
+		Set<ConstraintViolation<CityService>> constraintViolations = validator.forExecutables()
+				.validateParameters( cityService, method, new Object[] { null, null } );
+
+		assertCorrectPropertyPaths( constraintViolations, "findByCityAndStreet.city", "findByCityAndStreet.street" );
+	}
+
+	@Test
+	public void testMethodReturnValuePath() throws Exception {
+		Method method = CityService.class.getDeclaredMethod( "findByName", String.class );
+		Set<ConstraintViolation<CityService>> constraintViolations = validator.forExecutables()
+				.validateReturnValue( cityService, method, null );
+
+		assertCorrectPropertyPaths( constraintViolations, "findByName.<return value>" );
+	}
+
+	@Test
+	public void testMethodReturnValuePropertyPath() throws Exception {
+		Method method = CityService.class.getDeclaredMethod( "findByCityAndStreet", City.class, String.class );
+		Set<ConstraintViolation<CityService>> constraintViolations = validator.forExecutables()
+				.validateReturnValue( cityService, method, new Address( null, new City( "" ) ) );
+
+		assertCorrectPropertyPaths(
+				constraintViolations,
+				"findByCityAndStreet.<return value>.city.name",
+				"findByCityAndStreet.<return value>.street"
+		);
+	}
+
+	@Test
+	public void testMethodCrossPath() throws Exception {
+		Method method = CityService.class.getDeclaredMethod( "findByCityAndStreetAndZip", City.class, String.class, String.class );
+		Set<ConstraintViolation<CityService>> constraintViolations = validator.forExecutables()
+				.validateParameters( cityService, method, new Object[] { null, null, null } );
+
+		assertCorrectPropertyPaths( constraintViolations, "findByCityAndStreetAndZip.<cross-parameter>" );
+	}
+
+	private interface CityService {
+
+		@NotNull
+		City findByName(@NotNull @Size(min = 3) String name);
+
+		@Valid
+		Address findByCityAndStreet(@NotNull City city, @NotNull String street);
+
+		@ParameterScriptAssert(lang = "groovy", script = "false")
+		Address findByCityAndStreetAndZip(City city, String street, String zip);
+	}
+
+	private static class CityServiceImpl implements CityService {
+
+		@Override
+		public City findByName(String name) {
+			return new City( name );
+		}
+
+		@Override
+		public Address findByCityAndStreet(City city, String street) {
+			return new Address( street, city );
+		}
+
+		@Override
+		public Address findByCityAndStreetAndZip(City city, String street, String zip) {
+			return null;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/package-info.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+/**
+ * Contains tests for String representation of the {@link javax.validation.Path}.
+ */
+package org.hibernate.validator.test.internal.engine.path.stringrepresentation;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/SameElementContainedSeveralTimesInCollectionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/typeannotationconstraint/SameElementContainedSeveralTimesInCollectionTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.engine.typeannotationconstraint;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
 import java.util.Arrays;
@@ -46,7 +46,7 @@ public class SameElementContainedSeveralTimesInCollectionTest {
 
 		Set<ConstraintViolation<ListContainer>> constraintViolations = validator.validate( listContainer );
 
-		assertCorrectPropertyPaths( constraintViolations, "values[0].<list element>", "values[2].<list element>" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "values[0].<list element>", "values[2].<list element>" );
 	}
 
 	@Test
@@ -62,7 +62,7 @@ public class SameElementContainedSeveralTimesInCollectionTest {
 
 		Set<ConstraintViolation<MapContainer>> constraintViolations = validator.validate( withMap );
 
-		assertCorrectPropertyPaths( constraintViolations, "values[EMPTY_1].<map value>", "values[EMPTY_2].<map value>" );
+		assertCorrectPropertyPathStringRepresentations( constraintViolations, "values[EMPTY_1].<map value>", "values[EMPTY_2].<map value>" );
 	}
 
 	private static class ListContainer {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/MostSpecificValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/MostSpecificValueExtractorTest.java
@@ -8,7 +8,7 @@ package org.hibernate.validator.test.internal.engine.valuehandling;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 import java.util.Set;
 
@@ -51,7 +51,7 @@ public class MostSpecificValueExtractorTest {
 				.getValidator();
 
 		Set<ConstraintViolation<Entity1>> violations = validator.validate( new Entity1( null ) );
-		assertCorrectPropertyPaths( violations, "wrapper.IWrapper11" );
+		assertCorrectPropertyPathStringRepresentations( violations, "wrapper.IWrapper11" );
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/NestedTypeArgumentsValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/NestedTypeArgumentsValueExtractorTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.engine.valuehandling;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
@@ -54,7 +54,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( MapOfLists.invalidKey() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"map<K>[k].<map key>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -66,7 +66,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		);
 
 		constraintViolations = validator.validate( MapOfLists.invalidList() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"map[key1].<map value>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -78,7 +78,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		);
 
 		constraintViolations = validator.validate( MapOfLists.invalidString() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"map[key1].<map value>[0].<list element>",
 				"map[key1].<map value>[1].<list element>" );
@@ -98,7 +98,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		);
 
 		constraintViolations = validator.validate( MapOfLists.reallyInvalid() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"map<K>[k].<map key>",
 				"map[k].<map value>",
@@ -129,7 +129,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( MapOfListsWithAutomaticUnwrapping.invalidStringProperty() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"map[key].<map value>[1].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -142,7 +142,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		);
 
 		constraintViolations = validator.validate( MapOfListsWithAutomaticUnwrapping.invalidListElement() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"map[key].<map value>[0].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -161,7 +161,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( ArrayOfOptionalsWithAutomaticUnwrapping.invalidArray() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"array[0].<iterable element>",
 				"array[1].<iterable element>" );
@@ -182,7 +182,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 	@Test
 	public void validation_of_nested_type_arguments_works_on_getter_with_map_of_list_of_optional() {
 		Set<ConstraintViolation<MapOfListsUsingGetter>> constraintViolations = validator.validate( MapOfListsUsingGetter.invalidString() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"map[key1].<map value>[0].<list element>",
 				"map[key1].<map value>[1].<list element>"
@@ -209,7 +209,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( NestedArray.invalidArrayFirstDimension() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"array[0].<iterable element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
@@ -221,7 +221,7 @@ public class NestedTypeArgumentsValueExtractorTest {
 		);
 
 		constraintViolations = validator.validate( NestedArray.invalidArraySecondDimension() );
-		assertCorrectPropertyPaths(
+		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"array[1].<iterable element>[1].<iterable element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/ValueExtractorDefinitionInHierarchyTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valuehandling/ValueExtractorDefinitionInHierarchyTest.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.validator.test.internal.engine.valuehandling;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 import java.util.Set;
 
@@ -42,7 +42,7 @@ public class ValueExtractorDefinitionInHierarchyTest {
 
 		Set<ConstraintViolation<Entity>> violations = validator.validate( entity );
 
-		assertCorrectPropertyPaths( violations, "property.wrapped" );
+		assertCorrectPropertyPathStringRepresentations( violations, "property.wrapped" );
 	}
 
 	@Test
@@ -58,7 +58,7 @@ public class ValueExtractorDefinitionInHierarchyTest {
 
 		Set<ConstraintViolation<Entity>> violations = validator.validate( entity );
 
-		assertCorrectPropertyPaths( violations, "property.wrapped" );
+		assertCorrectPropertyPathStringRepresentations( violations, "property.wrapped" );
 	}
 
 	@Test(expectedExceptions = ValueExtractorDefinitionException.class, expectedExceptionsMessageRegExp = "HV000218.*")

--- a/engine/src/test/java/org/hibernate/validator/test/parameternameprovider/ParanamerParameterNameProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/parameternameprovider/ParanamerParameterNameProviderTest.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.test.parameternameprovider;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPaths;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 
 import java.lang.annotation.Annotation;
@@ -95,7 +95,7 @@ public class ParanamerParameterNameProviderTest {
 				parameterValues
 		);
 
-		assertCorrectPropertyPaths( violations, "pauseGame.durationInSeconds" );
+		assertCorrectPropertyPathStringRepresentations( violations, "pauseGame.durationInSeconds" );
 	}
 
 	@SuppressWarnings("unused")

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
@@ -74,7 +74,7 @@ public final class ConstraintViolationAssert {
 	 * @param violations The violation list to verify.
 	 * @param expectedPropertyPaths The expected property paths.
 	 */
-	public static void assertCorrectPropertyPaths(Set<? extends ConstraintViolation<?>> violations,
+	public static void assertCorrectPropertyPathStringRepresentations(Set<? extends ConstraintViolation<?>> violations,
 			String... expectedPropertyPaths) {
 		Set<String> actualPaths = violations.stream()
 			.map( ConstraintViolation::getPropertyPath )


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1387

I looked through the tests that we already have. And I didn't want to duplicate beans and stuff to just validate a string representation of the path. So here's what I came up with...

I've added `ConstraintViolationAssert#violationOfAnything` which allows to ignore the check of actual constraint but you can still do all the other stuff like path, message etc. I also added `String propertyPathString` to `ViolationExpectation` so string representations can be tested using the same approach. And as a result I replaced all usages of `ConstraintViolationAssert#assertCorrectPropertyPaths`.

Looking at the changed tests it seems that string representation of paths covers the cases that you mentioned. Or should we have a set of dedicated tests just for this string representation?