### PR TITLE
HV-1405 Review assertCorrectPropertyPathStringRepresentations usage

### DIFF
--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ScriptAssertDefTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ScriptAssertDefTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.validator.test.cfg;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 import static org.testng.Assert.assertTrue;
 
 import java.time.Instant;
@@ -20,6 +22,8 @@ import org.hibernate.validator.HibernateValidator;
 import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.cfg.defs.ScriptAssertDef;
+import org.hibernate.validator.constraints.ScriptAssert;
+import org.hibernate.validator.testutil.ConstraintViolationAssert;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.ValidatorUtil;
 import org.testng.annotations.Test;
@@ -42,7 +46,7 @@ public class ScriptAssertDefTest {
 				);
 		configuration.addMapping( programmaticMapping );
 
-		assertCalendarEventViolations( configuration.buildValidatorFactory().getValidator(), "startDate" );
+		assertCalendarEventViolations( configuration.buildValidatorFactory().getValidator(), pathWith().property( "startDate" ) );
 	}
 
 	@Test
@@ -57,7 +61,7 @@ public class ScriptAssertDefTest {
 				);
 		configuration.addMapping( programmaticMapping );
 
-		assertCalendarEventViolations( configuration.buildValidatorFactory().getValidator(), "" );
+		assertCalendarEventViolations( configuration.buildValidatorFactory().getValidator(), pathWith().bean() );
 	}
 
 	@Test(expectedExceptions = ValidationException.class)
@@ -72,10 +76,10 @@ public class ScriptAssertDefTest {
 				);
 		configuration.addMapping( programmaticMapping );
 
-		assertCalendarEventViolations( configuration.buildValidatorFactory().getValidator(), "" );
+		assertCalendarEventViolations( configuration.buildValidatorFactory().getValidator(), pathWith().bean() );
 	}
 
