### PR TITLE
HV-1459 HV-1460 Build improvements

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -386,5 +386,57 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>sigtest</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-tck-bv-api-signature-file</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.hibernate.beanvalidation.tck</groupId>
+                                            <artifactId>beanvalidation-tck-tests</artifactId>
+                                            <version>${tck.version}</version>
+                                            <type>jar</type>
+                                            <overWrite>true</overWrite>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <!-- We just need the signature file and nothing else -->
+                                    <includes>**/*.sig</includes>
+                                    <outputDirectory>${project.build.directory}/api-signature</outputDirectory>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.netbeans.tools</groupId>
+                        <artifactId>sigtest-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <packages>javax.validation,javax.validation.bootstrap,javax.validation.constraints,
+                                javax.validation.constraintvalidation,javax.validation.executable,javax.validation.groups,
+                                javax.validation.metadata,javax.validation.spi,javax.validation.valueextraction
+                            </packages>
+                            <sigfile>${project.build.directory}/api-signature/validation-api-java8.sig</sigfile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -209,10 +209,6 @@
         <hibernate-validator-parent.path>.</hibernate-validator-parent.path>
     </properties>
 
-    <prerequisites>
-        <maven>3.3.1</maven>
-    </prerequisites>
-
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -432,7 +428,7 @@
                                     <version>[1.8.0-20,)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
-                                    <version>3.0.3</version>
+                                    <version>3.3.1</version>
                                 </requireMavenVersion>
                             </rules>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,8 @@
         <maven.javadoc.skip>true</maven.javadoc.skip>
 
         <bv.api.version>2.0.0.Final</bv.api.version>
+        <tck.version>2.0.0.Final</tck.version>
+
         <!-- Version to be used as baseline for API/SPI change reports -->
         <previous.stable>5.4.1.Final</previous.stable>
 
@@ -891,6 +893,11 @@
                             </exclusions>
                         </dependency>
                     </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.netbeans.tools</groupId>
+                    <artifactId>sigtest-maven-plugin</artifactId>
+                    <version>1.0</version>
                 </plugin>
                 <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
                 <plugin>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -21,7 +21,6 @@
     <description>Aggregates dependencies and runs the JSR-380 TCK</description>
 
     <properties>
-        <tck.version>2.0.0.Final</tck.version>
         <tck.suite.file>${project.build.directory}/dependency/beanvalidation-tck-tests-suite.xml</tck.suite.file>
         <wildfly.target-dir>${project.build.directory}/wildfly-${wildfly.version}</wildfly.target-dir>
         <validation.provider>org.hibernate.validator.HibernateValidator</validation.provider>


### PR DESCRIPTION
@gunnarmorling here are 2 small commits to clear a Maven warning when we launch a build with Maven 3.5.0 (maybe it did exist before but it's more visible with the colors) and integrate the sigtest testing in a profile.

Note that I did not include the sigtest directly in the build as I thought we might not want to execute it  when working on new APIs and having the TCK lagging.

I'll create a CI job though once it's integrated so that we can be warned when there is an issue.

 * https://hibernate.atlassian.net/browse/HV-1459
 * https://hibernate.atlassian.net/browse/HV-1460