### PR TITLE
HV-1422 Extract properties for base URLs commonly used in the reference guide

### DIFF
--- a/annotation-processor/pom.xml
+++ b/annotation-processor/pom.xml
@@ -93,8 +93,8 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <links>
-                        <link>http://docs.oracle.com/javase/8/docs/api/</link>
-                        <link>http://docs.jboss.org/hibernate/stable/beanvalidation/api/</link>
+                        <link>${java.doc.base.url}api/</link>
+                        <link>${bv.doc.base.url}</link>
                     </links>
                     <packagesheader>Hibernate Validator Annotation Processor Packages</packagesheader>
                     <doctitle>Hibernate Validator Annotation Processor ${project.version}</doctitle>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -103,9 +103,9 @@
                         ${basedir}/../annotation-processor/src/main/java
                     </sourcepath>
                     <links>
-                        <link>http://docs.oracle.com/javase/8/docs/api</link>
+                        <link>${java.doc.base.url}api</link>
                         <link>http://docs.oracle.com/javaee/7/api</link>
-                        <link>http://docs.jboss.org/hibernate/stable/beanvalidation/api</link>
+                        <link>${bv.doc.base.url}</link>
                         <link>http://javamoney.github.io/apidocs</link>
                     </links>
                     <tags>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -230,6 +230,9 @@
                         <hvVersion>${project.version}</hvVersion>
                         <bvVersion>${bv.api.version}</bvVersion>
                         <wildflyVersion>${wildfly.version}</wildflyVersion>
+                        <!-- URLs -->
+                        <java_se_docs>${java.doc.base.url}</java_se_docs>
+                        <bv_api_docs>${bv.doc.base.url}index.html?javax/validation/</bv_api_docs>
                     </attributes>
                 </configuration>
             </plugin>

--- a/documentation/src/main/asciidoc/ch01.asciidoc
+++ b/documentation/src/main/asciidoc/ch01.asciidoc
@@ -87,9 +87,9 @@ application server. You can learn more about the integration of Bean Validation 
 [[section-getting-started-security-manager]]
 ==== Running with a security manager
 
-Hibernate Validator supports running with a http://docs.oracle.com/javase/8/docs/technotes/guides/security/index.html[security manager] being enabled.
+Hibernate Validator supports running with a {java_se_docs}technotes/guides/security/index.html[security manager] being enabled.
 To do so, you must assign several permissions to the Hibernate Validator and the Bean Validation API code bases.
-The following shows how to do this via a http://docs.oracle.com/javase/8/docs/technotes/guides/security/PolicyFiles.html[policy file] as processed by the Java default policy implementation:
+The following shows how to do this via a {java_se_docs}technotes/guides/security/PolicyFiles.html[policy file] as processed by the Java default policy implementation:
 
 .Policy file for using Hibernate Validator with a security manager
 ====

--- a/documentation/src/main/asciidoc/ch02.asciidoc
+++ b/documentation/src/main/asciidoc/ch02.asciidoc
@@ -666,7 +666,7 @@ With one exception also these constraints apply to the field/property level, onl
 	Supported data types::: `java.time.Duration`
 	Hibernate metadata impact::: None
 
-`@EAN`:: Checks that the annotated character sequence is a valid link:$$http://en.wikipedia.org/wiki/International_Article_Number_%28EAN%29$$[EAN] barcode. type determines the type of barcode. The default is EAN-13.
+`@EAN`:: Checks that the annotated character sequence is a valid http://en.wikipedia.org/wiki/International_Article_Number_%28EAN%29[EAN] barcode. type determines the type of barcode. The default is EAN-13.
 	Supported data types::: `CharSequence`
 	Hibernate metadata impact::: None
 
@@ -674,7 +674,7 @@ With one exception also these constraints apply to the field/property level, onl
 	Supported data types::: `CharSequence`
 	Hibernate metadata impact::: Column length will be set to max
 