-	private void assertCalendarEventViolations(Validator validator, String propertyPath) {
+	private void assertCalendarEventViolations(Validator validator, ConstraintViolationAssert.PathExpectation propertyPath) {
 		assertTrue( validator.validate( new CalendarEvent(
 						Instant.now(),
 						Instant.now().plusMillis( 1000L )
@@ -88,7 +92,10 @@ public class ScriptAssertDefTest {
 				)
 		);
 
-		assertCorrectPropertyPathStringRepresentations( violations, propertyPath );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ScriptAssert.class ).withPropertyPath( propertyPath )
+
+		);
 	}
 
 	/**

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/ClockProviderFutureTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/ClockProviderFutureTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv.time;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 
 import java.time.Clock;
@@ -19,6 +20,7 @@ import javax.validation.ValidatorFactory;
 import javax.validation.constraints.Future;
 
 import org.hibernate.validator.testutil.TestForIssue;
+
 import org.joda.time.DateTime;
 import org.joda.time.ReadableInstant;
 import org.joda.time.ReadablePartial;
@@ -63,7 +65,9 @@ public class ClockProviderFutureTest {
 		Order order = new Order();
 		order.shipmentDateAsReadableInstant = new DateTime( 2099, 2, 15, 4, 0, 0 );
 
-		assertCorrectPropertyPathStringRepresentations( validator.validate( order ), "shipmentDateAsReadableInstant" );
+		assertThat( validator.validate( order ) ).containsOnlyViolations(
+				violationOf( Future.class ).withProperty( "shipmentDateAsReadableInstant" )
+		);
 	}
 
 	@Test
@@ -71,7 +75,9 @@ public class ClockProviderFutureTest {
 		Order order = new Order();
 		order.shipmentDateAsReadablePartial = new org.joda.time.LocalDateTime( 2099, 2, 15, 4, 0, 0 );
 
-		assertCorrectPropertyPathStringRepresentations( validator.validate( order ), "shipmentDateAsReadablePartial" );
+		assertThat( validator.validate( order ) ).containsOnlyViolations(
+				violationOf( Future.class ).withProperty( "shipmentDateAsReadablePartial" )
+		);
 	}
 
 	private static class Order {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/ClockProviderPastTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/ClockProviderPastTest.java
@@ -6,7 +6,8 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv.time;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 
 import java.time.Clock;
@@ -63,7 +64,9 @@ public class ClockProviderPastTest {
 		Order order = new Order();
 		order.orderDateAsReadableInstant = new DateTime( 1901, 2, 15, 4, 0, 0 );
 
-		assertCorrectPropertyPathStringRepresentations( validator.validate( order ), "orderDateAsReadableInstant" );
+		assertThat( validator.validate( order ) ).containsOnlyViolations(
+				violationOf( Past.class ).withProperty( "orderDateAsReadableInstant" )
+		);
 	}
 
 	@Test
@@ -71,7 +74,9 @@ public class ClockProviderPastTest {
 		Order order = new Order();
 		order.orderDateAsReadablePartial = new org.joda.time.LocalDateTime( 1901, 2, 15, 4, 0, 0 );
 
-		assertCorrectPropertyPathStringRepresentations( validator.validate( order ), "orderDateAsReadablePartial" );
+		assertThat( validator.validate( order ) ).containsOnlyViolations(
+				violationOf( Past.class ).withProperty( "orderDateAsReadablePartial" )
+		);
 	}
 
 	private static class Order {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CascadingOnClassLevelConstraintTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CascadingOnClassLevelConstraintTest.java
@@ -8,7 +8,9 @@ package org.hibernate.validator.test.internal.engine.cascaded;
 
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -39,7 +41,20 @@ public class CascadingOnClassLevelConstraintTest {
 		Validator validator = ValidatorUtil.getValidator();
 		Set<ConstraintViolation<Bar>> violations = validator.validate( new Bar() );
 
-		assertCorrectPropertyPathStringRepresentations( violations, "foos[0]", "foos[1]" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidFoo.class )
+						.withPropertyPath( pathWith()
+								.property( "foos" )
+								.bean( true, null, 0, List.class, 0 )
+
+						),
+				violationOf( ValidFoo.class )
+						.withPropertyPath( pathWith()
+								.property( "foos" )
+								.bean( true, null, 1, List.class, 0 )
+
+						)
+		);
 	}
 
 	@Test
@@ -47,7 +62,20 @@ public class CascadingOnClassLevelConstraintTest {
 		Validator validator = ValidatorUtil.getValidator();
 		Set<ConstraintViolation<BarUsingTypeParameterOnField>> violations = validator.validate( new BarUsingTypeParameterOnField() );
 
-		assertCorrectPropertyPathStringRepresentations( violations, "foos[0]", "foos[1]" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidFoo.class )
+						.withPropertyPath( pathWith()
+								.property( "foos" )
+								.bean( true, null, 0, List.class, 0 )
+
+						),
+				violationOf( ValidFoo.class )
+						.withPropertyPath( pathWith()
+								.property( "foos" )
+								.bean( true, null, 1, List.class, 0 )
+
+						)
+		);
 	}
 
 	@Test
@@ -55,7 +83,20 @@ public class CascadingOnClassLevelConstraintTest {
 		Validator validator = ValidatorUtil.getValidator();
 		Set<ConstraintViolation<BarUsingTypeParameterOnGetter>> violations = validator.validate( new BarUsingTypeParameterOnGetter() );
 
-		assertCorrectPropertyPathStringRepresentations( violations, "foos[0]", "foos[1]" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( ValidFoo.class )
+						.withPropertyPath( pathWith()
+								.property( "foos" )
+								.bean( true, null, 0, List.class, 0 )
+
+						),
+				violationOf( ValidFoo.class )
+						.withPropertyPath( pathWith()
+								.property( "foos" )
+								.bean( true, null, 1, List.class, 0 )
+
+						)
+		);
 	}
 
 	@ValidFoo

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CascadingOnIterableMapWithAdditionalPropertiesTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/CascadingOnIterableMapWithAdditionalPropertiesTest.java
@@ -6,7 +6,9 @@
  */
 package org.hibernate.validator.test.internal.engine.cascaded;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
 import java.util.ArrayList;
@@ -38,10 +40,19 @@ public class CascadingOnIterableMapWithAdditionalPropertiesTest {
 	public void testValidateCustomIterableType() {
 		Validator validator = getValidator();
 		Set<ConstraintViolation<IterableExtHolder>> constraintViolations = validator.validate( new IterableExtHolder() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"iterableExt.value",
-				"iterableExt[].number"
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.property( "iterableExt" )
+								.property( "value" )
+
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.property( "iterableExt" )
+								.property( "number", true, null, null, IterableExt.class, null )
+
+						)
 		);
 	}
 
@@ -50,10 +61,19 @@ public class CascadingOnIterableMapWithAdditionalPropertiesTest {
 	public void testValidateCustomListType() {
 		Validator validator = getValidator();
 		Set<ConstraintViolation<ListExtHolder>> constraintViolations = validator.validate( new ListExtHolder() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"listExt.value",
-				"listExt[1].number"
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.property( "listExt" )
+								.property( "value" )
+
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.property( "listExt" )
+								.property( "number", true, null, 1, ListExt.class, null )
+
+						)
 		);
 	}
 
@@ -62,10 +82,19 @@ public class CascadingOnIterableMapWithAdditionalPropertiesTest {
 	public void testValidateCustomMapType() {
 		Validator validator = getValidator();
 		Set<ConstraintViolation<MapExtHolder>> constraintViolations = validator.validate( new MapExtHolder() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"mapExt.value",
-				"mapExt[second].number"
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.property( "mapExt" )
+								.property( "value" )
+
+						),
+				violationOf( Min.class )
+						.withPropertyPath( pathWith()
+								.property( "mapExt" )
+								.property( "number", true, "second", null, MapExt.class, null )
+
+						)
 		);
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/NestedCascadingArraySupportTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/cascaded/NestedCascadingArraySupportTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.validator.test.internal.engine.cascaded;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
@@ -45,11 +44,6 @@ public class NestedCascadingArraySupportTest {
 
 		constraintViolations = validator.validate( CinemaArray.invalidCinemaArray() );
 
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"array[0].<iterable element>[0].<list element>",
-				"array[0].<iterable element>[1].visitor.name"
-		);
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( NotNull.class )
 						.withPropertyPath( pathWith()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/conversion/AbstractGroupConversionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/conversion/AbstractGroupConversionTest.java
@@ -8,6 +8,9 @@ package org.hibernate.validator.test.internal.engine.groups.conversion;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.asSet;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
 import java.util.Arrays;
@@ -44,13 +47,31 @@ public abstract class AbstractGroupConversionTest {
 	@Test
 	public void groupConversionOnField() {
 		Set<ConstraintViolation<User1>> violations = validator.validate( new User1() );
-		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "street1", true, null, null, Set.class, 0 )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "zipCode" , true, null, null, Set.class, 0 )
+				)
+		);
 	}
 
 	@Test
 	public void groupConversionOnGetter() {
 		Set<ConstraintViolation<User2>> violations = validator.validate( new User2() );
-		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "street1", true, null, null, Set.class, 0 )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "zipCode" , true, null, null, Set.class, 0 )
+				)
+		);
 	}
 
 	@Test
