### PR TITLE
HV-1480 Performance and memory allocation improvements

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
@@ -91,7 +91,7 @@ public class ValidationContext<T> {
 	/**
 	 * The set of already processed unit of works. See {@link ProcessedUnit}.
 	 */
-	private final Set<ProcessedUnit> processedUnits;
+	private final Set<Object> processedUnits;
 
 	/**
 	 * Maps an object to a list of paths in which it has been validated. The objects are the bean instances.
@@ -573,14 +573,12 @@ public class ValidationContext<T> {
 		}
 	}
 
-	private interface ProcessedUnit {
-	}
+	private static final class BeanGroupProcessedUnit {
 
-	private static class BeanGroupProcessedUnit implements ProcessedUnit {
-
-		private final Object bean;
-		private final Class<?> group;
-		private final int hashCode;
+		// these fields are final but we don't mark them as final as an optimization
+		private Object bean;
+		private Class<?> group;
+		private int hashCode;
 
 		private BeanGroupProcessedUnit(Object bean, Class<?> group) {
 			this.bean = bean;
@@ -593,7 +591,7 @@ public class ValidationContext<T> {
 			if ( this == o ) {
 				return true;
 			}
-			if ( o == null || getClass() != o.getClass() ) {
+			if ( o == null || getClass() != BeanGroupProcessedUnit.class ) {
 				return false;
 			}
 
@@ -621,12 +619,13 @@ public class ValidationContext<T> {
 		}
 	}
 
-	private static class BeanPathMetaConstraintProcessedUnit implements ProcessedUnit {
+	private static final class BeanPathMetaConstraintProcessedUnit {
 
-		private final Object bean;
-		private final Path path;
-		private final MetaConstraint<?> metaConstraint;
-		private final int hashCode;
+		// these fields are final but we don't mark them as final as an optimization
+		private Object bean;
+		private Path path;
+		private MetaConstraint<?> metaConstraint;
+		private int hashCode;
 
 		private BeanPathMetaConstraintProcessedUnit(Object bean, Path path, MetaConstraint<?> metaConstraint) {
 			this.bean = bean;
@@ -640,7 +639,7 @@ public class ValidationContext<T> {
 			if ( this == o ) {
 				return true;
 			}
-			if ( o == null || getClass() != o.getClass() ) {
+			if ( o == null || getClass() != BeanPathMetaConstraintProcessedUnit.class ) {
 				return false;
 			}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.validator.internal.engine;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 
 import java.lang.reflect.Executable;
@@ -36,7 +35,6 @@ import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
-import org.hibernate.validator.internal.util.IdentitySet;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
@@ -91,20 +89,14 @@ public class ValidationContext<T> {
 	private final Object executableReturnValue;
 
 	/**
-	 * Maps a group to an identity set to keep track of already validated objects. We have to make sure
-	 * that each object gets only validated once per group and property path.
+	 * The set of already processed unit of works. See {@link ProcessedUnit}.
 	 */
-	private final Map<Class<?>, IdentitySet> processedBeansPerGroup;
+	private final Set<ProcessedUnit> processedUnits;
 
 	/**
 	 * Maps an object to a list of paths in which it has been validated. The objects are the bean instances.
 	 */
 	private final Map<Object, Set<PathImpl>> processedPathsPerBean;
-
-	/**
-	 * Maps processed constraints to the bean and path for which they have been processed.
-	 */
-	private final Map<BeanAndPath, IdentitySet> processedMetaConstraints;
 
 	/**
 	 * Contains all failing constraints so far.
@@ -174,9 +166,8 @@ public class ValidationContext<T> {
 		this.executableParameters = executableParameters;
 		this.executableReturnValue = executableReturnValue;
 
-		this.processedBeansPerGroup = newHashMap();
+		this.processedUnits = new HashSet<>();
 		this.processedPathsPerBean = new IdentityHashMap<>();
-		this.processedMetaConstraints = newHashMap();
 		this.failingConstraintViolations = newHashSet();
 	}
 
@@ -349,22 +340,11 @@ public class ValidationContext<T> {
 	}
 
 	public boolean hasMetaConstraintBeenProcessed(Object bean, Path path, MetaConstraint<?> metaConstraint) {
-		// TODO switch to proper multi key map (HF)
-		IdentitySet processedConstraints = processedMetaConstraints.get( new BeanAndPath( bean, path ) );
-		return processedConstraints != null && processedConstraints.contains( metaConstraint );
+		return processedUnits.contains( new BeanPathMetaConstraintProcessedUnit( bean, path, metaConstraint ) );
 	}
 
 	public void markConstraintProcessed(Object bean, Path path, MetaConstraint<?> metaConstraint) {
-		// TODO switch to proper multi key map (HF)
-		BeanAndPath beanAndPath = new BeanAndPath( bean, path );
-		if ( processedMetaConstraints.containsKey( beanAndPath ) ) {
-			processedMetaConstraints.get( beanAndPath ).add( metaConstraint );
-		}
-		else {
-			IdentitySet set = new IdentitySet();
-			set.add( metaConstraint );
-			processedMetaConstraints.put( beanAndPath, set );
-		}
+		processedUnits.add( new BeanPathMetaConstraintProcessedUnit( bean, path, metaConstraint ) );
 	}
 
 	public String getValidatedProperty() {
@@ -443,33 +423,17 @@ public class ValidationContext<T> {
 	}
 
 	private boolean isAlreadyValidatedForCurrentGroup(Object value, Class<?> group) {
-		IdentitySet objectsProcessedInCurrentGroups = processedBeansPerGroup.get( group );
-		return objectsProcessedInCurrentGroups != null && objectsProcessedInCurrentGroups.contains( value );
+		return processedUnits.contains( new BeanGroupProcessedUnit( value, group ) );
 	}
 
-	private void markCurrentBeanAsProcessedForCurrentPath(Object value, PathImpl path) {
+	private void markCurrentBeanAsProcessedForCurrentPath(Object bean, PathImpl path) {
 		// HV-1031 The path object is mutated as we traverse the object tree, hence copy it before saving it
-		path = PathImpl.createCopy( path );
-
-		if ( processedPathsPerBean.containsKey( value ) ) {
-			processedPathsPerBean.get( value ).add( path );
-		}
-		else {
-			Set<PathImpl> set = new HashSet<>();
-			set.add( path );
-			processedPathsPerBean.put( value, set );
-		}
+		processedPathsPerBean.computeIfAbsent( bean, b -> new HashSet<>() )
+				.add( PathImpl.createCopy( path ) );
 	}
 
-	private void markCurrentBeanAsProcessedForCurrentGroup(Object value, Class<?> group) {
-		if ( processedBeansPerGroup.containsKey( group ) ) {
-			processedBeansPerGroup.get( group ).add( value );
-		}
-		else {
-			IdentitySet set = new IdentitySet();
-			set.add( value );
-			processedBeansPerGroup.put( group, set );
-		}
+	private void markCurrentBeanAsProcessedForCurrentGroup(Object bean, Class<?> group) {
+		processedUnits.add( new BeanGroupProcessedUnit( bean, group ) );
 	}
 
 	/**
@@ -609,15 +573,18 @@ public class ValidationContext<T> {
 		}
 	}
 
-	private static final class BeanAndPath {
+	private interface ProcessedUnit {
+	}
+
+	private static class BeanGroupProcessedUnit implements ProcessedUnit {
+
 		private final Object bean;
-		private final Path path;
+		private final Class<?> group;
 		private final int hashCode;
 
-		private BeanAndPath(Object bean, Path path) {
+		private BeanGroupProcessedUnit(Object bean, Class<?> group) {
 			this.bean = bean;
-			this.path = path;
-			// pre-calculate hash code, the class is immutable and hashCode is needed often
+			this.group = group;
 			this.hashCode = createHashCode();
 		}
 
@@ -630,12 +597,62 @@ public class ValidationContext<T> {
 				return false;
 			}
 
-			BeanAndPath that = (BeanAndPath) o;
+			BeanGroupProcessedUnit that = (BeanGroupProcessedUnit) o;
+
+			if ( bean != that.bean ) {  // instance equality
+				return false;
+			}
+			if ( !group.equals( that.group ) ) {
+				return false;
+			}
+
+			return true;
+		}
+
+		@Override
+		public int hashCode() {
+			return hashCode;
+		}
+
+		private int createHashCode() {
+			int result = System.identityHashCode( bean );
+			result = 31 * result + group.hashCode();
+			return result;
+		}
+	}
+
+	private static class BeanPathMetaConstraintProcessedUnit implements ProcessedUnit {
+
+		private final Object bean;
+		private final Path path;
+		private final MetaConstraint<?> metaConstraint;
+		private final int hashCode;
+
+		private BeanPathMetaConstraintProcessedUnit(Object bean, Path path, MetaConstraint<?> metaConstraint) {
+			this.bean = bean;
+			this.path = path;
+			this.metaConstraint = metaConstraint;
+			this.hashCode = createHashCode();
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+
+			BeanPathMetaConstraintProcessedUnit that = (BeanPathMetaConstraintProcessedUnit) o;
 
 			if ( bean != that.bean ) {  // instance equality
 				return false;
 			}
 			if ( !path.equals( that.path ) ) {
+				return false;
+			}
+			if ( metaConstraint != that.metaConstraint ) {
 				return false;
 			}
 
@@ -650,6 +667,7 @@ public class ValidationContext<T> {
 		private int createHashCode() {
 			int result = System.identityHashCode( bean );
 			result = 31 * result + path.hashCode();
+			result = 31 * result + System.identityHashCode( metaConstraint );
 			return result;
 		}
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -668,15 +668,13 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 
 		@Override
 		public void indexedValue(String nodeName, int index, Object value) {
-			valueContext.markCurrentPropertyAsIterable();
-			valueContext.setIndex( index );
+			valueContext.markCurrentPropertyAsIterableAndSetIndex( index );
 			doValidate( value, nodeName );
 		}
 
 		@Override
 		public void keyedValue(String nodeName, Object key, Object value) {
-			valueContext.markCurrentPropertyAsIterable();
-			valueContext.setKey( key );
+			valueContext.markCurrentPropertyAsIterableAndSetKey( key );
 			doValidate( value, nodeName );
 		}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValueContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValueContext.java
@@ -192,7 +192,7 @@ public class ValueContext<T, V> {
 	}
 
 	public final void setCurrentValidatedValue(V currentValue) {
-		propertyPath.setLeafNodeValue( currentValue );
+		propertyPath.setLeafNodeValueIfRequired( currentValue );
 		this.currentValue = currentValue;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValueContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValueContext.java
@@ -159,12 +159,12 @@ public class ValueContext<T, V> {
 		propertyPath.makeLeafNodeIterable();
 	}
 
-	public final void setKey(Object key) {
-		propertyPath.setLeafNodeMapKey( key );
+	public final void markCurrentPropertyAsIterableAndSetKey(Object key) {
+		propertyPath.makeLeafNodeIterableAndSetMapKey( key );
 	}
 
-	public final void setIndex(Integer index) {
-		propertyPath.setLeafNodeIndex( index );
+	public final void markCurrentPropertyAsIterableAndSetIndex(Integer index) {
+		propertyPath.makeLeafNodeIterableAndSetIndex( index );
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
@@ -320,14 +320,14 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 
 		@Override
 		public NodeBuilder atKey(Object key) {
-			propertyPath.setLeafNodeMapKey( key );
+			propertyPath.makeLeafNodeIterableAndSetMapKey( key );
 			addLeafNode();
 			return new NodeBuilder( messageTemplate, propertyPath );
 		}
 
 		@Override
 		public NodeBuilder atIndex(Integer index) {
-			propertyPath.setLeafNodeIndex( index );
+			propertyPath.makeLeafNodeIterableAndSetIndex( index );
 			addLeafNode();
 			return new NodeBuilder( messageTemplate, propertyPath );
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.validator.internal.engine.constraintvalidation;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,6 +28,7 @@ import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -47,9 +46,9 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 	private Map<String, Object> expressionVariables;
 	private final List<String> methodParameterNames;
 	private final ClockProvider clockProvider;
-	private final List<ConstraintViolationCreationContext> constraintViolationCreationContexts = newArrayList( 3 );
 	private final PathImpl basePath;
 	private final ConstraintDescriptor<?> constraintDescriptor;
+	private List<ConstraintViolationCreationContext> constraintViolationCreationContexts;
 	private boolean defaultDisabled;
 	private Object dynamicPayload;
 
@@ -129,25 +128,34 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 	}
 
 	public final List<ConstraintViolationCreationContext> getConstraintViolationCreationContexts() {
-		if ( defaultDisabled && constraintViolationCreationContexts.size() == 0 ) {
-			throw log.getAtLeastOneCustomMessageMustBeCreatedException();
+		if ( defaultDisabled ) {
+			if ( constraintViolationCreationContexts == null || constraintViolationCreationContexts.size() == 0 ) {
+				throw log.getAtLeastOneCustomMessageMustBeCreatedException();
+			}
+
+			return CollectionHelper.toImmutableList( constraintViolationCreationContexts );
 		}
 
-		List<ConstraintViolationCreationContext> returnedConstraintViolationCreationContexts = new ArrayList<>(
-				constraintViolationCreationContexts
-		);
-		if ( !defaultDisabled ) {
-			returnedConstraintViolationCreationContexts.add(
-					new ConstraintViolationCreationContext(
-							getDefaultConstraintMessageTemplate(),
-							basePath,
-							messageParameters != null ? new HashMap<>( messageParameters ) : Collections.emptyMap(),
-							expressionVariables != null ? new HashMap<>( expressionVariables ) : Collections.emptyMap(),
-							dynamicPayload
-					)
-			);
+		if ( constraintViolationCreationContexts == null || constraintViolationCreationContexts.size() == 0 ) {
+			return Collections.singletonList( getDefaultConstraintViolationCreationContext() );
 		}
-		return returnedConstraintViolationCreationContexts;
+
+		List<ConstraintViolationCreationContext> returnedConstraintViolationCreationContexts =
+				new ArrayList<>( constraintViolationCreationContexts.size() + 1 );
+		returnedConstraintViolationCreationContexts.addAll( constraintViolationCreationContexts );
+		returnedConstraintViolationCreationContexts.add( getDefaultConstraintViolationCreationContext() );
+
+		return CollectionHelper.toImmutableList( returnedConstraintViolationCreationContexts );
+	}
+
+	private ConstraintViolationCreationContext getDefaultConstraintViolationCreationContext() {
+		return new ConstraintViolationCreationContext(
+				getDefaultConstraintMessageTemplate(),
+				basePath,
+				messageParameters != null ? new HashMap<>( messageParameters ) : Collections.emptyMap(),
+				expressionVariables != null ? new HashMap<>( expressionVariables ) : Collections.emptyMap(),
+				dynamicPayload
+		);
 	}
 
 	public List<String> getMethodParameterNames() {
@@ -164,6 +172,9 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 		}
 
 		public ConstraintValidatorContext addConstraintViolation() {
+			if ( constraintViolationCreationContexts == null ) {
+				constraintViolationCreationContexts = CollectionHelper.newArrayList( 3 );
+			}
 			constraintViolationCreationContexts.add(
 					new ConstraintViolationCreationContext(
 							messageTemplate,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/groups/ValidationOrder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/groups/ValidationOrder.java
@@ -16,6 +16,7 @@ import javax.validation.GroupDefinitionException;
  * Interface defining the methods needed to execute groups and sequences in the right order.
  *
  * @author Hardy Ferentschik
+ * @author Guillaume Smet
  */
 public interface ValidationOrder {
 
@@ -36,16 +37,21 @@ public interface ValidationOrder {
 			throws GroupDefinitionException;
 
 	/**
+	 * A {@link org.hibernate.validator.internal.engine.groups.ValidationOrder} which contains a single group, {@code Default}.
+	 */
+	ValidationOrder DEFAULT_GROUP = new DefaultGroupValidationOrder();
+
+	/**
 	 * A {@link org.hibernate.validator.internal.engine.groups.ValidationOrder} which contains a single sequence which
 	 * in turn contains a single group, {@code Default}.
 	 */
-	ValidationOrder DEFAULT_SEQUENCE = new DefaultValidationOrder();
+	ValidationOrder DEFAULT_SEQUENCE = new DefaultSequenceValidationOrder();
 
-	class DefaultValidationOrder implements ValidationOrder {
+	class DefaultSequenceValidationOrder implements ValidationOrder {
 
 		private final List<Sequence> defaultSequences;
 
-		private DefaultValidationOrder() {
+		private DefaultSequenceValidationOrder() {
 			defaultSequences = Collections.singletonList( Sequence.DEFAULT );
 		}
 
@@ -57,6 +63,29 @@ public interface ValidationOrder {
 		@Override
 		public Iterator<Sequence> getSequenceIterator() {
 			return defaultSequences.iterator();
+		}
+
+		@Override
+		public void assertDefaultGroupSequenceIsExpandable(List<Class<?>> defaultGroupSequence) throws GroupDefinitionException {
+		}
+	}
+
+	class DefaultGroupValidationOrder implements ValidationOrder {
+
+		private final List<Group> defaultGroups;
+
+		private DefaultGroupValidationOrder() {
+			defaultGroups = Collections.singletonList( Group.DEFAULT_GROUP );
+		}
+
+		@Override
+		public Iterator<Group> getGroupIterator() {
+			return defaultGroups.iterator();
+		}
+
+		@Override
+		public Iterator<Sequence> getSequenceIterator() {
+			return Collections.<Sequence>emptyIterator();
 		}
 
 		@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/groups/ValidationOrderGenerator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/groups/ValidationOrderGenerator.java
@@ -31,13 +31,6 @@ public class ValidationOrderGenerator {
 
 	private final ConcurrentMap<Class<?>, Sequence> resolvedSequences = new ConcurrentHashMap<Class<?>, Sequence>();
 
-	private final DefaultValidationOrder validationOrderForDefaultGroup;
-
-	public ValidationOrderGenerator() {
-		validationOrderForDefaultGroup = new DefaultValidationOrder();
-		validationOrderForDefaultGroup.insertGroup( Group.DEFAULT_GROUP );
-	}
-
 	/**
 	 * Creates a {@link ValidationOrder} for the given validation group.
 	 *
@@ -49,6 +42,10 @@ public class ValidationOrderGenerator {
 	 * @return a {@link ValidationOrder} for the given validation group
 	 */
 	public ValidationOrder getValidationOrder(Class<?> group, boolean expand) {
+		if ( Default.class.equals( group ) ) {
+			return ValidationOrder.DEFAULT_GROUP;
+		}
+
 		if ( expand ) {
 			return getValidationOrder( Arrays.<Class<?>>asList( group ) );
 		}
@@ -74,7 +71,7 @@ public class ValidationOrderGenerator {
 		// HV-621 - if we deal with the Default group we return the default ValidationOrder. No need to
 		// process Default as other groups which saves several reflection calls (HF)
 		if ( groups.size() == 1 && groups.contains( Default.class ) ) {
-			return validationOrderForDefaultGroup;
+			return ValidationOrder.DEFAULT_GROUP;
 		}
 
 		for ( Class<?> clazz : groups ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
@@ -439,7 +439,6 @@ public class NodeImpl
 		result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
 		result = prime * result + ( ( parameterIndex == null ) ? 0 : parameterIndex.hashCode() );
 		result = prime * result + ( ( parameterTypes == null ) ? 0 : Arrays.hashCode( parameterTypes ) );
-		result = prime * result + ( ( parent == null ) ? 0 : parent.hashCode() );
 		result = prime * result + ( ( containerClass == null ) ? 0 : containerClass.hashCode() );
 		result = prime * result + ( ( typeArgumentIndex == null ) ? 0 : typeArgumentIndex.hashCode() );
 		return result;
@@ -526,14 +525,6 @@ public class NodeImpl
 			}
 		}
 		else if ( !Arrays.equals( parameterTypes, other.parameterTypes ) ) {
-			return false;
-		}
-		if ( parent == null ) {
-			if ( other.parent != null ) {
-				return false;
-			}
-		}
-		else if ( !parent.equals( other.parent ) ) {
 			return false;
 		}
 		return true;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
@@ -60,7 +60,6 @@ public class NodeImpl
 	private final Integer index;
 	private final Object key;
 	private final ElementKind kind;
-	private final int hashCode;
 
 	//type-specific attributes
 	private final Class<?>[] parameterTypes;
@@ -69,6 +68,7 @@ public class NodeImpl
 	private final Class<?> containerClass;
 	private final Integer typeArgumentIndex;
 
+	private int hashCode = -1;
 	private String asString;
 
 	private NodeImpl(String name, NodeImpl parent, boolean isIterable, Integer index, Object key, ElementKind kind, Class<?>[] parameterTypes,
@@ -84,7 +84,6 @@ public class NodeImpl
 		this.parameterIndex = parameterIndex;
 		this.containerClass = containerClass;
 		this.typeArgumentIndex = typeArgumentIndex;
-		this.hashCode = buildHashCode();
 	}
 
 	//TODO It would be nicer if we could return PropertyNode
@@ -448,6 +447,10 @@ public class NodeImpl
 
 	@Override
 	public int hashCode() {
+		if ( hashCode == -1 ) {
+			hashCode = buildHashCode();
+		}
+
 		return hashCode;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/NodeImpl.java
@@ -207,7 +207,7 @@ public class NodeImpl
 		);
 	}
 
-	public static NodeImpl setIndex(NodeImpl node, Integer index) {
+	public static NodeImpl makeIterableAndSetIndex(NodeImpl node, Integer index) {
 		return new NodeImpl(
 				node.name,
 				node.parent,
@@ -223,7 +223,7 @@ public class NodeImpl
 		);
 	}
 
-	public static NodeImpl setMapKey(NodeImpl node, Object key) {
+	public static NodeImpl makeIterableAndSetMapKey(NodeImpl node, Object key) {
 		return new NodeImpl(
 				node.name,
 				node.parent,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -222,13 +222,16 @@ public final class PathImpl implements Path, Serializable {
 		return currentLeafNode;
 	}
 
-	public NodeImpl setLeafNodeValue(Object value) {
-		requiresWriteableNodeList();
+	public NodeImpl setLeafNodeValueIfRequired(Object value) {
+		// The value is only exposed for property and container element nodes
+		if ( currentLeafNode.getKind() == ElementKind.PROPERTY || currentLeafNode.getKind() == ElementKind.CONTAINER_ELEMENT ) {
+			requiresWriteableNodeList();
 
-		currentLeafNode = NodeImpl.setPropertyValue( currentLeafNode, value );
+			currentLeafNode = NodeImpl.setPropertyValue( currentLeafNode, value );
 
-		nodeList.set( nodeList.size() - 1, currentLeafNode );
-		hashCode = -1;
+			nodeList.set( nodeList.size() - 1, currentLeafNode );
+			hashCode = -1;
+		}
 		return currentLeafNode;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -313,6 +313,7 @@ public final class PathImpl implements Path, Serializable {
 	private PathImpl(PathImpl path) {
 		this( path.nodeList );
 		currentLeafNode = (NodeImpl) nodeList.get( nodeList.size() - 1 );
+		hashCode = path.hashCode;
 	}
 
 	private PathImpl() {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -115,7 +115,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl addPropertyNode(String nodeName) {
 		requiresWriteableNodeList();
 
-		NodeImpl parent = nodeList.isEmpty() ? null : (NodeImpl) nodeList.get( nodeList.size() - 1 );
+		NodeImpl parent = currentLeafNode;
 		currentLeafNode = NodeImpl.createPropertyNode( nodeName, parent );
 		nodeList.add( currentLeafNode );
 		hashCode = -1;
@@ -125,7 +125,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl addContainerElementNode(String nodeName) {
 		requiresWriteableNodeList();
 
-		NodeImpl parent = nodeList.isEmpty() ? null : (NodeImpl) nodeList.get( nodeList.size() - 1 );
+		NodeImpl parent = currentLeafNode;
 		currentLeafNode = NodeImpl.createContainerElementNode( nodeName, parent );
 		nodeList.add( currentLeafNode );
 		hashCode = -1;
@@ -135,7 +135,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl addParameterNode(String nodeName, int index) {
 		requiresWriteableNodeList();
 
-		NodeImpl parent = nodeList.isEmpty() ? null : (NodeImpl) nodeList.get( nodeList.size() - 1 );
+		NodeImpl parent = currentLeafNode;
 		currentLeafNode = NodeImpl.createParameterNode( nodeName, parent, index );
 		nodeList.add( currentLeafNode );
 		hashCode = -1;
@@ -145,7 +145,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl addCrossParameterNode() {
 		requiresWriteableNodeList();
 
-		NodeImpl parent = nodeList.isEmpty() ? null : (NodeImpl) nodeList.get( nodeList.size() - 1 );
+		NodeImpl parent = currentLeafNode;
 		currentLeafNode = NodeImpl.createCrossParameterNode( parent );
 		nodeList.add( currentLeafNode );
 		hashCode = -1;
@@ -155,7 +155,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl addBeanNode() {
 		requiresWriteableNodeList();
 
-		NodeImpl parent = nodeList.isEmpty() ? null : (NodeImpl) nodeList.get( nodeList.size() - 1 );
+		NodeImpl parent = currentLeafNode;
 		currentLeafNode = NodeImpl.createBeanNode( parent );
 		nodeList.add( currentLeafNode );
 		hashCode = -1;
@@ -165,7 +165,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl addReturnValueNode() {
 		requiresWriteableNodeList();
 
-		NodeImpl parent = nodeList.isEmpty() ? null : (NodeImpl) nodeList.get( nodeList.size() - 1 );
+		NodeImpl parent = currentLeafNode;
 		currentLeafNode = NodeImpl.createReturnValue( parent );
 		nodeList.add( currentLeafNode );
 		hashCode = -1;
@@ -175,7 +175,7 @@ public final class PathImpl implements Path, Serializable {
 	private NodeImpl addConstructorNode(String name, Class<?>[] parameterTypes) {
 		requiresWriteableNodeList();
 
-		NodeImpl parent = nodeList.isEmpty() ? null : (NodeImpl) nodeList.get( nodeList.size() - 1 );
+		NodeImpl parent = currentLeafNode;
 		currentLeafNode = NodeImpl.createConstructorNode( name, parent, parameterTypes );
 		nodeList.add( currentLeafNode );
 		hashCode = -1;
@@ -185,7 +185,7 @@ public final class PathImpl implements Path, Serializable {
 	private NodeImpl addMethodNode(String name, Class<?>[] parameterTypes) {
 		requiresWriteableNodeList();
 
-		NodeImpl parent = nodeList.isEmpty() ? null : (NodeImpl) nodeList.get( nodeList.size() - 1 );
+		NodeImpl parent = currentLeafNode;
 		currentLeafNode = NodeImpl.createMethodNode( name, parent, parameterTypes );
 		nodeList.add( currentLeafNode );
 		hashCode = -1;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -358,7 +358,7 @@ public final class PathImpl implements Path, Serializable {
 	}
 
 	private PathImpl() {
-		nodeList = new ArrayList<>();
+		nodeList = new ArrayList<>( 1 );
 		hashCode = -1;
 		nodeListRequiresCopy = false;
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -202,20 +202,20 @@ public final class PathImpl implements Path, Serializable {
 		return currentLeafNode;
 	}
 
-	public NodeImpl setLeafNodeIndex(Integer index) {
+	public NodeImpl makeLeafNodeIterableAndSetIndex(Integer index) {
 		requiresWriteableNodeList();
 
-		currentLeafNode = NodeImpl.setIndex( currentLeafNode, index );
+		currentLeafNode = NodeImpl.makeIterableAndSetIndex( currentLeafNode, index );
 
 		nodeList.set( nodeList.size() - 1, currentLeafNode );
 		hashCode = -1;
 		return currentLeafNode;
 	}
 
-	public NodeImpl setLeafNodeMapKey(Object key) {
+	public NodeImpl makeLeafNodeIterableAndSetMapKey(Object key) {
 		requiresWriteableNodeList();
 
-		currentLeafNode = NodeImpl.setMapKey( currentLeafNode, key );
+		currentLeafNode = NodeImpl.makeIterableAndSetMapKey( currentLeafNode, key );
 
 		nodeList.set( nodeList.size() - 1, currentLeafNode );
 		hashCode = -1;
@@ -394,10 +394,10 @@ public final class PathImpl implements Path, Serializable {
 				if ( indexOrKey != null && indexOrKey.length() > 0 ) {
 					try {
 						Integer i = Integer.parseInt( indexOrKey );
-						path.setLeafNodeIndex( i );
+						path.makeLeafNodeIterableAndSetIndex( i );
 					}
 					catch (NumberFormatException e) {
-						path.setLeafNodeMapKey( indexOrKey );
+						path.makeLeafNodeIterableAndSetMapKey( indexOrKey );
 					}
 				}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -353,7 +353,6 @@ public final class PathImpl implements Path, Serializable {
 	 */
 	private PathImpl(PathImpl path) {
 		this( path.nodeList );
-		currentLeafNode = (NodeImpl) nodeList.get( nodeList.size() - 1 );
 		hashCode = path.hashCode;
 	}
 
@@ -365,6 +364,7 @@ public final class PathImpl implements Path, Serializable {
 
 	private PathImpl(List<Node> nodeList) {
 		this.nodeList = nodeList;
+		currentLeafNode = (NodeImpl) nodeList.get( nodeList.size() - 1 );
 		hashCode = -1;
 		nodeListRequiresCopy = true;
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -178,8 +178,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl makeLeafNodeIterable() {
 		currentLeafNode = NodeImpl.makeIterable( currentLeafNode );
 
-		nodeList.remove( nodeList.size() - 1 );
-		nodeList.add( currentLeafNode );
+		nodeList.set( nodeList.size() - 1, currentLeafNode );
 		hashCode = -1;
 		return currentLeafNode;
 	}
@@ -187,8 +186,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl setLeafNodeIndex(Integer index) {
 		currentLeafNode = NodeImpl.setIndex( currentLeafNode, index );
 
-		nodeList.remove( nodeList.size() - 1 );
-		nodeList.add( currentLeafNode );
+		nodeList.set( nodeList.size() - 1, currentLeafNode );
 		hashCode = -1;
 		return currentLeafNode;
 	}
@@ -196,8 +194,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl setLeafNodeMapKey(Object key) {
 		currentLeafNode = NodeImpl.setMapKey( currentLeafNode, key );
 
-		nodeList.remove( nodeList.size() - 1 );
-		nodeList.add( currentLeafNode );
+		nodeList.set( nodeList.size() - 1, currentLeafNode );
 		hashCode = -1;
 		return currentLeafNode;
 	}
@@ -205,8 +202,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl setLeafNodeValue(Object value) {
 		currentLeafNode = NodeImpl.setPropertyValue( currentLeafNode, value );
 
-		nodeList.remove( nodeList.size() - 1 );
-		nodeList.add( currentLeafNode );
+		nodeList.set( nodeList.size() - 1, currentLeafNode );
 		hashCode = -1;
 		return currentLeafNode;
 	}
@@ -214,8 +210,7 @@ public final class PathImpl implements Path, Serializable {
 	public NodeImpl setLeafNodeTypeParameter(Class<?> containerClass, Integer typeArgumentIndex) {
 		currentLeafNode = NodeImpl.setTypeParameter( currentLeafNode, containerClass, typeArgumentIndex );
 
-		nodeList.remove( nodeList.size() - 1 );
-		nodeList.add( currentLeafNode );
+		nodeList.set( nodeList.size() - 1, currentLeafNode );
 		hashCode = -1;
 		return currentLeafNode;
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/MetaConstraint.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/MetaConstraint.java
@@ -194,15 +194,13 @@ public class MetaConstraint<A extends Annotation> {
 
 		@Override
 		public void indexedValue(String nodeName, int index, Object value) {
-			valueContext.markCurrentPropertyAsIterable();
-			valueContext.setIndex( index );
+			valueContext.markCurrentPropertyAsIterableAndSetIndex( index );
 			doValidate( value, nodeName );
 		}
 
 		@Override
 		public void keyedValue(String nodeName, Object key, Object value) {
-			valueContext.markCurrentPropertyAsIterable();
-			valueContext.setKey( key );
+			valueContext.markCurrentPropertyAsIterableAndSetKey( key );
 			doValidate( value, nodeName );
 		}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/validation/GroupValidationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/validation/GroupValidationTest.java
@@ -29,7 +29,7 @@ import javax.validation.Payload;
 import javax.validation.Validator;
 
 import org.hibernate.validator.testutil.TestForIssue;
-
+import org.hibernate.validator.testutils.CandidateForTck;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -46,6 +46,7 @@ public class GroupValidationTest {
 
 	@Test
 	@TestForIssue(jiraKey = "HV-678")
+	@CandidateForTck
 	public void testConstraintIsOnlyValidatedOnceEvenWhenPartOfMultipleGroups() {
 		A a = new A();
 

--- a/performance/README.md
+++ b/performance/README.md
@@ -85,6 +85,10 @@ a shared _ValidatorFactory_ and once the factory is recreated on each invocation
 
 Simple bean with cascaded validation which gets executed over and over.
 
+### [CascadedWithLotsOfItemsValidation](https://github.com/hibernate/hibernate-validator/blob/master/performance/src/main/java/org/hibernate/validator/performance/cascaded/CascadedWithLotsOfItemsValidation.java)
+
+Validation of a bean containing a lot of beans to cascade to.
+
 ### [StatisticalValidation](https://github.com/hibernate/hibernate-validator/blob/master/performance/src/main/java/org/hibernate/validator/performance/statistical/StatisticalValidation.java)
 
 A number of _TestEntity_s is created where each entity contains a property for each built-in constraint type and also a reference

--- a/performance/README.md
+++ b/performance/README.md
@@ -89,6 +89,10 @@ Simple bean with cascaded validation which gets executed over and over.
 
 Validation of a bean containing a lot of beans to cascade to.
 
+### [CascadedWithLotsOfItemsAndMoreConstraintsValidation](https://github.com/hibernate/hibernate-validator/blob/master/performance/src/main/java/org/hibernate/validator/performance/cascaded/CascadedWithLotsOfItemsAndMoreConstraintsValidation.java)
+
+This test has a few more constraints than the previous one, allowing to test our hypothesis in more realistic situation.
+
 ### [StatisticalValidation](https://github.com/hibernate/hibernate-validator/blob/master/performance/src/main/java/org/hibernate/validator/performance/statistical/StatisticalValidation.java)
 
 A number of _TestEntity_s is created where each entity contains a property for each built-in constraint type and also a reference

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -193,6 +193,47 @@
             </build>
         </profile>
         <profile>
+            <id>hv-6.0</id>
+            <activation>
+                <property>
+                    <name>validator</name>
+                    <value>hv-6.0</value>
+                </property>
+            </activation>
+            <properties>
+                <beanvalidation-impl.name>Hibernate Validator</beanvalidation-impl.name>
+                <beanvalidation-impl.version>6.0.2.Final</beanvalidation-impl.version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.validation</groupId>
+                    <artifactId>validation-api</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>${project.groupId}</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                    <version>${beanvalidation-impl.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish</groupId>
+                    <artifactId>javax.el</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </dependency>
+            </dependencies>
+            <!-- adding sources for BV 2.0 tests -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>hv-5.4</id>
             <activation>
                 <property>

--- a/performance/src/main/java/org/hibernate/validator/performance/BenchmarkRunner.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/BenchmarkRunner.java
@@ -10,6 +10,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.hibernate.validator.performance.cascaded.CascadedValidation;
+import org.hibernate.validator.performance.cascaded.CascadedWithLotsOfItemsValidation;
 import org.hibernate.validator.performance.simple.SimpleValidation;
 import org.hibernate.validator.performance.statistical.StatisticalValidation;
 
@@ -33,6 +34,7 @@ public final class BenchmarkRunner {
 	private static final Stream<? extends Class<?>> DEFAULT_TEST_CLASSES = Stream.of(
 			SimpleValidation.class.getName(),
 			CascadedValidation.class.getName(),
+			CascadedWithLotsOfItemsValidation.class.getName(),
 			StatisticalValidation.class.getName(),
 			// Benchmarks specific to Bean Validation 2.0
 			// Tests are located in a separate source folder only added for implementations compatible with BV 2.0

--- a/performance/src/main/java/org/hibernate/validator/performance/cascaded/CascadedValidation.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/cascaded/CascadedValidation.java
@@ -52,7 +52,7 @@ public class CascadedValidation {
 	@Fork(value = 1)
 	@Threads(50)
 	@Warmup(iterations = 10)
-	@Measurement(iterations = 50)
+	@Measurement(iterations = 20)
 	public void testCascadedValidation(CascadedValidationState state, Blackhole bh) {
 		// TODO graphs needs to be generated and deeper
 		Person kermit = new Person( "kermit" );

--- a/performance/src/main/java/org/hibernate/validator/performance/cascaded/CascadedWithLotsOfItemsAndMoreConstraintsValidation.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/cascaded/CascadedWithLotsOfItemsAndMoreConstraintsValidation.java
@@ -1,0 +1,114 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.performance.cascaded;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * @author Guillaume Smet
+ */
+public class CascadedWithLotsOfItemsAndMoreConstraintsValidation {
+
+	private static final int NUMBER_OF_ARTICLES_PER_SHOP = 2000;
+
+	@State(Scope.Benchmark)
+	public static class CascadedWithLotsOfItemsValidationState {
+		public volatile Validator validator;
+
+		public volatile Shop shop;
+
+		public CascadedWithLotsOfItemsValidationState() {
+			ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+			validator = factory.getValidator();
+
+			shop = createShop();
+		}
+
+		private Shop createShop() {
+			Shop shop = new Shop( 1, "Shop" );
+
+			for ( int i = 0; i < NUMBER_OF_ARTICLES_PER_SHOP; i++ ) {
+				shop.addArticle( new Article( i, "Article " + i ) );
+			}
+
+			return shop;
+		}
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.Throughput)
+	@OutputTimeUnit(TimeUnit.SECONDS)
+	@Fork(value = 1)
+	@Threads(20)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 20)
+	public void testCascadedValidationWithLotsOfItems(CascadedWithLotsOfItemsValidationState state, Blackhole bh) {
+		Set<ConstraintViolation<Shop>> violations = state.validator.validate( state.shop );
+		assertThat( violations ).hasSize( 0 );
+
+		bh.consume( violations );
+	}
+
+	public static class Shop {
+		@NotNull
+		private Integer id;
+
+		@NotEmpty
+		private String name;
+
+		@NotNull
+		@Valid
+		private List<Article> articles = new ArrayList<>();
+
+		public Shop(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public void addArticle(Article article) {
+			articles.add( article );
+		}
+	}
+
+	public static class Article {
+		@NotNull
+		private Integer id;
+
+		@NotEmpty
+		private String name;
+
+		public Article(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+}

--- a/performance/src/main/java/org/hibernate/validator/performance/cascaded/CascadedWithLotsOfItemsValidation.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/cascaded/CascadedWithLotsOfItemsValidation.java
@@ -1,0 +1,105 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.performance.cascaded;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotNull;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * @author Guillaume Smet
+ */
+public class CascadedWithLotsOfItemsValidation {
+
+	private static final int NUMBER_OF_ARTICLES_PER_SHOP = 2000;
+
+	@State(Scope.Benchmark)
+	public static class CascadedWithLotsOfItemsValidationState {
+		public volatile Validator validator;
+
+		public volatile Shop shop;
+
+		public CascadedWithLotsOfItemsValidationState() {
+			ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+			validator = factory.getValidator();
+
+			shop = createShop();
+		}
+
+		private Shop createShop() {
+			Shop shop = new Shop( 1 );
+
+			for ( int i = 0; i < NUMBER_OF_ARTICLES_PER_SHOP; i++ ) {
+				shop.addArticle( new Article( i ) );
+			}
+
+			return shop;
+		}
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.Throughput)
+	@OutputTimeUnit(TimeUnit.SECONDS)
+	@Fork(value = 1)
+	@Threads(20)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 20)
+	public void testCascadedValidationWithLotsOfItems(CascadedWithLotsOfItemsValidationState state, Blackhole bh) {
+		Set<ConstraintViolation<Shop>> violations = state.validator.validate( state.shop );
+		assertThat( violations ).hasSize( 0 );
+
+		bh.consume( violations );
+	}
+
+	public static class Shop {
+		@NotNull
+		private Integer id;
+
+		@NotNull
+		@Valid
+		private List<Article> articles = new ArrayList<>();
+
+		public Shop(Integer id) {
+			this.id = id;
+		}
+
+		public void addArticle(Article article) {
+			articles.add( article );
+		}
+	}
+
+	public static class Article {
+		@NotNull
+		private Integer id;
+
+		public Article(Integer id) {
+			this.id = id;
+		}
+	}
+}

--- a/performance/src/main/java/org/hibernate/validator/performance/simple/SimpleValidation.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/simple/SimpleValidation.java
@@ -69,7 +69,7 @@ public class SimpleValidation {
 	@Fork(value = 1)
 	@Threads(50)
 	@Warmup(iterations = 10)
-	@Measurement(iterations = 50)
+	@Measurement(iterations = 20)
 	public void testSimpleBeanValidation(ValidationState state, Blackhole bh) {
 		DriverSetup driverSetup = new DriverSetup( state );
 		Set<ConstraintViolation<Driver>> violations = state.validator.validate( driverSetup.getDriver() );


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1480

Note that, even if this patch improves the situation a bit, we are still allocating a lot of memory for the `PathImpl`/`NodeImpl` construction. It would be nice if we could improve the situation. Both the number of `NodeImpl` creations and the copy of the node list in `PathImpl` are really concerning.

Results for each version for the 3 benchmarks (~ a 20% speed up):

**HV 6.0.2.Final**

Result "org.hibernate.validator.performance.simple.SimpleValidation.testSimpleBeanValidation":
  960.500 ±(99.9%) 10.939 ops/ms [Average]
  (min, avg, max) = (945.886, 960.500, 989.234), stdev = 12.597
  CI (99.9%): [949.561, 971.439] (assumes normal distribution)

Result "org.hibernate.validator.performance.cascaded.CascadedValidation.testCascadedValidation":
  452.387 ±(99.9%) 14.470 ops/ms [Average]
  (min, avg, max) = (426.984, 452.387, 496.972), stdev = 16.664
  CI (99.9%): [437.917, 466.857] (assumes normal distribution)

Result "org.hibernate.validator.performance.cascaded.CascadedWithLotsOfItemsValidation.testCascadedValidationWithLotsOfItems":
  1100.356 ±(99.9%) 15.799 ops/s [Average]
  (min, avg, max) = (1067.990, 1100.356, 1124.266), stdev = 18.194
  CI (99.9%): [1084.557, 1116.155] (assumes normal distribution)

**HV 6.0.3-SNAPSHOT**

Result "org.hibernate.validator.performance.simple.SimpleValidation.testSimpleBeanValidation":
  1159.744 ±(99.9%) 9.638 ops/ms [Average]
  (min, avg, max) = (1149.546, 1159.744, 1191.913), stdev = 11.099
  CI (99.9%): [1150.107, 1169.382] (assumes normal distribution)

Result "org.hibernate.validator.performance.cascaded.CascadedValidation.testCascadedValidation":
  542.513 ±(99.9%) 15.477 ops/ms [Average]
  (min, avg, max) = (514.498, 542.513, 581.028), stdev = 17.823
  CI (99.9%): [527.036, 557.990] (assumes normal distribution)

Result "org.hibernate.validator.performance.cascaded.CascadedWithLotsOfItemsValidation.testCascadedValidationWithLotsOfItems":
  1393.947 ±(99.9%) 22.632 ops/s [Average]
  (min, avg, max) = (1348.617, 1393.947, 1429.664), stdev = 26.063
  CI (99.9%): [1371.315, 1416.580] (assumes normal distribution)