-`@LuhnCheck(startIndex= , endIndex=, checkDigitIndex=, ignoreNonDigitCharacters=)`:: Checks that the digits within the annotated character sequence pass the Luhn checksum algorithm (see also link:$$http://en.wikipedia.org/wiki/Luhn_algorithm$$[Luhn algorithm]). `startIndex` and `endIndex` allow to only run the algorithm on the specified sub-string. `checkDigitIndex` allows to use an arbitrary digit within the character sequence as the check digit. If not specified it is assumed that the check digit is part of the specified range. Last but not least, `ignoreNonDigitCharacters` allows to ignore non digit characters.
+`@LuhnCheck(startIndex= , endIndex=, checkDigitIndex=, ignoreNonDigitCharacters=)`:: Checks that the digits within the annotated character sequence pass the Luhn checksum algorithm (see also http://en.wikipedia.org/wiki/Luhn_algorithm[Luhn algorithm]). `startIndex` and `endIndex` allow to only run the algorithm on the specified sub-string. `checkDigitIndex` allows to use an arbitrary digit within the character sequence as the check digit. If not specified it is assumed that the check digit is part of the specified range. Last but not least, `ignoreNonDigitCharacters` allows to ignore non digit characters.
 	Supported data types::: `CharSequence`
 	Hibernate metadata impact::: None
 

--- a/documentation/src/main/asciidoc/ch03.asciidoc
+++ b/documentation/src/main/asciidoc/ch03.asciidoc
@@ -229,7 +229,7 @@ type `T` is used, also a subtype `S` of `T` may be used without altering the pro
 As an example, consider a class invoking a method on an object with the static type `T`. If the
 runtime type of that object was `S` and `S` imposed additional preconditions, the client class might
 fail to satisfy these preconditions as is not aware of them. The rules of behavioral subtyping are
-also known as the link:$$http://en.wikipedia.org/wiki/Liskov_substitution_principle$$[Liskov
+also known as the http://en.wikipedia.org/wiki/Liskov_substitution_principle[Liskov
 substitution principle].
 
 The Bean Validation specification implements the first rule by disallowing parameter constraints on
@@ -462,7 +462,7 @@ provides access to the validated object in case of return value validation.
 
 All the other `ConstraintViolation` methods generally work for method validation in the same way as
 for validation of beans. Refer to the
-http://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/index.html?javax/validation/metadata/BeanDescriptor.html[JavaDoc]
+{bv_api_docs}metadata/BeanDescriptor.html[JavaDoc]
 to learn more about the behavior of the individual methods and their return values during bean and
 method validation.
 

--- a/documentation/src/main/asciidoc/ch08.asciidoc
+++ b/documentation/src/main/asciidoc/ch08.asciidoc
@@ -72,7 +72,7 @@ If a `ValidatorFactory` instance is no longer in use, it should be disposed by c
 ==== `ValidationProviderResolver`
 
 By default, available Bean Validation providers are discovered using the
-http://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#Service_Provider[Java
+{java_se_docs}technotes/guides/jar/jar.html#Service_Provider[Java
 Service Provider] mechanism.
 
 For that purpose, each provider includes the file _META-