@@ -61,7 +82,18 @@ public abstract class AbstractGroupConversionTest {
 				new List<?>[] { Arrays.asList( new Address() ) }
 		);
 
-		assertCorrectPropertyPathStringRepresentations( violations, "setAddresses.addresses[0].street1", "setAddresses.addresses[0].zipCode" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.method( "setAddresses" )
+						.parameter( "addresses",0 )
+						.property( "street1", true, null, 0, List.class, 0 )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.method( "setAddresses" )
+						.parameter( "addresses",0 )
+						.property( "zipCode" , true, null, 0, List.class, 0 )
+				)
+		);
 	}
 
 	@Test
@@ -72,6 +104,18 @@ public abstract class AbstractGroupConversionTest {
 				Arrays.asList( new Address() )
 		);
 
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.method( "findAddresses" )
+						.returnValue()
+						.property( "street1", true, null, 0, List.class, 0 )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.method( "findAddresses" )
+						.returnValue()
+						.property( "zipCode" , true, null, 0, List.class, 0 )
+				)
+		);
 		assertCorrectPropertyPathStringRepresentations(
 				violations,
 				"findAddresses.<return value>[0].street1",
@@ -82,28 +126,85 @@ public abstract class AbstractGroupConversionTest {
 	@Test
 	public void multipleGroupConversionsOnField() {
 		Set<ConstraintViolation<User3>> violations = validator.validate( new User3() );
-		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "street1", true, null, null, Set.class, 0 )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "zipCode" , true, null, null, Set.class, 0 )
+				)
+		);
 
 		violations = validator.validate( new User3(), Complete.class );
 		for ( ConstraintViolation<User3> constraintViolation : violations ) {
 			log.info( constraintViolation.getPropertyPath() );
 		}
