### PR TITLE
HV-1481 Legacy cascading support broken when the collection/array type cannot be detected at runtime

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -54,7 +54,6 @@ import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.CascadingMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ContainerCascadingMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData;
-import org.hibernate.validator.internal.metadata.aggregated.NonContainerCascadingMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ParameterMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.PropertyMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ReturnValueMetaData;
@@ -581,28 +580,15 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 				CascadingMetaData cascadingMetaData = cascadable.getCascadingMetaData();
 
 				if ( value != null ) {
+					CascadingMetaData effectiveCascadingMetaData = cascadingMetaData.addRuntimeLegacyCollectionSupport( value.getClass() );
+
 					// validate cascading on the annotated object
-					if ( cascadingMetaData.isCascading() ) {
-						validateCascadedAnnotatedObjectForCurrentGroup( value, validationContext, valueContext, cascadingMetaData );
-
-						if ( !cascadingMetaData.isContainer() ) {
-							// We might be in the case where the legacy @Valid support for collections and arrays has been used on a type for which
-							// it cannot be detected at bootstrap time: thus we need to check with the runtime type.
-							// Note that if it has been detected at bootstrap time, the cascading metadata has been modified to include it
-							// and we are then in the container case.
-							NonContainerCascadingMetaData nonContainerCascadingMetaData = cascadingMetaData.as( NonContainerCascadingMetaData.class );
-							ContainerCascadingMetaData legacyContainerCascadingMetaData = nonContainerCascadingMetaData
-									.getLegacyContainerCascadingMetaData( value.getClass() );
-
-							if ( legacyContainerCascadingMetaData != null ) {
-								validateCascadedContainerElementsForCurrentGroup( value, validationContext, valueContext,
-										Collections.singletonList( legacyContainerCascadingMetaData ) );
-							}
-						}
+					if ( effectiveCascadingMetaData.isCascading() ) {
+						validateCascadedAnnotatedObjectForCurrentGroup( value, validationContext, valueContext, effectiveCascadingMetaData );
 					}
 
-					if ( cascadingMetaData.isContainer() ) {
-						ContainerCascadingMetaData containerCascadingMetaData = cascadingMetaData.as( ContainerCascadingMetaData.class );
+					if ( effectiveCascadingMetaData.isContainer() ) {
+						ContainerCascadingMetaData containerCascadingMetaData = effectiveCascadingMetaData.as( ContainerCascadingMetaData.class );
 
 						if ( containerCascadingMetaData.hasContainerElementsMarkedForCascading() ) {
 							// validate cascading on the container elements

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/LegacyCollectionSupportValueExtractors.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/LegacyCollectionSupportValueExtractors.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.valueextraction;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.hibernate.validator.internal.util.CollectionHelper;
+
+public class LegacyCollectionSupportValueExtractors {
+
+	public static final Set<ValueExtractorDescriptor> LIST = Collections.singleton( ListValueExtractor.DESCRIPTOR );
+	public static final Set<ValueExtractorDescriptor> MAP = Collections.singleton( MapValueExtractor.DESCRIPTOR );
+	public static final Set<ValueExtractorDescriptor> ITERABLE = Collections.singleton( IterableValueExtractor.DESCRIPTOR );
+	public static final Set<ValueExtractorDescriptor> OPTIONAL = Collections.singleton( OptionalValueExtractor.DESCRIPTOR );
+	public static final Set<ValueExtractorDescriptor> ARRAY = CollectionHelper.asSet(
+			BooleanArrayValueExtractor.DESCRIPTOR,
+			ByteArrayValueExtractor.DESCRIPTOR,
+			CharArrayValueExtractor.DESCRIPTOR,
+			DoubleArrayValueExtractor.DESCRIPTOR,
+			FloatArrayValueExtractor.DESCRIPTOR,
+			IntArrayValueExtractor.DESCRIPTOR,
+			LongArrayValueExtractor.DESCRIPTOR,
+			ObjectArrayValueExtractor.DESCRIPTOR,
+			ShortArrayValueExtractor.DESCRIPTOR
+	);
+
+	private LegacyCollectionSupportValueExtractors() {
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ListPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ListPropertyValueExtractor.java
@@ -25,7 +25,7 @@ import javafx.beans.value.ObservableValue;
  * @author Guillaume Smet
  */
 @SuppressWarnings("restriction")
-public class ListPropertyValueExtractor implements ValueExtractor<ListProperty<@ExtractedValue ?>> {
+class ListPropertyValueExtractor implements ValueExtractor<ListProperty<@ExtractedValue ?>> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ListPropertyValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapPropertyKeyExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapPropertyKeyExtractor.java
@@ -25,7 +25,7 @@ import javafx.beans.value.ObservableValue;
  * @author Guillaume Smet
  */
 @SuppressWarnings("restriction")
-public class MapPropertyKeyExtractor implements ValueExtractor<MapProperty<@ExtractedValue ?, ?>> {
+class MapPropertyKeyExtractor implements ValueExtractor<MapProperty<@ExtractedValue ?, ?>> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapPropertyKeyExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapPropertyValueExtractor.java
@@ -25,7 +25,7 @@ import javafx.beans.value.ObservableValue;
  * @author Guillaume Smet
  */
 @SuppressWarnings("restriction")
-public class MapPropertyValueExtractor implements ValueExtractor<MapProperty<?, @ExtractedValue ?>> {
+class MapPropertyValueExtractor implements ValueExtractor<MapProperty<?, @ExtractedValue ?>> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapPropertyValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ObservableValueValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ObservableValueValueExtractor.java
@@ -19,7 +19,7 @@ import javafx.beans.value.ObservableValue;
  */
 @SuppressWarnings("restriction")
 @UnwrapByDefault
-public class ObservableValueValueExtractor implements ValueExtractor<ObservableValue<@ExtractedValue ?>> {
+class ObservableValueValueExtractor implements ValueExtractor<ObservableValue<@ExtractedValue ?>> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ObservableValueValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalDoubleValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalDoubleValueExtractor.java
@@ -16,7 +16,7 @@ import javax.validation.valueextraction.ValueExtractor;
  * @author Guillaume Smet
  */
 @UnwrapByDefault
-public class OptionalDoubleValueExtractor implements ValueExtractor<@ExtractedValue(type = Double.class) OptionalDouble> {
+class OptionalDoubleValueExtractor implements ValueExtractor<@ExtractedValue(type = Double.class) OptionalDouble> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalDoubleValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalIntValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalIntValueExtractor.java
@@ -16,7 +16,7 @@ import javax.validation.valueextraction.ValueExtractor;
  * @author Guillaume Smet
  */
 @UnwrapByDefault
-public class OptionalIntValueExtractor implements ValueExtractor<@ExtractedValue(type = Integer.class) OptionalInt> {
+class OptionalIntValueExtractor implements ValueExtractor<@ExtractedValue(type = Integer.class) OptionalInt> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalIntValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalLongValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalLongValueExtractor.java
@@ -16,7 +16,7 @@ import javax.validation.valueextraction.ValueExtractor;
  * @author Guillaume Smet
  */
 @UnwrapByDefault
-public class OptionalLongValueExtractor implements ValueExtractor<@ExtractedValue(type = Long.class) OptionalLong> {
+class OptionalLongValueExtractor implements ValueExtractor<@ExtractedValue(type = Long.class) OptionalLong> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalLongValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalValueExtractor.java
@@ -14,7 +14,7 @@ import javax.validation.valueextraction.ValueExtractor;
 /**
  * @author Gunnar Morling
  */
-public class OptionalValueExtractor implements ValueExtractor<Optional<@ExtractedValue ?>> {
+class OptionalValueExtractor implements ValueExtractor<Optional<@ExtractedValue ?>> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyListPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyListPropertyValueExtractor.java
@@ -25,7 +25,7 @@ import javafx.beans.value.ObservableValue;
  * @author Guillaume Smet
  */
 @SuppressWarnings("restriction")
-public class ReadOnlyListPropertyValueExtractor implements ValueExtractor<ReadOnlyListProperty<@ExtractedValue ?>> {
+class ReadOnlyListPropertyValueExtractor implements ValueExtractor<ReadOnlyListProperty<@ExtractedValue ?>> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlyListPropertyValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyMapPropertyKeyExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyMapPropertyKeyExtractor.java
@@ -25,7 +25,7 @@ import javafx.beans.value.ObservableValue;
  * @author Guillaume Smet
  */
 @SuppressWarnings("restriction")
-public class ReadOnlyMapPropertyKeyExtractor implements ValueExtractor<ReadOnlyMapProperty<@ExtractedValue ?, ?>> {
+class ReadOnlyMapPropertyKeyExtractor implements ValueExtractor<ReadOnlyMapProperty<@ExtractedValue ?, ?>> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlyMapPropertyKeyExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyMapPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyMapPropertyValueExtractor.java
@@ -25,7 +25,7 @@ import javafx.beans.value.ObservableValue;
  * @author Guillaume Smet
  */
 @SuppressWarnings("restriction")
-public class ReadOnlyMapPropertyValueExtractor implements ValueExtractor<ReadOnlyMapProperty<?, @ExtractedValue ?>> {
+class ReadOnlyMapPropertyValueExtractor implements ValueExtractor<ReadOnlyMapProperty<?, @ExtractedValue ?>> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlyMapPropertyValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlySetPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlySetPropertyValueExtractor.java
@@ -25,7 +25,7 @@ import javafx.beans.value.ObservableValue;
  * @author Guillaume Smet
  */
 @SuppressWarnings("restriction")
-public class ReadOnlySetPropertyValueExtractor implements ValueExtractor<ReadOnlySetProperty<@ExtractedValue ?>> {
+class ReadOnlySetPropertyValueExtractor implements ValueExtractor<ReadOnlySetProperty<@ExtractedValue ?>> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlySetPropertyValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/SetPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/SetPropertyValueExtractor.java
@@ -25,7 +25,7 @@ import javafx.beans.value.ObservableValue;
  * @author Guillaume Smet
  */
 @SuppressWarnings("restriction")
-public class SetPropertyValueExtractor implements ValueExtractor<SetProperty<@ExtractedValue ?>> {
+class SetPropertyValueExtractor implements ValueExtractor<SetProperty<@ExtractedValue ?>> {
 
 	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new SetPropertyValueExtractor() );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/CascadingMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/CascadingMetaData.java
@@ -41,4 +41,19 @@ public interface CascadingMetaData {
 	boolean isContainer();
 
 	<T extends CascadingMetaData> T as(Class<T> clazz);
+
+	/**
+	 * Add additional cascading metadata when:
+	 * <ul>
+	 * <li>the element is marked with {@code @Valid},</li>
+	 * <li>the runtime type of the element is collection based (e.g. collections, maps or arrays),</li>
+	 * <li>and the static type isn't collection based.</li>
+	 * </ul>
+	 * <p>
+	 * An example of this particular situation is: {@code @Valid private Object element = new ArrayList<String>()}.
+	 * <p>
+	 * Note that if the static type is collection based, the cascading information are directly included at bootstrap
+	 * time.
+	 */
+	CascadingMetaData addRuntimeLegacyCollectionSupport(Class<?> valueClass);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ContainerCascadingMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ContainerCascadingMetaData.java
@@ -131,6 +131,19 @@ public class ContainerCascadingMetaData implements CascadingMetaData {
 		}
 	}
 
+	ContainerCascadingMetaData(Type enclosingType, TypeVariable<?> typeParameter, Class<?> declaredContainerClass, TypeVariable<?> declaredTypeParameter,
+			GroupConversionHelper groupConversionHelper, Set<ValueExtractorDescriptor> valueExtractorCandidates) {
+		this.enclosingType = enclosingType;
+		this.typeParameter = typeParameter;
+		this.declaredContainerClass = declaredContainerClass;
+		this.declaredTypeParameter = declaredTypeParameter;
+		this.containerElementTypesCascadingMetaData = Collections.emptyList();
+		this.cascading = true;
+		this.groupConversionHelper = groupConversionHelper;
+		this.hasContainerElementsMarkedForCascading = false;
+		this.valueExtractorCandidates = valueExtractorCandidates;
+	}
+
 	@Override
 	public boolean isContainer() {
 		return true;

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ContainerCascadingMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ContainerCascadingMetaData.java
@@ -131,6 +131,19 @@ public class ContainerCascadingMetaData implements CascadingMetaData {
 		}
 	}
 
+	ContainerCascadingMetaData(Type enclosingType, List<ContainerCascadingMetaData> containerElementTypesCascadingMetaData,
+			GroupConversionHelper groupConversionHelper) {
+		this.enclosingType = enclosingType;
+		this.typeParameter = AnnotatedObject.INSTANCE;
+		this.declaredContainerClass = null;
+		this.declaredTypeParameter = null;
+		this.containerElementTypesCascadingMetaData = containerElementTypesCascadingMetaData;
+		this.cascading = true;
+		this.groupConversionHelper = groupConversionHelper;
+		this.hasContainerElementsMarkedForCascading = true;
+		this.valueExtractorCandidates = Collections.emptySet();
+	}
+
 	ContainerCascadingMetaData(Type enclosingType, TypeVariable<?> typeParameter, Class<?> declaredContainerClass, TypeVariable<?> declaredTypeParameter,
 			GroupConversionHelper groupConversionHelper, Set<ValueExtractorDescriptor> valueExtractorCandidates) {
 		this.enclosingType = enclosingType;
@@ -206,6 +219,11 @@ public class ContainerCascadingMetaData implements CascadingMetaData {
 		}
 
 		throw LOG.getUnableToCastException( this, clazz );
+	}
+
+	@Override
+	public CascadingMetaData addRuntimeLegacyCollectionSupport(Class<?> valueClass) {
+		return this;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/GroupConversionHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/GroupConversionHelper.java
@@ -26,7 +26,7 @@ import org.hibernate.validator.internal.util.stereotypes.Immutable;
  */
 public class GroupConversionHelper {
 
-	private static final GroupConversionHelper EMPTY = new GroupConversionHelper( Collections.emptyMap() );
+	static final GroupConversionHelper EMPTY = new GroupConversionHelper( Collections.emptyMap() );
 
 	@Immutable
 	private final Map<Class<?>, Class<?>> groupConversions;
@@ -79,6 +79,10 @@ public class GroupConversionHelper {
 		}
 
 		return CollectionHelper.toImmutableSet( descriptors );
+	}
+
+	boolean isEmpty() {
+		return groupConversions.isEmpty();
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/NonContainerCascadingMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/NonContainerCascadingMetaData.java
@@ -8,11 +8,17 @@ package org.hibernate.validator.internal.metadata.aggregated;
 
 import java.lang.reflect.TypeVariable;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.metadata.GroupConversionDescriptor;
 
 import org.hibernate.validator.internal.engine.valueextraction.AnnotatedObject;
+import org.hibernate.validator.internal.engine.valueextraction.ArrayElement;
+import org.hibernate.validator.internal.engine.valueextraction.LegacyCollectionSupportValueExtractors;
+import org.hibernate.validator.internal.util.TypeVariables;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
@@ -93,6 +99,34 @@ public class NonContainerCascadingMetaData implements CascadingMetaData {
 	@Override
 	public boolean isContainer() {
 		return false;
+	}
+
+	public ContainerCascadingMetaData getLegacyContainerCascadingMetaData(Class<?> valueClass) {
+		if ( List.class.isAssignableFrom( valueClass ) ) {
+			return new ContainerCascadingMetaData( List.class, List.class.getTypeParameters()[0], List.class, List.class.getTypeParameters()[0],
+					groupConversionHelper, LegacyCollectionSupportValueExtractors.LIST );
+		}
+		else if ( Map.class.isAssignableFrom( valueClass ) ) {
+			return new ContainerCascadingMetaData( Map.class, Map.class.getTypeParameters()[1], Map.class, Map.class.getTypeParameters()[1],
+					groupConversionHelper, LegacyCollectionSupportValueExtractors.MAP );
+		}
+		else if ( Iterable.class.isAssignableFrom( valueClass ) ) {
+			return new ContainerCascadingMetaData( Iterable.class, Iterable.class.getTypeParameters()[0], Iterable.class, Iterable.class.getTypeParameters()[0],
+					groupConversionHelper, LegacyCollectionSupportValueExtractors.ITERABLE );
+		}
+		else if ( Optional.class.isAssignableFrom( valueClass ) ) {
+			return new ContainerCascadingMetaData( Optional.class, Optional.class.getTypeParameters()[0], Optional.class, Optional.class.getTypeParameters()[0],
+					groupConversionHelper, LegacyCollectionSupportValueExtractors.OPTIONAL );
+		}
+		else if ( valueClass.isArray() ) {
+			TypeVariable<?> typeParameter = new ArrayElement( valueClass );
+
+			return new ContainerCascadingMetaData( valueClass, typeParameter,
+					TypeVariables.getContainerClass( typeParameter ), TypeVariables.getActualTypeParameter( typeParameter ),
+					groupConversionHelper, LegacyCollectionSupportValueExtractors.ARRAY );
+		}
+
+		return null;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/NonContainerCascadingMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/NonContainerCascadingMetaData.java
@@ -32,10 +32,26 @@ public class NonContainerCascadingMetaData implements CascadingMetaData {
 	private static final Log LOG = LoggerFactory.make();
 
 	private static final NonContainerCascadingMetaData NON_CASCADING = new NonContainerCascadingMetaData( false,
-			GroupConversionHelper.of( Collections.emptyMap() ) );
+			GroupConversionHelper.EMPTY );
 
 	private static final NonContainerCascadingMetaData CASCADING_WITHOUT_GROUP_CONVERSIONS = new NonContainerCascadingMetaData( true,
-			GroupConversionHelper.of( Collections.emptyMap() ) );
+			GroupConversionHelper.EMPTY );
+
+	private static final ContainerCascadingMetaData LIST_CONTAINER_WITHOUT_GROUP_CONVERSIONS =
+			new ContainerCascadingMetaData( List.class, List.class.getTypeParameters()[0], List.class, List.class.getTypeParameters()[0],
+					GroupConversionHelper.EMPTY, LegacyCollectionSupportValueExtractors.LIST );
+
+	private static final ContainerCascadingMetaData MAP_CONTAINER_WITHOUT_GROUP_CONVERSIONS =
+			new ContainerCascadingMetaData( Map.class, Map.class.getTypeParameters()[1], Map.class, Map.class.getTypeParameters()[1],
+					GroupConversionHelper.EMPTY, LegacyCollectionSupportValueExtractors.MAP );
+
+	private static final ContainerCascadingMetaData ITERABLE_CONTAINER_WITHOUT_GROUP_CONVERSIONS =
+			new ContainerCascadingMetaData( Iterable.class, Iterable.class.getTypeParameters()[0], Iterable.class, Iterable.class.getTypeParameters()[0],
+					GroupConversionHelper.EMPTY, LegacyCollectionSupportValueExtractors.ITERABLE );
+
+	private static final ContainerCascadingMetaData OPTIONAL_CONTAINER_WITHOUT_GROUP_CONVERSIONS =
+			new ContainerCascadingMetaData( Optional.class, Optional.class.getTypeParameters()[0], Optional.class, Optional.class.getTypeParameters()[0],
+					GroupConversionHelper.EMPTY, LegacyCollectionSupportValueExtractors.OPTIONAL );
 
 	/**
 	 * If this type parameter is marked for cascading.
@@ -117,19 +133,27 @@ public class NonContainerCascadingMetaData implements CascadingMetaData {
 
 	private ContainerCascadingMetaData getLegacyContainerElementCascadingMetaData(Class<?> valueClass) {
 		if ( List.class.isAssignableFrom( valueClass ) ) {
-			return new ContainerCascadingMetaData( List.class, List.class.getTypeParameters()[0], List.class, List.class.getTypeParameters()[0],
+			return groupConversionHelper.isEmpty() ?
+					LIST_CONTAINER_WITHOUT_GROUP_CONVERSIONS :
+					new ContainerCascadingMetaData( List.class, List.class.getTypeParameters()[0], List.class, List.class.getTypeParameters()[0],
 					groupConversionHelper, LegacyCollectionSupportValueExtractors.LIST );
 		}
 		else if ( Map.class.isAssignableFrom( valueClass ) ) {
-			return new ContainerCascadingMetaData( Map.class, Map.class.getTypeParameters()[1], Map.class, Map.class.getTypeParameters()[1],
+			return groupConversionHelper.isEmpty() ?
+					MAP_CONTAINER_WITHOUT_GROUP_CONVERSIONS :
+					new ContainerCascadingMetaData( Map.class, Map.class.getTypeParameters()[1], Map.class, Map.class.getTypeParameters()[1],
 					groupConversionHelper, LegacyCollectionSupportValueExtractors.MAP );
 		}
 		else if ( Iterable.class.isAssignableFrom( valueClass ) ) {
-			return new ContainerCascadingMetaData( Iterable.class, Iterable.class.getTypeParameters()[0], Iterable.class, Iterable.class.getTypeParameters()[0],
+			return groupConversionHelper.isEmpty() ?
+					ITERABLE_CONTAINER_WITHOUT_GROUP_CONVERSIONS :
+					new ContainerCascadingMetaData( Iterable.class, Iterable.class.getTypeParameters()[0], Iterable.class, Iterable.class.getTypeParameters()[0],
 					groupConversionHelper, LegacyCollectionSupportValueExtractors.ITERABLE );
 		}
 		else if ( Optional.class.isAssignableFrom( valueClass ) ) {
-			return new ContainerCascadingMetaData( Optional.class, Optional.class.getTypeParameters()[0], Optional.class, Optional.class.getTypeParameters()[0],
+			return groupConversionHelper.isEmpty() ?
+					OPTIONAL_CONTAINER_WITHOUT_GROUP_CONVERSIONS :
+					new ContainerCascadingMetaData( Optional.class, Optional.class.getTypeParameters()[0], Optional.class, Optional.class.getTypeParameters()[0],
 					groupConversionHelper, LegacyCollectionSupportValueExtractors.OPTIONAL );
 		}
 		else if ( valueClass.isArray() ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/NonContainerCascadingMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/NonContainerCascadingMetaData.java
@@ -101,7 +101,21 @@ public class NonContainerCascadingMetaData implements CascadingMetaData {
 		return false;
 	}
 
-	public ContainerCascadingMetaData getLegacyContainerCascadingMetaData(Class<?> valueClass) {
+	@Override
+	public CascadingMetaData addRuntimeLegacyCollectionSupport(Class<?> valueClass) {
+		if ( !cascading ) {
+			return this;
+		}
+
+		ContainerCascadingMetaData legacyContainerElementCascadingMetaData = getLegacyContainerElementCascadingMetaData( valueClass );
+		if ( legacyContainerElementCascadingMetaData == null ) {
+			return this;
+		}
+
+		return new ContainerCascadingMetaData( valueClass, Collections.singletonList( legacyContainerElementCascadingMetaData ), groupConversionHelper );
+	}
+
+	private ContainerCascadingMetaData getLegacyContainerElementCascadingMetaData(Class<?> valueClass) {
 		if ( List.class.isAssignableFrom( valueClass ) ) {
 			return new ContainerCascadingMetaData( List.class, List.class.getTypeParameters()[0], List.class, List.class.getTypeParameters()[0],
 					groupConversionHelper, LegacyCollectionSupportValueExtractors.LIST );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/GenericModelLegacyCascadingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/GenericModelLegacyCascadingTest.java
@@ -1,0 +1,142 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.valueextraction;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.CandidateForTck;
+import org.testng.annotations.Test;
+
+@CandidateForTck
+public class GenericModelLegacyCascadingTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1481")
+	public void testCascadingOnObject() {
+		Validator validator = getValidator();
+
+		GenericModelHolder<InvalidModel> holder = new GenericModelHolder<>();
+		holder.setModel( new InvalidModel() );
+
+		Set<ConstraintViolation<GenericModelHolder<?>>> constraintViolations = validator.validate( holder );
+
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.property( "model" )
+								.property( "notNullProperty" ) ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1481")
+	public void testCascadingOnList() {
+		Validator validator = getValidator();
+
+		GenericModelHolder<List<InvalidModel>> holder = new GenericModelHolder<>();
+		holder.setModel( Arrays.asList( new InvalidModel() ) );
+
+		Set<ConstraintViolation<GenericModelHolder<?>>> constraintViolations = validator.validate( holder );
+
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.property( "model" )
+								.property( "notNullProperty", true, null, 0, List.class, 0 ) ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1481")
+	public void testCascadingOnMap() {
+		Validator validator = getValidator();
+
+		Map<String, InvalidModel> map = new HashMap<>();
+		map.put( "invalidModel", new InvalidModel() );
+
+		GenericModelHolder<Map<String, InvalidModel>> holder = new GenericModelHolder<>();
+		holder.setModel( map );
+
+		Set<ConstraintViolation<GenericModelHolder<?>>> constraintViolations = validator.validate( holder );
+
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.property( "model" )
+								.property( "notNullProperty", true, "invalidModel", null, Map.class, 1 ) ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1481")
+	public void testCascadingOnIterable() {
+		Validator validator = getValidator();
+
+		GenericModelHolder<Set<InvalidModel>> holder = new GenericModelHolder<>();
+		holder.setModel( CollectionHelper.asSet( new InvalidModel() ) );
+
+		Set<ConstraintViolation<GenericModelHolder<?>>> constraintViolations = validator.validate( holder );
+
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.property( "model" )
+								.property( "notNullProperty", true, null, null, Iterable.class, 0 ) ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1481")
+	public void testCascadingOnArray() {
+		Validator validator = getValidator();
+
+		GenericModelHolder<InvalidModel[]> holder = new GenericModelHolder<>();
+		holder.setModel( new InvalidModel[]{ new InvalidModel() } );
+
+		Set<ConstraintViolation<GenericModelHolder<?>>> constraintViolations = validator.validate( holder );
+
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+						.withPropertyPath( pathWith()
+								.property( "model" )
+								.property( "notNullProperty", true, null, 0, Object[].class, null ) ) );
+	}
+
+	private class GenericModelHolder<M> {
+
+		private M model;
+
+		@Valid
+		public M getModel() {
+			return model;
+		}
+
+		public void setModel(M model) {
+			this.model = model;
+		}
+	}
+
+	public class InvalidModel {
+
+		@NotNull
+		public Object getNotNullProperty() {
+			return null;
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1481
https://hibernate.atlassian.net/browse/HV-1482

I kept the original approach of modifying the cascading metadata as it's faster if we can use it.

Note that this patch adds some overhead even when we have something like:
```
@Valid
private MyBean bean;
```

but I don't think we can avoid it, unfortunately...