### PR TITLE
HV-1454 Support JDK 9 build 180

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1144,9 +1144,9 @@
                             <artifactId>wildfly-maven-plugin</artifactId>
                             <configuration>
                                 <javaOpts>
-                                    <javaOpt>--add-opens=java.base/java.lang=ALL-UNNAMED</javaOpt>
-                                    <javaOpt>--add-opens=java.base/java.security=ALL-UNNAMED</javaOpt>
-                                    <javaOpt>--add-opens=java.base/java.io=ALL-UNNAMED</javaOpt>
+                                    --add-opens=java.base/java.lang=ALL-UNNAMED
+                                    --add-opens=java.base/java.security=ALL-UNNAMED
+                                    --add-opens=java.base/java.io=ALL-UNNAMED
                                 </javaOpts>
                             </configuration>
                         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -417,7 +417,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.4.1</version>
+                <version>3.0.0-M1</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>
@@ -771,7 +771,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.4</version>
+                    <version>3.0.0-M1</version>
                     <configuration>
                         <docfilessubdirs>true</docfilessubdirs>
                         <javadocDirectory>${project.basedir}/../src/main/javadoc</javadocDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <wildfly-patch-gen-maven-plugin.version>2.0.1.Alpha5</wildfly-patch-gen-maven-plugin.version>
         <wildfly-patch-gen-maven-plugin.woodstox.version>5.0.3</wildfly-patch-gen-maven-plugin.woodstox.version>
         <wildfly-maven-plugin.version>1.2.0.Alpha6</wildfly-maven-plugin.version>
-        <wildfly-core.version>1.0.1.Final</wildfly-core.version>
+        <wildfly-core.version>3.0.0.Beta27</wildfly-core.version>
 
         <!-- Test dependencies -->
         <arquillian.version>1.1.11.Final</arquillian.version>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -23,7 +23,7 @@
     <properties>
         <tck.version>2.0.0-SNAPSHOT</tck.version>
         <tck.suite.file>${project.build.directory}/dependency/beanvalidation-tck-tests-suite.xml</tck.suite.file>
-        <wildflyTargetDir>${project.build.directory}/wildfly-${wildfly.version}</wildflyTargetDir>
+        <wildfly.target-dir>${project.build.directory}/wildfly-${wildfly.version}</wildfly.target-dir>
         <validation.provider>org.hibernate.validator.HibernateValidator</validation.provider>
         <remote.debug />
 
@@ -287,15 +287,6 @@
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
-                            <!-- Currently the WF Maven plug-in cannot apply offline commands, although patch itself wouldn't require a running
-                            server; see https://issues.jboss.org/projects/WFMP/issues/WFMP-11 -->
-                            <execution>
-                                <id>start-wildfly-for-patching</id>
-                                <phase>generate-test-resources</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                            </execution>
                             <execution>
                                 <id>apply-patch-file</id>
                                 <phase>generate-test-resources</phase>
@@ -303,22 +294,16 @@
                                     <goal>execute-commands</goal>
                                 </goals>
                                 <configuration>
+                                    <offline>true</offline>
                                     <fail-on-error>false</fail-on-error>
                                     <commands>
                                         <command>patch apply --path ${project.build.directory}/hibernate-validator-modules-${project.version}-wildfly-${wildfly.version}-patch.zip</command>
                                     </commands>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>shutdown-wildfly-for-patching</id>
-                                <phase>generate-test-resources</phase>
-                                <goals>
-                                    <goal>shutdown</goal>
-                                </goals>
-                            </execution>
                         </executions>
                         <configuration>
-                            <jbossHome>${wildflyTargetDir}</jbossHome>
+                            <jbossHome>${wildfly.target-dir}</jbossHome>
                         </configuration>
                     </plugin>
                     <!-- Copy additional modules -->
@@ -332,7 +317,7 @@
                                     <goal>copy-resources</goal>
                                 </goals>
                                 <configuration>
-                                    <outputDirectory>${wildflyTargetDir}/modules/system/layers/base/</outputDirectory>
+                                    <outputDirectory>${wildfly.target-dir}/modules/system/layers/base/</outputDirectory>
                                     <resources>
                                         <resource>
                                             <directory>src/test/modules</directory>

--- a/tck-runner/src/script/updateStandaloneXml.groovy
+++ b/tck-runner/src/script/updateStandaloneXml.groovy
@@ -8,7 +8,7 @@ def processFileInplace(File file, Closure processText) {
 }
 
 // Add javafx.api module to the global modules
-standaloneXml = new File( project.properties['wildflyTargetDir'], 'standalone/configuration/standalone.xml' )
+standaloneXml = new File( project.properties['wildfly.target-dir'], 'standalone/configuration/standalone.xml' )
 println "[INFO] Add javafx.api as global module"
 
 processFileInplace( standaloneXml ) { text ->

--- a/tck-runner/src/test/resources/arquillian.xml
+++ b/tck-runner/src/test/resources/arquillian.xml
@@ -25,7 +25,7 @@
         <protocol type="Servlet 3.0"/>
         <!-- Takes no effect - ARQ-579 -->
         <configuration>
-            <property name="jbossHome">${wildflyTargetDir}</property>
+            <property name="jbossHome">${wildfly.target-dir}</property>
             <property name="javaVmArguments">${arquillian.javaVmArguments.add-opens}
                 -Xmx1024m -XX:MaxPermSize=512m ${remote.debug}
                 -Dvalidation.provider=${validation.provider}


### PR DESCRIPTION
Built on top of https://github.com/hibernate/hibernate-validator/pull/821 .

 * https://hibernate.atlassian.net/browse/HV-1454

The javadoc error was already present with the previous version of the plugin so it's not blocking for the upgrade.