-		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].doorCode", "addresses[].street1", "addresses[].zipCode" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "street1", true, null, null, Set.class, 0 )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "doorCode", true, null, null, Set.class, 0 )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "zipCode" , true, null, null, Set.class, 0 )
+				)
+		);
 	}
 
 	@Test
 	public void multipleGroupConversionsOnGetter() {
 		Set<ConstraintViolation<User4>> violations = validator.validate( new User4() );
-		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].street1", "addresses[].zipCode" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "street1", true, null, null, Set.class, 0 )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "zipCode" , true, null, null, Set.class, 0 )
+				)
+		);
 
 		violations = validator.validate( new User4(), Complete.class );
-		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].doorCode", "addresses[].street1", "addresses[].zipCode" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "street1", true, null, null, Set.class, 0 )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "doorCode", true, null, null, Set.class, 0 )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "zipCode" , true, null, null, Set.class, 0 )
+				)
+		);
 	}
 
 	@Test
 	public void conversionIsEvaluatedPerProperty() {
 		Set<ConstraintViolation<User5>> violations = validator.validate( new User5() );
-		assertCorrectPropertyPathStringRepresentations( violations, "addresses[].street1", "addresses[].zipCode", "phoneNumber.number" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "street1", true, null, null, Set.class, 0 )
+				),
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "phoneNumber" )
+						.property( "number" )
+				),
+				violationOf( Size.class ).withPropertyPath( pathWith()
+						.property( "addresses" )
+						.property( "zipCode" , true, null, null, Set.class, 0 )
+				)
+		);
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class,

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/DefaultGroupWithInheritanceTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupwithinheritance/DefaultGroupWithInheritanceTest.java
@@ -6,16 +6,18 @@
  */
 package org.hibernate.validator.test.internal.engine.groups.defaultgroupwithinheritance;
 
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.ValidatorUtil;
 import org.testng.annotations.Test;
-
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 /**
  * @author Gunnar Morling
@@ -28,7 +30,10 @@ public class DefaultGroupWithInheritanceTest {
 		Validator validator = ValidatorUtil.getValidator();
 
 		Set<ConstraintViolation<A>> violations = validator.validate( new A() );
-		assertCorrectPropertyPathStringRepresentations( violations, "foo", "bar" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "foo" ),
+				violationOf( NotNull.class ).withProperty( "bar" )
+		);
 	}
 
 	@Test
@@ -36,6 +41,9 @@ public class DefaultGroupWithInheritanceTest {
 		Validator validator = ValidatorUtil.getValidator();
 
 		Set<ConstraintViolation<B>> violations = validator.validate( new B(), Max.class, Min.class );
-		assertCorrectPropertyPathStringRepresentations( violations, "foo", "bar" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "foo" ),
+				violationOf( NotNull.class ).withProperty( "bar" )
+		);
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/sequence/SequenceOfSequencesTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/sequence/SequenceOfSequencesTest.java
@@ -6,6 +6,9 @@
  */
 package org.hibernate.validator.test.internal.engine.groups.sequence;
 
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
@@ -22,8 +25,6 @@ import org.hibernate.validator.test.internal.engine.groups.sequence.SequenceOfSe
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.ValidatorUtil;
 import org.testng.annotations.Test;
