### PR TITLE
HV-1490 Don't fallback to the TCCL when detecting features in ConstraintHelper

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
@@ -990,7 +990,7 @@ public class ConstraintHelper {
 
 	private static boolean isClassPresent(String className) {
 		try {
-			run( LoadClass.action( className, ConstraintHelper.class.getClassLoader() ) );
+			run( LoadClass.action( className, ConstraintHelper.class.getClassLoader(), false ) );
 			return true;
 		}
 		catch (ValidationException e) {


### PR DESCRIPTION
We need to be able to access the class from the HV CL when we extract
the validated type from the validator generics.

 * https://hibernate.atlassian.net/browse/HV-1490