--- a/documentation/src/main/asciidoc/ch09.asciidoc
+++ b/documentation/src/main/asciidoc/ch09.asciidoc
@@ -32,8 +32,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter09/Car.java[t
 === `BeanDescriptor`
 
 The entry point into the metadata API is the method `Validator#getConstraintsForClass()`, which
-returns an instance of the link:$$https://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/index.
-html?javax/validation/metadata/BeanDescriptor.html$$[`BeanDescriptor`] interface. Using this
+returns an instance of the {bv_api_docs}metadata/BeanDescriptor.html[`BeanDescriptor`] interface. Using this
 descriptor, you can obtain metadata for constraints declared directly on the bean itself (class- or
 property-level), but also retrieve metadata descriptors representing single properties, methods and
 constructors.
@@ -85,7 +84,7 @@ methods to be returned (getters, non-getters or both).
 === `PropertyDescriptor`
 
 The interface
-https://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/index.html?javax/validation/metadata/PropertyDescriptor.html[`PropertyDescriptor`] represents one given property of a
+{bv_api_docs}metadata/PropertyDescriptor.html[`PropertyDescriptor`] represents one given property of a
 class. It is transparent whether constraints are declared on a field or a property getter, provided
 the JavaBeans naming conventions are respected. <<metadata-example-using-propertydescriptor>> shows
 how to use the `PropertyDescriptor` interface.
@@ -108,8 +107,8 @@ XML), `false` otherwise. Any configured group conversions are returned by `getGr
 === `MethodDescriptor` and `ConstructorDescriptor`
 
 Constrained methods and constructors are represented by the interfaces
-https://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/index.html?javax/validation/metadata/MethodDescriptor.html[`MethodDescriptor`]
-and https://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/index.html?javax/validation/metadata/ConstructorDescriptor.html[`ConstructorDescriptor`], respectively.
+{bv_api_docs}metadata/MethodDescriptor.html[`MethodDescriptor`]
+{bv_api_docs}metadata/ConstructorDescriptor.html[`ConstructorDescriptor`], respectively.
 <<metadata-example-using-methodandconstructordescriptor>> demonstrates how to work with these
 descriptors.
 
@@ -154,7 +153,7 @@ getter's `MethodDescriptor` (e.g.
 [[validator-metadata-api-elementdescriptor]]
 === `ElementDescriptor`
 
-The https://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/index.html?javax/validation/metadata/ElementDescriptor.html[`ElementDiscriptor`]
+The {bv_api_docs}metadata/ElementDescriptor.html[`ElementDiscriptor`]
 interface is the common base class for the
 individual descriptor types such as `BeanDescriptor`, `PropertyDescriptor` etc. Besides
 `getConstraintDescriptors()` it provides some more methods common to all descriptors.
@@ -218,7 +217,7 @@ sequence are.
 All those descriptor types that represent elements which can be subject of cascaded validation
 (i.e., `PropertyDescriptor`, `ParameterDescriptor` and `ReturnValueDescriptor`) provide access to the
 element's group conversions via `getGroupConversions()`. The returned set contains a
-https://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/index.html?javax/validation/metadata/GroupConversionDescriptor.html[`GroupConversionDescriptor`]
+{bv_api_docs}/metadata/GroupConversionDescriptor.html[`GroupConversionDescriptor`]
 for each configured conversion, allowing to retrieve
 source and target groups of the conversion. <<metadata-example-using-groupconversiondescriptor>>
 shows an example.
@@ -236,7 +235,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter09/CarTest.ja
 === `ConstraintDescriptor`
 
 Last but not least, the
-https://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/index.html?javax/validation/metadata/ConstraintDescriptor.html[`ConstraintDescriptor`]
+{bv_api_docs}metadata/ConstraintDescriptor.html[`ConstraintDescriptor`]
 interface describes a
 single constraint together with its composing constraints. Via an instance of this interface you get
 access to the constraint annotation and its parameters.

--- a/documentation/src/main/asciidoc/ch10.asciidoc
+++ b/documentation/src/main/asciidoc/ch10.asciidoc
@@ -138,7 +138,7 @@ specification.
 [TIP]
 ====
 The integration between JSF 2 and Bean Validation is described in the "Bean Validation Integration"
-chapter of link:$$http://jcp.org/en/jsr/detail?id=314$$[JSR-314]. It is interesting to know that JSF
+chapter of http://jcp.org/en/jsr/detail?id=314[JSR-314]. It is interesting to know that JSF
 2 implements a custom `MessageInterpolator` to ensure proper localization. To encourage the use
 of the Bean Validation message facility, JSF 2 will per default only display the generated Bean
 Validation message. This can, however, be configured via the application resource bundle by

--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -681,7 +681,7 @@ useful and whether they meet your needs.
 ==== Constraint definitions via `ServiceLoader`
 
 Hibernate Validator allows to utilize Java's
-http://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html[ServiceLoader]
+{java_se_docs}api/java/util/ServiceLoader.html[ServiceLoader]
 mechanism to register additional constraint definitions. All you have to do is to add the file
 _javax.validation.ConstraintValidator_ to _META-INF/services_. In this service file you list the
 fully qualified classnames of your constraint validator classes (one per line). Hibernate Validator

--- a/documentation/src/main/asciidoc/ch12.asciidoc
+++ b/documentation/src/main/asciidoc/ch12.asciidoc
@@ -47,7 +47,7 @@ annotations themselves
 === Options
 
 The behavior of the Hibernate Validator Annotation Processor can be controlled using the following
-http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javac.html#BHCHACIB[processor options]:
+{java_se_docs}technotes/tools/windows/javac.html#BHCHACIB[processor options]:
 
 `diagnosticKind`:: Controls how constraint problems are reported. Must be the
             string representation of one of the values from the enum `javax.tools.Diagnostic.Kind`,
@@ -141,7 +141,7 @@ for http://ant.apache.org/[Apache Ant]:
 ===== javac
 
 When compiling on the command line using
-http://docs.oracle.com/javase/8/docs/technotes/guides/javac/index.html[javac], specify the JAR
+{java_se_docs}technotes/guides/javac/index.html[javac], specify the JAR
 _hibernate-validator-annotation-processor-{hvVersion}.jar_ using the "processorpath" option as shown in
 the following listing. The processor will be detected automatically by the compiler and invoked
 during compilation.

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,8 @@
         <forbiddenapis-junit.path>forbidden-junit.txt</forbiddenapis-junit.path>
 
         <hibernate-validator-parent.path>.</hibernate-validator-parent.path>
+        <java.doc.base.url>http://docs.oracle.com/javase/8/docs/</java.doc.base.url>
+        <bv.doc.base.url>http://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/</bv.doc.base.url>
     </properties>
 
     <prerequisites>


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1422

I haven't found any mention of Asciidoctor supporting property files (I saw one suggestion to write a custom processor which can read *.properties file and use values from it while processing). So I thought that this approach might work - having urls extracted to attributes. I've added a separate file just for such attributes and extracted a few urls from first chapter just to test and see if it works. 

If you think such approach is ok I can look for and extract those commonly used ones in such a way.