-
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 
 /**
  * Sequences may comprise other sequences.
@@ -42,19 +43,27 @@ public class SequenceOfSequencesTest {
 		PlushAlligator alligator = new PlushAlligator();
 
 		Set<ConstraintViolation<PlushAlligator>> violations = validator.validate( alligator, AllConstraints.class );
-		assertCorrectPropertyPathStringRepresentations( violations, "name" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "name" )
+		);
 
 		alligator.name = "Ruben";
 		violations = validator.validate( alligator, AllConstraints.class );
-		assertCorrectPropertyPathStringRepresentations( violations, "highestEducationalDegree" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "highestEducationalDegree" )
+		);
 
 		alligator.highestEducationalDegree = "PhD";
 		violations = validator.validate( alligator, AllConstraints.class );
-		assertCorrectPropertyPathStringRepresentations( violations, "length" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "length" )
+		);
 
 		alligator.length = 540;
 		violations = validator.validate( alligator, AllConstraints.class );
-		assertCorrectPropertyPathStringRepresentations( violations, "age" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "age" )
+		);
 	}
 
 	/**
@@ -68,19 +77,27 @@ public class SequenceOfSequencesTest {
 		PlushCrocodile crocodile = new PlushCrocodile();
 
 		Set<ConstraintViolation<PlushCrocodile>> violations = validator.validate( crocodile );
-		assertCorrectPropertyPathStringRepresentations( violations, "name" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "name" )
+		);
 
 		crocodile.name = "Ruben";
 		violations = validator.validate( crocodile, AllConstraints.class );
-		assertCorrectPropertyPathStringRepresentations( violations, "highestEducationalDegree" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "highestEducationalDegree" )
+		);
 
 		crocodile.highestEducationalDegree = "PhD";
 		violations = validator.validate( crocodile, AllConstraints.class );
-		assertCorrectPropertyPathStringRepresentations( violations, "length" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "length" )
+		);
 
 		crocodile.length = 540;
 		violations = validator.validate( crocodile, AllConstraints.class );
-		assertCorrectPropertyPathStringRepresentations( violations, "age" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "age" )
+		);
 	}
 
 	public static class PlushAlligator {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ContainerElementPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ContainerElementPathStringRepresentationTest.java
@@ -15,6 +15,7 @@ import static org.hibernate.validator.testutil.ConstraintViolationAssert.violati
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -192,6 +193,39 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 				"map[k].<map value>[0].<list element>" );
 	}
 
+	// HV-1428 Container element support is disabled for arrays
+	@Test(enabled = false)
+	public void testArrayPath() throws Exception {
+		Set<ConstraintViolation<Region>> constraintViolations = validator.validate( new Region(
+				Arrays.asList( new Address( null, null ) ),
+				Arrays.asList( null )
+		) );
+
+		assertCorrectPropertyPathStringRepresentations(
+				constraintViolations,
+				"array[0].<iterable element>[0].street",
+				"array[1].<iterable element>[0].<list element>"
+		);
+	}
+
+	@Test
+	public void testSetPath() throws Exception {
+		Set<ConstraintViolation<AddressBook>> constraintViolations = validator.validate(
+				new AddressBook()
+						.add( new Address( null, null ) )
+						.add( new Address( "Street", new City( "C" ) ) )
+						.add( new Address( "Street2", new City( "C" ) ) ) // expected to fail ?
+						.add( null )
+		);
+
+		assertCorrectPropertyPathStringRepresentations(
+				constraintViolations,
+				"addresses[].street",
+				"addresses[].city.name",
+				"addresses[].<iterable element>"
+		);
+	}
+
 	private static class DemographicStatistics {
 
 		private Map<@NotNull @Valid Address, @NotNull Integer> inhabitantsPerAddress = new HashMap<>();
@@ -207,6 +241,29 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 
 		public void add(Address address) {
 			addresses.add( address );
+		}
+	}
+
+	private static class AddressBook {
+
+		private final Set<@Valid @NotNull Address> addresses;
+
+		private AddressBook() {
+			this.addresses = new HashSet<>();
+		}
+
+		public AddressBook add(Address address) {
+			this.addresses.add( address );
+			return this;
+		}
+	}
+
+	private static class Region {
+
+		private final List<@Valid @NotNull Address>[] addresses;
+
+		private Region(List<Address>... addresses) {
+			this.addresses = addresses;
 		}
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ContainerElementPathStringRepresentationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/stringrepresentation/ContainerElementPathStringRepresentationTest.java
@@ -214,13 +214,16 @@ public class ContainerElementPathStringRepresentationTest extends AbstractPathSt
 				new AddressBook()
 						.add( new Address( null, null ) )
 						.add( new Address( "Street", new City( "C" ) ) )
-						.add( new Address( "Street2", new City( "C" ) ) ) // expected to fail ?
+						.add( new Address( "Street2", new City( "C" ) ) )
+						.add( new Address( "other", new City( "a" ) ) )
 						.add( null )
 		);
 
 		assertCorrectPropertyPathStringRepresentations(
 				constraintViolations,
 				"addresses[].street",
+				"addresses[].city.name",
+				"addresses[].city.name",
 				"addresses[].city.name",
 				"addresses[].<iterable element>"
 		);

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/MostSpecificValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/MostSpecificValueExtractorTest.java
@@ -8,7 +8,8 @@ package org.hibernate.validator.test.internal.engine.valueextraction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -16,6 +17,7 @@ import javax.validation.ConstraintDeclarationException;
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
@@ -29,7 +31,9 @@ import org.hibernate.validator.test.internal.engine.valueextraction.model.IWrapp
 import org.hibernate.validator.test.internal.engine.valueextraction.model.IWrapper212;
 import org.hibernate.validator.test.internal.engine.valueextraction.model.IWrapper22;
 import org.hibernate.validator.test.internal.engine.valueextraction.model.IWrapper221;
+import org.hibernate.validator.test.internal.engine.valueextraction.model.Wrapper1;
 import org.hibernate.validator.test.internal.engine.valueextraction.model.Wrapper2;
+import org.hibernate.validator.testutil.ConstraintViolationAssert;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.CandidateForTck;
 import org.testng.annotations.Test;
@@ -51,7 +55,12 @@ public class MostSpecificValueExtractorTest {
 				.getValidator();
 
 		Set<ConstraintViolation<Entity1>> violations = validator.validate( new Entity1( null ) );
-		assertCorrectPropertyPathStringRepresentations( violations, "wrapper.IWrapper11" );
+		ConstraintViolationAssert.assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "wrapper" )
+						.containerElement( "IWrapper11", false, null, null, Wrapper1.class, 0 )
+				)
+		);
 	}
 
 	@Test

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/NestedTypeArgumentsValueExtractorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/NestedTypeArgumentsValueExtractorTest.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.validator.test.internal.engine.valueextraction;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
@@ -54,9 +53,6 @@ public class NestedTypeArgumentsValueExtractorTest {
 		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( MapOfLists.invalidKey() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"map<K>[k].<map key>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -66,9 +62,6 @@ public class NestedTypeArgumentsValueExtractorTest {
 		);
 
 		constraintViolations = validator.validate( MapOfLists.invalidList() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"map[key1].<map value>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -78,10 +71,6 @@ public class NestedTypeArgumentsValueExtractorTest {
 		);
 
 		constraintViolations = validator.validate( MapOfLists.invalidString() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"map[key1].<map value>[0].<list element>",
-				"map[key1].<map value>[1].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -98,11 +87,6 @@ public class NestedTypeArgumentsValueExtractorTest {
 		);
 
 		constraintViolations = validator.validate( MapOfLists.reallyInvalid() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"map<K>[k].<map key>",
-				"map[k].<map value>",
-				"map[k].<map value>[0].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -129,9 +113,6 @@ public class NestedTypeArgumentsValueExtractorTest {
 		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( MapOfListsWithAutomaticUnwrapping.invalidStringProperty() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"map[key].<map value>[1].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -142,9 +123,6 @@ public class NestedTypeArgumentsValueExtractorTest {
 		);
 
 		constraintViolations = validator.validate( MapOfListsWithAutomaticUnwrapping.invalidListElement() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"map[key].<map value>[0].<list element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( NotNull.class )
 						.withPropertyPath( pathWith()
@@ -162,10 +140,6 @@ public class NestedTypeArgumentsValueExtractorTest {
 		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( ArrayOfOptionalsWithAutomaticUnwrapping.invalidArray() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"array[0].<iterable element>",
-				"array[1].<iterable element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( NotNull.class )
 						.withPropertyPath( pathWith()
@@ -183,11 +157,6 @@ public class NestedTypeArgumentsValueExtractorTest {
 	@Test
 	public void validation_of_nested_type_arguments_works_on_getter_with_map_of_list_of_optional() {
 		Set<ConstraintViolation<MapOfListsUsingGetter>> constraintViolations = validator.validate( MapOfListsUsingGetter.invalidString() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"map[key1].<map value>[0].<list element>",
-				"map[key1].<map value>[1].<list element>"
-		);
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -211,9 +180,6 @@ public class NestedTypeArgumentsValueExtractorTest {
 		assertNoViolations( constraintViolations );
 
 		constraintViolations = validator.validate( NestedArray.invalidArrayFirstDimension() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"array[0].<iterable element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Size.class )
 						.withPropertyPath( pathWith()
@@ -223,9 +189,6 @@ public class NestedTypeArgumentsValueExtractorTest {
 		);
 
 		constraintViolations = validator.validate( NestedArray.invalidArraySecondDimension() );
-		assertCorrectPropertyPathStringRepresentations(
-				constraintViolations,
-				"array[1].<iterable element>[1].<iterable element>" );
 		assertThat( constraintViolations ).containsOnlyViolations(
 				violationOf( Email.class )
 						.withPropertyPath( pathWith()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/ValueExtractorDefinitionInHierarchyTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/ValueExtractorDefinitionInHierarchyTest.java
@@ -6,7 +6,10 @@
  */
 package org.hibernate.validator.test.internal.engine.valueextraction;
 
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 
 import java.util.Set;
 
