### PR TITLE
HV-937 Changing how references are rendered in documentation

### DIFF
--- a/documentation/src/main/asciidoc/index.asciidoc
+++ b/documentation/src/main/asciidoc/index.asciidoc
@@ -3,6 +3,7 @@ Hardy Ferentschik; Gunnar Morling; Guillaume Smet
 :doctype: book
 :revdate: {docdate}
 :sectanchors:
+:xrefstyle: full
 :anchor:
 :toc: left
 :toclevels: 3

--- a/pom.xml
+++ b/pom.xml
@@ -173,10 +173,10 @@
 
         <!-- Asciidoctor -->
         <hibernate-asciidoctor-theme.version>1.0.1.Final</hibernate-asciidoctor-theme.version>
-        <hibernate-asciidoctor-extensions.version>1.0.1.Final</hibernate-asciidoctor-extensions.version>
+        <hibernate-asciidoctor-extensions.version>1.0.3.Final</hibernate-asciidoctor-extensions.version>
         <asciidoctor-maven-plugin.version>1.5.5</asciidoctor-maven-plugin.version>
         <jruby.version>9.1.8.0</jruby.version>
-        <asciidoctorj.version>1.6.0-alpha.3</asciidoctorj.version>
+        <asciidoctorj.version>1.6.0-alpha.5</asciidoctorj.version>
         <asciidoctorj-pdf.version>1.5.0-alpha.15</asciidoctorj-pdf.version>
 
         <!-- URLs used in javadoc and documentation generation -->


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-937

I guess that next release of `hibernate-asciidoctor-extensions` would be 1.0.3 :). This change depends on https://github.com/hibernate/hibernate-asciidoctor-extensions/pull/3