@@ -39,8 +42,12 @@ public class ValueExtractorDefinitionInHierarchyTest {
 				.getValidator();
 
 		Set<ConstraintViolation<Entity>> violations = validator.validate( entity );
-
-		assertCorrectPropertyPathStringRepresentations( violations, "property.wrapped" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "property" )
+						.containerElement( "wrapped", false, null, null, Wrapper.class, 0 )
+				)
+		);
 	}
 
 	@Test
@@ -56,7 +63,12 @@ public class ValueExtractorDefinitionInHierarchyTest {
 
 		Set<ConstraintViolation<Entity>> violations = validator.validate( entity );
 
-		assertCorrectPropertyPathStringRepresentations( violations, "property.wrapped" );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withPropertyPath( pathWith()
+						.property( "property" )
+						.containerElement( "wrapped", false, null, null, Wrapper.class, 0 )
+				)
+		);
 	}
 
 	@Test(expectedExceptions = ValueExtractorDefinitionException.class, expectedExceptionsMessageRegExp = "HV000218.*")

--- a/engine/src/test/java/org/hibernate/validator/test/parameternameprovider/ParanamerParameterNameProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/parameternameprovider/ParanamerParameterNameProviderTest.java
@@ -7,7 +7,8 @@
 package org.hibernate.validator.test.parameternameprovider;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertCorrectPropertyPathStringRepresentations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 
 import java.lang.annotation.Annotation;
@@ -24,6 +25,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.executable.ExecutableValidator;
 
 import org.hibernate.validator.parameternameprovider.ParanamerParameterNameProvider;
+import org.hibernate.validator.testutil.ConstraintViolationAssert;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.testng.annotations.Test;
 
@@ -95,7 +97,12 @@ public class ParanamerParameterNameProviderTest {
 				parameterValues
 		);
 
-		assertCorrectPropertyPathStringRepresentations( violations, "pauseGame.durationInSeconds" );
+		ConstraintViolationAssert.assertThat( violations ).containsOnlyViolations(
+				violationOf( Min.class ).withPropertyPath( pathWith()
+						.method( "pauseGame" )
+						.parameter( "durationInSeconds", 0 )
+				)
+		);
 	}
 
 	@SuppressWarnings("unused")

--- a/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
+++ b/test-utils/src/main/java/org/hibernate/validator/testutil/ConstraintViolationAssert.java
@@ -76,12 +76,12 @@ public final class ConstraintViolationAssert {
 	 */
 	public static void assertCorrectPropertyPathStringRepresentations(Set<? extends ConstraintViolation<?>> violations,
 			String... expectedPropertyPaths) {
-		Set<String> actualPaths = violations.stream()
+		List<String> actualPaths = violations.stream()
 			.map( ConstraintViolation::getPropertyPath )
 			.map( Path::toString )
-			.collect( Collectors.toSet() );
+			.collect( Collectors.toList() );
 
-		Assertions.assertThat( actualPaths ).containsOnly( expectedPropertyPaths );
+		Assertions.assertThat( actualPaths ).containsExactlyInAnyOrder( expectedPropertyPaths );
 	}
 
 	public static ConstraintViolationSetAssert assertThat(Set<? extends ConstraintViolation<?>> actualViolations) {


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1405

I found only that "container array thing" and set examples were missing, based on other usages of `assertCorrectPropertyPathStringRepresentations`. Also I changed the way this method works, because it was not giving expected result in case of Set. 

That `Set` example also got me thinking that maybe the string representation for it should be different ? Maybe for example something like this:
```
"addresses[hashcode_goes_here].street",
```
