### PR TITLE
HV-1493 Add time based constraints with clock skew tolerance

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/HibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/HibernateValidatorConfiguration.java
@@ -6,10 +6,15 @@
  */
 package org.hibernate.validator;
 
+import java.time.Duration;
 import java.util.Set;
 
 import javax.validation.Configuration;
 import javax.validation.TraversableResolver;
+import javax.validation.constraints.Future;
+import javax.validation.constraints.FutureOrPresent;
+import javax.validation.constraints.Past;
+import javax.validation.constraints.PastOrPresent;
 import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.cfg.ConstraintMapping;
@@ -85,6 +90,15 @@ public interface HibernateValidatorConfiguration extends Configuration<Hibernate
 	 */
 	@Incubating
 	String SCRIPT_EVALUATOR_FACTORY_CLASSNAME = "hibernate.validator.script_evaluator_factory";
+
+	/**
+	 * Property for configuring clock skew tolerance, allowing to set the acceptable margin of error when comparing
+	 * date/time in time related constraints. In milliseconds.
+	 *
+	 * @since 6.0.5
+	 */
+	@Incubating
+	String CLOCK_SKEW_TOLERANCE = "hibernate.validator.clock_skew_tolerance";
 
 	/**
 	 * <p>
@@ -264,4 +278,17 @@ public interface HibernateValidatorConfiguration extends Configuration<Hibernate
 	 */
 	@Incubating
 	HibernateValidatorConfiguration scriptEvaluatorFactory(ScriptEvaluatorFactory scriptEvaluatorFactory);
+
+	/**
+	 * Allows set the acceptable margin of error when comparing date/time in time related constraints
+	 * like {@link Past}/{@link PastOrPresent} and {@link Future}/{@link FutureOrPresent}.
+	 *
+	 * @param clockSkewTolerance the acceptable tolerance as {@link Duration}
+	 *
+	 * @return {@code this} following the chaining method pattern
+	 *
+	 * @since 6.0.5
+	 */
+	@Incubating
+	HibernateValidatorConfiguration clockSkewTolerance(Duration clockSkewTolerance);
 }

--- a/engine/src/main/java/org/hibernate/validator/HibernateValidatorFactory.java
+++ b/engine/src/main/java/org/hibernate/validator/HibernateValidatorFactory.java
@@ -7,6 +7,8 @@
 
 package org.hibernate.validator;
 
+import java.time.Duration;
+
 import javax.validation.ValidatorFactory;
 
 import org.hibernate.validator.constraints.ParameterScriptAssert;
@@ -33,6 +35,17 @@ public interface HibernateValidatorFactory extends ValidatorFactory {
 	 */
 	@Incubating
 	ScriptEvaluatorFactory getScriptEvaluatorFactory();
+
+	/**
+	 * Returns clock skew tolerance as {@link Duration} i.e. the acceptable margin of error
+	 * when comparing date/time in time related constraints.
+	 *
+	 * @return a tolerance as {@link Duration}
+	 *
+	 * @since 6.0.5
+	 */
+	@Incubating
+	Duration getClockSkewTolerance();
 
 	/**
 	 * Returns a context for validator configuration via options from the

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.constraintvalidation;
+
+import java.lang.annotation.Annotation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.metadata.ConstraintDescriptor;
+
+import org.hibernate.validator.Incubating;
+
+/**
+ * Extends the contract of {@link ConstraintValidator} by adding {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)}
+ * which gives more flexibility during initialization of a constraint validator.
+ *
+ * @author Marko Bekhta
+ * @since 6.1
+ */
+@Incubating
+public interface HibernateConstraintValidator<A extends Annotation, T> extends ConstraintValidator<A, T> {
+
+	/**
+	 * Initializes the validator in preparation for {@link #isValid(Object, ConstraintValidatorContext)} calls.
+	 * It is an alternative to {@link #initialize(Annotation)} method. Should be used if any additional information
+	 * except annotation is needed to initialize a validator.
+	 * Note, when using {@link HibernateConstraintValidator} user should only override one of the methods, either
+	 * {@link #initialize(Annotation)} or {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)}.
+	 * It is guaranteed that in case of {@link HibernateConstraintValidator} just the
+	 * {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)} will be called during initialization.
+	 *
+	 * @param constraintDescriptor a constraint descriptor for a given constraint declaration
+	 * @param initializationContext an initialization context for a current {@link ConstraintValidatorFactory}
+	 */
+	default void initialize(ConstraintDescriptor<A> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		initialize( constraintDescriptor.getAnnotation() );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorContext.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorContext.java
@@ -8,11 +8,6 @@ package org.hibernate.validator.constraintvalidation;
 
 import javax.validation.ConstraintValidatorContext;
 
-import org.hibernate.validator.Incubating;
-import org.hibernate.validator.spi.scripting.ScriptEvaluator;
-import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
-import org.hibernate.validator.spi.scripting.ScriptEvaluatorNotFoundException;
-
 /**
  * A custom {@link ConstraintValidatorContext} which allows to set additional message parameters for
  * interpolation.
@@ -112,19 +107,4 @@ public interface HibernateConstraintValidatorContext extends ConstraintValidator
 	 */
 	HibernateConstraintValidatorContext withDynamicPayload(Object payload);
 
-	/**
-	 * Returns a {@link ScriptEvaluator} created based on the {@link ScriptEvaluatorFactory}
-	 * passed at bootstrap.
-	 *
-	 * @param languageName the name of the scripting language
-	 *
-	 * @return a script executor for the given language. Never null.
-	 *
-	 * @throws ScriptEvaluatorNotFoundException in case no {@link ScriptEvaluator} was
-	 * found for a given {@code languageName}
-	 *
-	 * @since 6.0.3
-	 */
-	@Incubating
-	ScriptEvaluator getScriptEvaluatorForLanguage(String languageName);
 }

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
@@ -1,0 +1,36 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.constraintvalidation;
+
+import org.hibernate.validator.Incubating;
+import org.hibernate.validator.spi.scripting.ScriptEvaluator;
+import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
+import org.hibernate.validator.spi.scripting.ScriptEvaluatorNotFoundException;
+
+/**
+ * Provides contextual data and operations when initializing constraint validator.
+ *
+ * @author Marko Bekhta
+ * @since 6.1
+ */
+@Incubating
+public interface HibernateConstraintValidatorInitializationContext {
+
+	/**
+	 * Returns a {@link ScriptEvaluator} created based on the {@link ScriptEvaluatorFactory}
+	 * passed at bootstrap.
+	 *
+	 * @param languageName the name of the scripting language
+	 *
+	 * @return a script executor for the given language. Never null.
+	 *
+	 * @throws ScriptEvaluatorNotFoundException in case no {@link ScriptEvaluator} was
+	 * found for a given {@code languageName}
+	 */
+
+	ScriptEvaluator getScriptEvaluatorForLanguage(String languageName);
+}

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.constraintvalidation;
 
+import java.time.Duration;
+
 import org.hibernate.validator.Incubating;
 import org.hibernate.validator.spi.scripting.ScriptEvaluator;
 import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
@@ -33,4 +35,13 @@ public interface HibernateConstraintValidatorInitializationContext {
 	 */
 
 	ScriptEvaluator getScriptEvaluatorForLanguage(String languageName);
+
+	/**
+	 * Returns clock skew tolerance as {@link Duration} which is used to determine
+	 * acceptable margin of error in milliseconds, which is allowed
+	 * when comparing date/time in time related constraints.
+	 *
+	 * @return a tolerance as  {@link Duration}
+	 */
+	Duration getClockSkewTolerance();
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/AbstractEpochBasedTimeValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/AbstractEpochBasedTimeValidator.java
@@ -9,11 +9,14 @@ package org.hibernate.validator.internal.constraintvalidators.bv.time;
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.time.Clock;
+import java.time.Duration;
 
 import javax.validation.ClockProvider;
-import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import javax.validation.metadata.ConstraintDescriptor;
 
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
@@ -23,9 +26,16 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
  * @author Alaa Nassef
  * @author Guillaume Smet
  */
-public abstract class AbstractEpochBasedTimeValidator<C extends Annotation, T> implements ConstraintValidator<C, T> {
+public abstract class AbstractEpochBasedTimeValidator<C extends Annotation, T> implements HibernateConstraintValidator<C, T> {
 
 	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
+
+	protected Duration tolerance;
+
+	@Override
+	public void initialize(ConstraintDescriptor<C> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		this.tolerance = initializationContext.getClockSkewTolerance();
+	}
 
 	@Override
 	public boolean isValid(T value, ConstraintValidatorContext context) {
@@ -44,7 +54,7 @@ public abstract class AbstractEpochBasedTimeValidator<C extends Annotation, T> i
 			throw LOG.getUnableToGetCurrentTimeFromClockProvider( e );
 		}
 
-		int result = Long.compare( getEpochMillis( value, reference ), reference.millis() );
+		int result = Long.compare( getEpochMillis( value, reference ), adjustedReferenceValue( reference.millis() ) );
 
 		return isValid( result );
 	}
@@ -54,6 +64,12 @@ public abstract class AbstractEpochBasedTimeValidator<C extends Annotation, T> i
 	 * use the {@link Clock} provided by the {@link ClockProvider}.
 	 */
 	protected abstract long getEpochMillis(T value, Clock reference);
+
+	/**
+	 * @param value a value to adjust
+	 * @return an adjusted value based on {@link #tolerance} and constraint type
+	 */
+	protected abstract long adjustedReferenceValue(long value);
 
 	/**
 	 * Returns whether the result of the comparison between the validated value and the time reference is considered

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/AbstractJavaTimeValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/AbstractJavaTimeValidator.java
@@ -9,12 +9,15 @@ package org.hibernate.validator.internal.constraintvalidators.bv.time;
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
 
 import javax.validation.ClockProvider;
-import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import javax.validation.metadata.ConstraintDescriptor;
 
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
@@ -24,9 +27,16 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
  * @author Alaa Nassef
  * @author Guillaume Smet
  */
-public abstract class AbstractJavaTimeValidator<C extends Annotation, T extends TemporalAccessor & Comparable<? super T>> implements ConstraintValidator<C, T> {
+public abstract class AbstractJavaTimeValidator<C extends Annotation, T extends TemporalAccessor & Comparable<? super T>> implements HibernateConstraintValidator<C, T> {
 
 	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
+
+	protected Duration tolerance;
+
+	@Override
+	public void initialize(ConstraintDescriptor<C> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		this.tolerance = initializationContext.getClockSkewTolerance();
+	}
 
 	@Override
 	public boolean isValid(T value, ConstraintValidatorContext context) {
@@ -45,7 +55,7 @@ public abstract class AbstractJavaTimeValidator<C extends Annotation, T extends 
 			throw LOG.getUnableToGetCurrentTimeFromClockProvider( e );
 		}
 
-		int result = value.compareTo( getReferenceValue( reference ) );
+		int result = value.compareTo( adjustedReferenceValue( getReferenceValue( reference ) ) );
 
 		return isValid( result );
 	}
@@ -55,6 +65,12 @@ public abstract class AbstractJavaTimeValidator<C extends Annotation, T extends 
 	 * {@link ClockProvider}.
 	 */
 	protected abstract T getReferenceValue(Clock reference);
+
+	/**
+	 * @param value a value to adjust
+	 * @return an adjusted value based on {@link #tolerance} and constraint type
+	 */
+	protected abstract T adjustedReferenceValue(T value);
 
 	/**
 	 * Returns whether the result of the comparison between the validated value and the time reference is considered

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureEpochBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureEpochBasedValidator.java
@@ -23,4 +23,8 @@ public abstract class AbstractFutureEpochBasedValidator<T> extends AbstractEpoch
 		return result > 0;
 	}
 
+	@Override
+	protected long adjustedReferenceValue(long value) {
+		return value - tolerance.toMillis();
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureInstantBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureInstantBasedValidator.java
@@ -25,4 +25,8 @@ public abstract class AbstractFutureInstantBasedValidator<T> extends AbstractIns
 		return result > 0;
 	}
 
+	@Override
+	protected Instant adjustedReferenceValue(Instant value) {
+		return value.minus( tolerance );
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureJavaTimeTemporalValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureJavaTimeTemporalValidator.java
@@ -6,19 +6,15 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.future;
 
-import java.time.Clock;
-import java.time.Year;
+import java.time.temporal.Temporal;
 
 /**
- * Check that the {@code java.time.Year} passed is in the future.
- *
- * @author Guillaume Smet
+ * @author Marko Bekhta
  */
-public class FutureValidatorForYear extends AbstractFutureJavaTimeTemporalValidator<Year> {
+public abstract class AbstractFutureJavaTimeTemporalValidator<T extends Temporal & Comparable<? super T>> extends AbstractFutureJavaTimeValidator<T> {
 
 	@Override
-	protected Year getReferenceValue(Clock reference) {
-		return Year.now( reference );
+	protected T adjustedReferenceValue(T value) {
+		return (T) value.minus( tolerance );
 	}
-
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForHijrahDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForHijrahDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.HijrahDate;
  *
  * @author Guillaume Smet
  */
-public class FutureValidatorForHijrahDate extends AbstractFutureJavaTimeValidator<HijrahDate> {
+public class FutureValidatorForHijrahDate extends AbstractFutureJavaTimeTemporalValidator<HijrahDate> {
 
 	@Override
 	protected HijrahDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForInstant.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForInstant.java
@@ -15,7 +15,7 @@ import java.time.Instant;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class FutureValidatorForInstant extends AbstractFutureJavaTimeValidator<Instant> {
+public class FutureValidatorForInstant extends AbstractFutureJavaTimeTemporalValidator<Instant> {
 
 	@Override
 	protected Instant getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForJapaneseDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForJapaneseDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.JapaneseDate;
  *
  * @author Guillaume Smet
  */
-public class FutureValidatorForJapaneseDate extends AbstractFutureJavaTimeValidator<JapaneseDate> {
+public class FutureValidatorForJapaneseDate extends AbstractFutureJavaTimeTemporalValidator<JapaneseDate> {
 
 	@Override
 	protected JapaneseDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForLocalDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForLocalDate.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
  *
  * @author Guillaume Smet
  */
-public class FutureValidatorForLocalDate extends AbstractFutureJavaTimeValidator<LocalDate> {
+public class FutureValidatorForLocalDate extends AbstractFutureJavaTimeTemporalValidator<LocalDate> {
 
 	@Override
 	protected LocalDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForLocalDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForLocalDateTime.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
  *
  * @author Guillaume Smet
  */
-public class FutureValidatorForLocalDateTime extends AbstractFutureJavaTimeValidator<LocalDateTime> {
+public class FutureValidatorForLocalDateTime extends AbstractFutureJavaTimeTemporalValidator<LocalDateTime> {
 
 	@Override
 	protected LocalDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForLocalTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForLocalTime.java
@@ -14,7 +14,7 @@ import java.time.LocalTime;
  *
  * @author Guillaume Smet
  */
-public class FutureValidatorForLocalTime extends AbstractFutureJavaTimeValidator<LocalTime> {
+public class FutureValidatorForLocalTime extends AbstractFutureJavaTimeTemporalValidator<LocalTime> {
 
 	@Override
 	protected LocalTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForMinguoDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForMinguoDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.MinguoDate;
  *
  * @author Guillaume Smet
  */
-public class FutureValidatorForMinguoDate extends AbstractFutureJavaTimeValidator<MinguoDate> {
+public class FutureValidatorForMinguoDate extends AbstractFutureJavaTimeTemporalValidator<MinguoDate> {
 
 	@Override
 	protected MinguoDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForMonthDay.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForMonthDay.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.constraintvalidators.bv.time.future;
 
 import java.time.Clock;
+import java.time.LocalDateTime;
 import java.time.MonthDay;
 
 /**
@@ -18,7 +19,13 @@ public class FutureValidatorForMonthDay extends AbstractFutureJavaTimeValidator<
 
 	@Override
 	protected MonthDay getReferenceValue(Clock reference) {
-		return MonthDay.now( reference );
+		LocalDateTime now = LocalDateTime.now( reference ).minus( tolerance );
+		return MonthDay.of( now.getMonth(), now.getDayOfMonth() );
 	}
 
+	@Override
+	protected MonthDay adjustedReferenceValue(MonthDay value) {
+		// value is already adjusted in the reference method
+		return value;
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForOffsetDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForOffsetDateTime.java
@@ -15,7 +15,7 @@ import java.time.OffsetDateTime;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class FutureValidatorForOffsetDateTime extends AbstractFutureJavaTimeValidator<OffsetDateTime> {
+public class FutureValidatorForOffsetDateTime extends AbstractFutureJavaTimeTemporalValidator<OffsetDateTime> {
 
 	@Override
 	protected OffsetDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForOffsetTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForOffsetTime.java
@@ -14,7 +14,7 @@ import java.time.OffsetTime;
  *
  * @author Guillaume Smet
  */
-public class FutureValidatorForOffsetTime extends AbstractFutureJavaTimeValidator<OffsetTime> {
+public class FutureValidatorForOffsetTime extends AbstractFutureJavaTimeTemporalValidator<OffsetTime> {
 
 	@Override
 	protected OffsetTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForThaiBuddhistDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForThaiBuddhistDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.ThaiBuddhistDate;
  *
  * @author Guillaume Smet
  */
-public class FutureValidatorForThaiBuddhistDate extends AbstractFutureJavaTimeValidator<ThaiBuddhistDate> {
+public class FutureValidatorForThaiBuddhistDate extends AbstractFutureJavaTimeTemporalValidator<ThaiBuddhistDate> {
 
 	@Override
 	protected ThaiBuddhistDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForYearMonth.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForYearMonth.java
@@ -14,7 +14,7 @@ import java.time.YearMonth;
  *
  * @author Guillaume Smet
  */
-public class FutureValidatorForYearMonth extends AbstractFutureJavaTimeValidator<YearMonth> {
+public class FutureValidatorForYearMonth extends AbstractFutureJavaTimeTemporalValidator<YearMonth> {
 
 	@Override
 	protected YearMonth getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForZonedDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/FutureValidatorForZonedDateTime.java
@@ -15,7 +15,7 @@ import java.time.ZonedDateTime;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class FutureValidatorForZonedDateTime extends AbstractFutureJavaTimeValidator<ZonedDateTime> {
+public class FutureValidatorForZonedDateTime extends AbstractFutureJavaTimeTemporalValidator<ZonedDateTime> {
 
 	@Override
 	protected ZonedDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentEpochBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentEpochBasedValidator.java
@@ -23,4 +23,8 @@ public abstract class AbstractFutureOrPresentEpochBasedValidator<T> extends Abst
 		return result >= 0;
 	}
 
+	@Override
+	protected long adjustedReferenceValue(long value) {
+		return value - tolerance.toMillis();
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentInstantBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentInstantBasedValidator.java
@@ -25,4 +25,8 @@ public abstract class AbstractFutureOrPresentInstantBasedValidator<T> extends Ab
 		return result >= 0;
 	}
 
+	@Override
+	protected Instant adjustedReferenceValue(Instant value) {
+		return value.minus( tolerance );
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentJavaTimeTemporalValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentJavaTimeTemporalValidator.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent;
+
+import java.time.temporal.Temporal;
+
+/**
+ * @author Marko Bekhta
+ */
+public abstract class AbstractFutureOrPresentJavaTimeTemporalValidator<T extends Temporal & Comparable<? super T>> extends AbstractFutureOrPresentJavaTimeValidator<T> {
+
+	@Override
+	protected T adjustedReferenceValue(T value) {
+		return (T) value.minus( tolerance );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForHijrahDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForHijrahDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.HijrahDate;
  *
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForHijrahDate extends AbstractFutureOrPresentJavaTimeValidator<HijrahDate> {
+public class FutureOrPresentValidatorForHijrahDate extends AbstractFutureOrPresentJavaTimeTemporalValidator<HijrahDate> {
 
 	@Override
 	protected HijrahDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForInstant.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForInstant.java
@@ -15,7 +15,7 @@ import java.time.Instant;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForInstant extends AbstractFutureOrPresentJavaTimeValidator<Instant> {
+public class FutureOrPresentValidatorForInstant extends AbstractFutureOrPresentJavaTimeTemporalValidator<Instant> {
 
 	@Override
 	protected Instant getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForJapaneseDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForJapaneseDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.JapaneseDate;
  *
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForJapaneseDate extends AbstractFutureOrPresentJavaTimeValidator<JapaneseDate> {
+public class FutureOrPresentValidatorForJapaneseDate extends AbstractFutureOrPresentJavaTimeTemporalValidator<JapaneseDate> {
 
 	@Override
 	protected JapaneseDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForLocalDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForLocalDate.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
  *
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForLocalDate extends AbstractFutureOrPresentJavaTimeValidator<LocalDate> {
+public class FutureOrPresentValidatorForLocalDate extends AbstractFutureOrPresentJavaTimeTemporalValidator<LocalDate> {
 
 	@Override
 	protected LocalDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForLocalDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForLocalDateTime.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
  *
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForLocalDateTime extends AbstractFutureOrPresentJavaTimeValidator<LocalDateTime> {
+public class FutureOrPresentValidatorForLocalDateTime extends AbstractFutureOrPresentJavaTimeTemporalValidator<LocalDateTime> {
 
 	@Override
 	protected LocalDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForLocalTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForLocalTime.java
@@ -14,7 +14,7 @@ import java.time.LocalTime;
  *
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForLocalTime extends AbstractFutureOrPresentJavaTimeValidator<LocalTime> {
+public class FutureOrPresentValidatorForLocalTime extends AbstractFutureOrPresentJavaTimeTemporalValidator<LocalTime> {
 
 	@Override
 	protected LocalTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForMinguoDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForMinguoDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.MinguoDate;
  *
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForMinguoDate extends AbstractFutureOrPresentJavaTimeValidator<MinguoDate> {
+public class FutureOrPresentValidatorForMinguoDate extends AbstractFutureOrPresentJavaTimeTemporalValidator<MinguoDate> {
 
 	@Override
 	protected MinguoDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForMonthDay.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForMonthDay.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent;
 
 import java.time.Clock;
+import java.time.LocalDateTime;
 import java.time.MonthDay;
 
 /**
@@ -18,7 +19,14 @@ public class FutureOrPresentValidatorForMonthDay extends AbstractFutureOrPresent
 
 	@Override
 	protected MonthDay getReferenceValue(Clock reference) {
-		return MonthDay.now( reference );
+		LocalDateTime now = LocalDateTime.now( reference ).minus( tolerance );
+		return MonthDay.of( now.getMonth(), now.getDayOfMonth() );
+	}
+
+	@Override
+	protected MonthDay adjustedReferenceValue(MonthDay value) {
+		// value is already adjusted in the reference method
+		return value;
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForOffsetDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForOffsetDateTime.java
@@ -15,7 +15,7 @@ import java.time.OffsetDateTime;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForOffsetDateTime extends AbstractFutureOrPresentJavaTimeValidator<OffsetDateTime> {
+public class FutureOrPresentValidatorForOffsetDateTime extends AbstractFutureOrPresentJavaTimeTemporalValidator<OffsetDateTime> {
 
 	@Override
 	protected OffsetDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForOffsetTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForOffsetTime.java
@@ -14,7 +14,7 @@ import java.time.OffsetTime;
  *
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForOffsetTime extends AbstractFutureOrPresentJavaTimeValidator<OffsetTime> {
+public class FutureOrPresentValidatorForOffsetTime extends AbstractFutureOrPresentJavaTimeTemporalValidator<OffsetTime> {
 
 	@Override
 	protected OffsetTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForThaiBuddhistDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForThaiBuddhistDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.ThaiBuddhistDate;
  *
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForThaiBuddhistDate extends AbstractFutureOrPresentJavaTimeValidator<ThaiBuddhistDate> {
+public class FutureOrPresentValidatorForThaiBuddhistDate extends AbstractFutureOrPresentJavaTimeTemporalValidator<ThaiBuddhistDate> {
 
 	@Override
 	protected ThaiBuddhistDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForYear.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForYear.java
@@ -14,7 +14,7 @@ import java.time.Year;
  *
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForYear extends AbstractFutureOrPresentJavaTimeValidator<Year> {
+public class FutureOrPresentValidatorForYear extends AbstractFutureOrPresentJavaTimeTemporalValidator<Year> {
 
 	@Override
 	protected Year getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForYearMonth.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForYearMonth.java
@@ -14,7 +14,7 @@ import java.time.YearMonth;
  *
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForYearMonth extends AbstractFutureOrPresentJavaTimeValidator<YearMonth> {
+public class FutureOrPresentValidatorForYearMonth extends AbstractFutureOrPresentJavaTimeTemporalValidator<YearMonth> {
 
 	@Override
 	protected YearMonth getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForZonedDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/FutureOrPresentValidatorForZonedDateTime.java
@@ -15,7 +15,7 @@ import java.time.ZonedDateTime;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class FutureOrPresentValidatorForZonedDateTime extends AbstractFutureOrPresentJavaTimeValidator<ZonedDateTime> {
+public class FutureOrPresentValidatorForZonedDateTime extends AbstractFutureOrPresentJavaTimeTemporalValidator<ZonedDateTime> {
 
 	@Override
 	protected ZonedDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastEpochBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastEpochBasedValidator.java
@@ -23,4 +23,8 @@ public abstract class AbstractPastEpochBasedValidator<T> extends AbstractEpochBa
 		return result < 0;
 	}
 
+	@Override
+	protected long adjustedReferenceValue(long value) {
+		return value + tolerance.toMillis();
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastInstantBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastInstantBasedValidator.java
@@ -25,4 +25,8 @@ public abstract class AbstractPastInstantBasedValidator<T> extends AbstractInsta
 		return result < 0;
 	}
 
+	@Override
+	protected Instant adjustedReferenceValue(Instant value) {
+		return value.plus( tolerance );
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastJavaTimeTemporalValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastJavaTimeTemporalValidator.java
@@ -6,19 +6,15 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.past;
 
-import java.time.Clock;
-import java.time.Year;
+import java.time.temporal.Temporal;
 
 /**
- * Check that the {@code java.time.Year} passed is in the past.
- *
- * @author Guillaume Smet
+ * @author Marko Bekhta
  */
-public class PastValidatorForYear extends AbstractPastJavaTimeTemporalValidator<Year> {
+public abstract class AbstractPastJavaTimeTemporalValidator<T extends Temporal & Comparable<? super T>> extends AbstractPastJavaTimeValidator<T> {
 
 	@Override
-	protected Year getReferenceValue(Clock reference) {
-		return Year.now( reference );
+	protected T adjustedReferenceValue(T value) {
+		return (T) value.plus( tolerance );
 	}
-
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForHijrahDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForHijrahDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.HijrahDate;
  *
  * @author Guillaume Smet
  */
-public class PastValidatorForHijrahDate extends AbstractPastJavaTimeValidator<HijrahDate> {
+public class PastValidatorForHijrahDate extends AbstractPastJavaTimeTemporalValidator<HijrahDate> {
 
 	@Override
 	protected HijrahDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForInstant.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForInstant.java
@@ -15,7 +15,7 @@ import java.time.Instant;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class PastValidatorForInstant extends AbstractPastJavaTimeValidator<Instant> {
+public class PastValidatorForInstant extends AbstractPastJavaTimeTemporalValidator<Instant> {
 
 	@Override
 	protected Instant getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForJapaneseDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForJapaneseDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.JapaneseDate;
  *
  * @author Guillaume Smet
  */
-public class PastValidatorForJapaneseDate extends AbstractPastJavaTimeValidator<JapaneseDate> {
+public class PastValidatorForJapaneseDate extends AbstractPastJavaTimeTemporalValidator<JapaneseDate> {
 
 	@Override
 	protected JapaneseDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForLocalDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForLocalDate.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
  *
  * @author Guillaume Smet
  */
-public class PastValidatorForLocalDate extends AbstractPastJavaTimeValidator<LocalDate> {
+public class PastValidatorForLocalDate extends AbstractPastJavaTimeTemporalValidator<LocalDate> {
 
 	@Override
 	protected LocalDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForLocalDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForLocalDateTime.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
  *
  * @author Guillaume Smet
  */
-public class PastValidatorForLocalDateTime extends AbstractPastJavaTimeValidator<LocalDateTime> {
+public class PastValidatorForLocalDateTime extends AbstractPastJavaTimeTemporalValidator<LocalDateTime> {
 
 	@Override
 	protected LocalDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForLocalTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForLocalTime.java
@@ -14,7 +14,7 @@ import java.time.LocalTime;
  *
  * @author Guillaume Smet
  */
-public class PastValidatorForLocalTime extends AbstractPastJavaTimeValidator<LocalTime> {
+public class PastValidatorForLocalTime extends AbstractPastJavaTimeTemporalValidator<LocalTime> {
 
 	@Override
 	protected LocalTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForMinguoDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForMinguoDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.MinguoDate;
  *
  * @author Guillaume Smet
  */
-public class PastValidatorForMinguoDate extends AbstractPastJavaTimeValidator<MinguoDate> {
+public class PastValidatorForMinguoDate extends AbstractPastJavaTimeTemporalValidator<MinguoDate> {
 
 	@Override
 	protected MinguoDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForMonthDay.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForMonthDay.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.constraintvalidators.bv.time.past;
 
 import java.time.Clock;
+import java.time.LocalDateTime;
 import java.time.MonthDay;
 
 /**
@@ -18,7 +19,14 @@ public class PastValidatorForMonthDay extends AbstractPastJavaTimeValidator<Mont
 
 	@Override
 	protected MonthDay getReferenceValue(Clock reference) {
-		return MonthDay.now( reference );
+		LocalDateTime now = LocalDateTime.now( reference ).plus( tolerance );
+		return MonthDay.of( now.getMonth(), now.getDayOfMonth() );
+	}
+
+	@Override
+	protected MonthDay adjustedReferenceValue(MonthDay value) {
+		// value is already adjusted in the reference method
+		return value;
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForOffsetDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForOffsetDateTime.java
@@ -15,7 +15,7 @@ import java.time.OffsetDateTime;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class PastValidatorForOffsetDateTime extends AbstractPastJavaTimeValidator<OffsetDateTime> {
+public class PastValidatorForOffsetDateTime extends AbstractPastJavaTimeTemporalValidator<OffsetDateTime> {
 
 	@Override
 	protected OffsetDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForOffsetTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForOffsetTime.java
@@ -14,7 +14,7 @@ import java.time.OffsetTime;
  *
  * @author Guillaume Smet
  */
-public class PastValidatorForOffsetTime extends AbstractPastJavaTimeValidator<OffsetTime> {
+public class PastValidatorForOffsetTime extends AbstractPastJavaTimeTemporalValidator<OffsetTime> {
 
 	@Override
 	protected OffsetTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForThaiBuddhistDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForThaiBuddhistDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.ThaiBuddhistDate;
  *
  * @author Guillaume Smet
  */
-public class PastValidatorForThaiBuddhistDate extends AbstractPastJavaTimeValidator<ThaiBuddhistDate> {
+public class PastValidatorForThaiBuddhistDate extends AbstractPastJavaTimeTemporalValidator<ThaiBuddhistDate> {
 
 	@Override
 	protected ThaiBuddhistDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForYearMonth.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForYearMonth.java
@@ -14,7 +14,7 @@ import java.time.YearMonth;
  *
  * @author Guillaume Smet
  */
-public class PastValidatorForYearMonth extends AbstractPastJavaTimeValidator<YearMonth> {
+public class PastValidatorForYearMonth extends AbstractPastJavaTimeTemporalValidator<YearMonth> {
 
 	@Override
 	protected YearMonth getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForZonedDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/PastValidatorForZonedDateTime.java
@@ -15,7 +15,7 @@ import java.time.ZonedDateTime;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class PastValidatorForZonedDateTime extends AbstractPastJavaTimeValidator<ZonedDateTime> {
+public class PastValidatorForZonedDateTime extends AbstractPastJavaTimeTemporalValidator<ZonedDateTime> {
 
 	@Override
 	protected ZonedDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentEpochBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentEpochBasedValidator.java
@@ -23,4 +23,8 @@ public abstract class AbstractPastOrPresentEpochBasedValidator<T> extends Abstra
 		return result <= 0;
 	}
 
+	@Override
+	protected long adjustedReferenceValue(long value) {
+		return value + tolerance.toMillis();
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentInstantBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentInstantBasedValidator.java
@@ -25,4 +25,8 @@ public abstract class AbstractPastOrPresentInstantBasedValidator<T> extends Abst
 		return result <= 0;
 	}
 
+	@Override
+	protected Instant adjustedReferenceValue(Instant value) {
+		return value.plus( tolerance );
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentJavaTimeTemporalValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentJavaTimeTemporalValidator.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent;
+
+import java.time.temporal.Temporal;
+
+/**
+ * @author Marko Bekhta
+ */
+public abstract class AbstractPastOrPresentJavaTimeTemporalValidator<T extends Temporal & Comparable<? super T>> extends AbstractPastOrPresentJavaTimeValidator<T> {
+
+	@Override
+	protected T adjustedReferenceValue(T value) {
+		return (T) value.plus( tolerance );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForHijrahDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForHijrahDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.HijrahDate;
  *
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForHijrahDate extends AbstractPastOrPresentJavaTimeValidator<HijrahDate> {
+public class PastOrPresentValidatorForHijrahDate extends AbstractPastOrPresentJavaTimeTemporalValidator<HijrahDate> {
 
 	@Override
 	protected HijrahDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForInstant.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForInstant.java
@@ -15,7 +15,7 @@ import java.time.Instant;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForInstant extends AbstractPastOrPresentJavaTimeValidator<Instant> {
+public class PastOrPresentValidatorForInstant extends AbstractPastOrPresentJavaTimeTemporalValidator<Instant> {
 
 	@Override
 	protected Instant getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForJapaneseDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForJapaneseDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.JapaneseDate;
  *
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForJapaneseDate extends AbstractPastOrPresentJavaTimeValidator<JapaneseDate> {
+public class PastOrPresentValidatorForJapaneseDate extends AbstractPastOrPresentJavaTimeTemporalValidator<JapaneseDate> {
 
 	@Override
 	protected JapaneseDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForLocalDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForLocalDate.java
@@ -14,7 +14,7 @@ import java.time.LocalDate;
  *
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForLocalDate extends AbstractPastOrPresentJavaTimeValidator<LocalDate> {
+public class PastOrPresentValidatorForLocalDate extends AbstractPastOrPresentJavaTimeTemporalValidator<LocalDate> {
 
 	@Override
 	protected LocalDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForLocalDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForLocalDateTime.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
  *
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForLocalDateTime extends AbstractPastOrPresentJavaTimeValidator<LocalDateTime> {
+public class PastOrPresentValidatorForLocalDateTime extends AbstractPastOrPresentJavaTimeTemporalValidator<LocalDateTime> {
 
 	@Override
 	protected LocalDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForLocalTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForLocalTime.java
@@ -14,7 +14,7 @@ import java.time.LocalTime;
  *
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForLocalTime extends AbstractPastOrPresentJavaTimeValidator<LocalTime> {
+public class PastOrPresentValidatorForLocalTime extends AbstractPastOrPresentJavaTimeTemporalValidator<LocalTime> {
 
 	@Override
 	protected LocalTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForMinguoDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForMinguoDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.MinguoDate;
  *
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForMinguoDate extends AbstractPastOrPresentJavaTimeValidator<MinguoDate> {
+public class PastOrPresentValidatorForMinguoDate extends AbstractPastOrPresentJavaTimeTemporalValidator<MinguoDate> {
 
 	@Override
 	protected MinguoDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForMonthDay.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForMonthDay.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent;
 
 import java.time.Clock;
+import java.time.LocalDateTime;
 import java.time.MonthDay;
 
 /**
@@ -18,7 +19,14 @@ public class PastOrPresentValidatorForMonthDay extends AbstractPastOrPresentJava
 
 	@Override
 	protected MonthDay getReferenceValue(Clock reference) {
-		return MonthDay.now( reference );
+		LocalDateTime now = LocalDateTime.now( reference ).plus( tolerance );
+		return MonthDay.of( now.getMonth(), now.getDayOfMonth() );
+	}
+
+	@Override
+	protected MonthDay adjustedReferenceValue(MonthDay value) {
+		// value is already adjusted in the reference method
+		return value;
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForOffsetDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForOffsetDateTime.java
@@ -15,7 +15,7 @@ import java.time.OffsetDateTime;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForOffsetDateTime extends AbstractPastOrPresentJavaTimeValidator<OffsetDateTime> {
+public class PastOrPresentValidatorForOffsetDateTime extends AbstractPastOrPresentJavaTimeTemporalValidator<OffsetDateTime> {
 
 	@Override
 	protected OffsetDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForOffsetTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForOffsetTime.java
@@ -14,7 +14,7 @@ import java.time.OffsetTime;
  *
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForOffsetTime extends AbstractPastOrPresentJavaTimeValidator<OffsetTime> {
+public class PastOrPresentValidatorForOffsetTime extends AbstractPastOrPresentJavaTimeTemporalValidator<OffsetTime> {
 
 	@Override
 	protected OffsetTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForThaiBuddhistDate.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForThaiBuddhistDate.java
@@ -14,7 +14,7 @@ import java.time.chrono.ThaiBuddhistDate;
  *
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForThaiBuddhistDate extends AbstractPastOrPresentJavaTimeValidator<ThaiBuddhistDate> {
+public class PastOrPresentValidatorForThaiBuddhistDate extends AbstractPastOrPresentJavaTimeTemporalValidator<ThaiBuddhistDate> {
 
 	@Override
 	protected ThaiBuddhistDate getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForYear.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForYear.java
@@ -14,7 +14,7 @@ import java.time.Year;
  *
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForYear extends AbstractPastOrPresentJavaTimeValidator<Year> {
+public class PastOrPresentValidatorForYear extends AbstractPastOrPresentJavaTimeTemporalValidator<Year> {
 
 	@Override
 	protected Year getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForYearMonth.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForYearMonth.java
@@ -14,7 +14,7 @@ import java.time.YearMonth;
  *
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForYearMonth extends AbstractPastOrPresentJavaTimeValidator<YearMonth> {
+public class PastOrPresentValidatorForYearMonth extends AbstractPastOrPresentJavaTimeTemporalValidator<YearMonth> {
 
 	@Override
 	protected YearMonth getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForZonedDateTime.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/PastOrPresentValidatorForZonedDateTime.java
@@ -15,7 +15,7 @@ import java.time.ZonedDateTime;
  * @author Khalid Alqinyah
  * @author Guillaume Smet
  */
-public class PastOrPresentValidatorForZonedDateTime extends AbstractPastOrPresentJavaTimeValidator<ZonedDateTime> {
+public class PastOrPresentValidatorForZonedDateTime extends AbstractPastOrPresentJavaTimeTemporalValidator<ZonedDateTime> {
 
 	@Override
 	protected ZonedDateTime getReferenceValue(Clock reference) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/AbstractScriptAssertValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/AbstractScriptAssertValidator.java
@@ -9,10 +9,8 @@ package org.hibernate.validator.internal.constraintvalidators.hv;
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
-
-import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.spi.scripting.ScriptEvaluator;
@@ -21,7 +19,7 @@ import org.hibernate.validator.spi.scripting.ScriptEvaluatorNotFoundException;
 /**
  * @author Marko Bekhta
  */
-public abstract class AbstractScriptAssertValidator<A extends Annotation, T> implements ConstraintValidator<A, T> {
+public abstract class AbstractScriptAssertValidator<A extends Annotation, T> implements HibernateConstraintValidator<A, T> {
 
 	private static final Log log = LoggerFactory.make( MethodHandles.lookup() );
 
@@ -30,24 +28,13 @@ public abstract class AbstractScriptAssertValidator<A extends Annotation, T> imp
 	protected String escapedScript;
 	protected volatile ScriptAssertContext scriptAssertContext;
 
-	protected ScriptAssertContext getScriptAssertContext(ConstraintValidatorContext constraintValidatorContext) {
-		if ( scriptAssertContext == null ) {
-			synchronized ( this ) {
-				if ( scriptAssertContext == null ) {
-					ScriptEvaluator scriptEvaluator = null;
-					if ( constraintValidatorContext instanceof HibernateConstraintValidatorContext ) {
-						try {
-							scriptEvaluator = constraintValidatorContext.unwrap( HibernateConstraintValidatorContext.class )
-									.getScriptEvaluatorForLanguage( languageName );
-						}
-						catch (ScriptEvaluatorNotFoundException e) {
-							throw log.getCreationOfScriptExecutorFailedException( languageName, e );
-						}
-					}
-					scriptAssertContext = new ScriptAssertContext( script, scriptEvaluator );
-				}
-			}
+	protected void initializeScriptContext(HibernateConstraintValidatorInitializationContext initializationContext) {
+		try {
+			ScriptEvaluator scriptEvaluator = initializationContext.getScriptEvaluatorForLanguage( languageName );
+			scriptAssertContext = new ScriptAssertContext( script, scriptEvaluator );
 		}
-		return scriptAssertContext;
+		catch (ScriptEvaluatorNotFoundException e) {
+			throw log.getCreationOfScriptExecutorFailedException( languageName, e );
+		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/ParameterScriptAssertValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/ParameterScriptAssertValidator.java
@@ -15,9 +15,11 @@ import java.util.Map;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.constraintvalidation.SupportedValidationTarget;
 import javax.validation.constraintvalidation.ValidationTarget;
+import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraints.ParameterScriptAssert;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.messageinterpolation.util.InterpolationHelper;
 import org.hibernate.validator.internal.util.Contracts;
@@ -33,11 +35,15 @@ import org.hibernate.validator.internal.util.Contracts;
 public class ParameterScriptAssertValidator extends AbstractScriptAssertValidator<ParameterScriptAssert, Object[]> {
 
 	@Override
-	public void initialize(ParameterScriptAssert constraintAnnotation) {
+	public void initialize(ConstraintDescriptor<ParameterScriptAssert> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		ParameterScriptAssert constraintAnnotation = constraintDescriptor.getAnnotation();
 		validateParameters( constraintAnnotation );
+
 		this.languageName = constraintAnnotation.lang();
 		this.script = constraintAnnotation.script();
 		this.escapedScript = InterpolationHelper.escapeMessageParameter( constraintAnnotation.script() );
+
+		initializeScriptContext( initializationContext );
 	}
 
 	@Override
@@ -51,7 +57,7 @@ public class ParameterScriptAssertValidator extends AbstractScriptAssertValidato
 
 		Map<String, Object> bindings = getBindings( arguments, parameterNames );
 
-		return getScriptAssertContext( constraintValidatorContext ).evaluateScriptAssertExpression( bindings );
+		return scriptAssertContext.evaluateScriptAssertExpression( bindings );
 	}
 
 	private Map<String, Object> getBindings(Object[] arguments, List<String> parameterNames) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/ScriptAssertValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/ScriptAssertValidator.java
@@ -9,9 +9,11 @@ package org.hibernate.validator.internal.constraintvalidators.hv;
 import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
 
 import javax.validation.ConstraintValidatorContext;
+import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraints.ScriptAssert;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.messageinterpolation.util.InterpolationHelper;
 import org.hibernate.validator.internal.util.Contracts;
 
@@ -32,7 +34,8 @@ public class ScriptAssertValidator extends AbstractScriptAssertValidator<ScriptA
 	private String message;
 
 	@Override
-	public void initialize(ScriptAssert constraintAnnotation) {
+	public void initialize(ConstraintDescriptor<ScriptAssert> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		ScriptAssert constraintAnnotation = constraintDescriptor.getAnnotation();
 		validateParameters( constraintAnnotation );
 
 		this.alias = constraintAnnotation.alias();
@@ -41,6 +44,8 @@ public class ScriptAssertValidator extends AbstractScriptAssertValidator<ScriptA
 		this.languageName = constraintAnnotation.lang();
 		this.script = constraintAnnotation.script();
 		this.escapedScript = InterpolationHelper.escapeMessageParameter( constraintAnnotation.script() );
+
+		initializeScriptContext( initializationContext );
 	}
 
 	@Override
@@ -49,7 +54,7 @@ public class ScriptAssertValidator extends AbstractScriptAssertValidator<ScriptA
 			constraintValidatorContext.unwrap( HibernateConstraintValidatorContext.class ).addMessageParameter( "script", escapedScript );
 		}
 
-		boolean validationResult = getScriptAssertContext( constraintValidatorContext ).evaluateScriptAssertExpression( value, alias );
+		boolean validationResult = scriptAssertContext.evaluateScriptAssertExpression( value, alias );
 
 		if ( !validationResult && !reportOn.isEmpty() ) {
 			constraintValidatorContext.disableDefaultConstraintViolation();

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +101,7 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 	private final MethodValidationConfiguration.Builder methodValidationConfigurationBuilder = new MethodValidationConfiguration.Builder();
 	private boolean traversableResolverResultCacheEnabled = true;
 	private ScriptEvaluatorFactory scriptEvaluatorFactory;
+	private Duration clockSkewTolerance;
 
 	public ConfigurationImpl(BootstrapState state) {
 		this();
@@ -275,6 +277,14 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 		return this;
 	}
 
+	@Override
+	public HibernateValidatorConfiguration clockSkewTolerance(Duration clockSkewTolerance) {
+		Contracts.assertNotNull( clockSkewTolerance, MESSAGES.parameterMustNotBeNull( "clockSkewTolerance" ) );
+
+		this.clockSkewTolerance = clockSkewTolerance;
+		return this;
+	}
+
 	public boolean isAllowParallelMethodsDefineParameterConstraints() {
 		return this.methodValidationConfigurationBuilder.isAllowParallelMethodsDefineParameterConstraints();
 	}
@@ -421,6 +431,10 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 
 	public ScriptEvaluatorFactory getScriptEvaluatorFactory() {
 		return scriptEvaluatorFactory;
+	}
+
+	public Duration getClockSkewTolerance() {
+		return clockSkewTolerance;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
@@ -10,6 +10,7 @@ import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Executable;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -131,6 +132,12 @@ public class ValidationContext<T> {
 	private final ClockProvider clockProvider;
 
 	/**
+	 * Defines allowed margin of error when comparing date/time during validation of {@code @Future} or {@code @Past}
+	 * constraints.
+	 */
+	private final Duration clockSkewTolerance;
+
+	/**
 	 * Script evaluator factory which should be used in this context.
 	 */
 	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
@@ -153,6 +160,7 @@ public class ValidationContext<T> {
 			ClockProvider clockProvider,
 			ScriptEvaluatorFactory scriptEvaluatorFactory,
 			boolean failFast,
+			Duration clockSkewTolerance,
 			T rootBean,
 			Class<T> rootBeanClass,
 			BeanMetaData<T> rootBeanMetaData,
@@ -167,6 +175,7 @@ public class ValidationContext<T> {
 		this.clockProvider = clockProvider;
 		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
 		this.failFast = failFast;
+		this.clockSkewTolerance = clockSkewTolerance;
 
 		this.rootBean = rootBean;
 		this.rootBeanClass = rootBeanClass;
@@ -188,7 +197,8 @@ public class ValidationContext<T> {
 			TraversableResolver traversableResolver,
 			ClockProvider clockProvider,
 			ScriptEvaluatorFactory scriptEvaluatorFactory,
-			boolean failFast) {
+			boolean failFast,
+			Duration clockSkewTolerance) {
 
 		return new ValidationContextBuilder(
 				beanMetaDataManager,
@@ -198,7 +208,8 @@ public class ValidationContext<T> {
 				traversableResolver,
 				clockProvider,
 				scriptEvaluatorFactory,
-				failFast
+				failFast,
+				clockSkewTolerance
 		);
 	}
 
@@ -251,6 +262,10 @@ public class ValidationContext<T> {
 
 	public ScriptEvaluatorFactory getScriptEvaluatorFactory() {
 		return scriptEvaluatorFactory;
+	}
+
+	public Duration getClockSkewTolerance() {
+		return clockSkewTolerance;
 	}
 
 	public Set<ConstraintViolation<T>> createConstraintViolations(ValueContext<?, ?> localContext,
@@ -465,6 +480,7 @@ public class ValidationContext<T> {
 		private final ClockProvider clockProvider;
 		private final ScriptEvaluatorFactory scriptEvaluatorFactory;
 		private final boolean failFast;
+		private final Duration clockSkewTolerance;
 
 		private ValidationContextBuilder(
 				BeanMetaDataManager beanMetaDataManager,
@@ -474,7 +490,8 @@ public class ValidationContext<T> {
 				TraversableResolver traversableResolver,
 				ClockProvider clockProvider,
 				ScriptEvaluatorFactory scriptEvaluatorFactory,
-				boolean failFast) {
+				boolean failFast,
+				Duration clockSkewTolerance) {
 			this.beanMetaDataManager = beanMetaDataManager;
 			this.constraintValidatorManager = constraintValidatorManager;
 			this.messageInterpolator = messageInterpolator;
@@ -483,6 +500,7 @@ public class ValidationContext<T> {
 			this.clockProvider = clockProvider;
 			this.scriptEvaluatorFactory = scriptEvaluatorFactory;
 			this.failFast = failFast;
+			this.clockSkewTolerance = clockSkewTolerance;
 		}
 
 		public <T> ValidationContext<T> forValidate(T rootBean) {
@@ -497,6 +515,7 @@ public class ValidationContext<T> {
 					clockProvider,
 					scriptEvaluatorFactory,
 					failFast,
+					clockSkewTolerance,
 					rootBean,
 					rootBeanClass,
 					beanMetaDataManager.getBeanMetaData( rootBeanClass ),
@@ -518,6 +537,7 @@ public class ValidationContext<T> {
 					clockProvider,
 					scriptEvaluatorFactory,
 					failFast,
+					clockSkewTolerance,
 					rootBean,
 					rootBeanClass,
 					beanMetaDataManager.getBeanMetaData( rootBeanClass ),
@@ -537,6 +557,7 @@ public class ValidationContext<T> {
 					clockProvider,
 					scriptEvaluatorFactory,
 					failFast,
+					clockSkewTolerance,
 					null,
 					rootBeanClass, //root bean
 					beanMetaDataManager.getBeanMetaData( rootBeanClass ),
@@ -562,6 +583,7 @@ public class ValidationContext<T> {
 					clockProvider,
 					scriptEvaluatorFactory,
 					failFast,
+					clockSkewTolerance,
 					rootBean,
 					rootBeanClass,
 					beanMetaDataManager.getBeanMetaData( rootBeanClass ),
@@ -586,6 +608,7 @@ public class ValidationContext<T> {
 					clockProvider,
 					scriptEvaluatorFactory,
 					failFast,
+					clockSkewTolerance,
 					rootBean,
 					rootBeanClass,
 					beanMetaDataManager.getBeanMetaData( rootBeanClass ),

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,6 +46,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 	private ExecutableParameterNameProvider parameterNameProvider;
 	private ClockProvider clockProvider;
 	private ScriptEvaluatorFactory scriptEvaluatorFactory;
+	private Duration clockSkewTolerance;
 	private boolean failFast;
 	private boolean traversableResolverResultCacheEnabled;
 	private final ValueExtractorManager valueExtractorManager;
@@ -59,6 +61,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 		this.parameterNameProvider = validatorFactory.getExecutableParameterNameProvider();
 		this.clockProvider = validatorFactory.getClockProvider();
 		this.scriptEvaluatorFactory = validatorFactory.getScriptEvaluatorFactory();
+		this.clockSkewTolerance = validatorFactory.getClockSkewTolerance();
 		this.failFast = validatorFactory.isFailFast();
 		this.traversableResolverResultCacheEnabled = validatorFactory.isTraversableResolverResultCacheEnabled();
 		this.methodValidationConfigurationBuilder = new MethodValidationConfiguration.Builder( validatorFactory.getMethodValidationConfiguration() );
@@ -173,6 +176,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 				clockProvider,
 				scriptEvaluatorFactory,
 				failFast,
+				clockSkewTolerance,
 				valueExtractorDescriptors.isEmpty() ? valueExtractorManager : new ValueExtractorManager( valueExtractorManager, valueExtractorDescriptors ),
 				methodValidationConfigurationBuilder.build(),
 				traversableResolverResultCacheEnabled

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -13,6 +13,7 @@ import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +93,12 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 	 * Provider for the current time when validating {@code @Future} or {@code @Past}
 	 */
 	private final ClockProvider clockProvider;
+
+	/**
+	 * Defines allowed margin of error when comparing date/time during validation of {@code @Future} or {@code @Past}
+	 * constraints.
+	 */
+	private final Duration clockSkewTolerance;
 
 	/**
 	 * Used to get the {@code ScriptEvaluatorFactory} when validating {@code @ScriptAssert} and
@@ -259,6 +266,8 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 
 		this.scriptEvaluatorFactory = getScriptEvaluatorFactory( configurationState, properties, externalClassLoader );
 
+		this.clockSkewTolerance = getClockSkewTolerance( configurationState, properties );
+
 		if ( LOG.isDebugEnabled() ) {
 			logValidatorFactoryScopedConfiguration( configurationState, this.scriptEvaluatorFactory.getClass() );
 		}
@@ -311,6 +320,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 				clockProvider,
 				scriptEvaluatorFactory,
 				failFast,
+				clockSkewTolerance,
 				valueExtractorManager,
 				methodValidationConfiguration,
 				traversableResolverResultCacheEnabled
@@ -349,6 +359,11 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 	@Override
 	public ScriptEvaluatorFactory getScriptEvaluatorFactory() {
 		return scriptEvaluatorFactory;
+	}
+
+	@Override
+	public Duration getClockSkewTolerance() {
+		return clockSkewTolerance;
 	}
 
 	public boolean isFailFast() {
@@ -398,6 +413,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 			ClockProvider clockProvider,
 			ScriptEvaluatorFactory scriptEvaluatorFactory,
 			boolean failFast,
+			Duration clockSkewTolerance,
 			ValueExtractorManager valueExtractorManager,
 			MethodValidationConfiguration methodValidationConfiguration,
 			boolean traversableResolverResultCacheEnabled) {
@@ -430,7 +446,8 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 				constraintValidatorManager,
 				validationOrderGenerator,
 				failFast,
-				traversableResolverResultCacheEnabled
+				traversableResolverResultCacheEnabled,
+				clockSkewTolerance
 		);
 	}
 
@@ -533,6 +550,30 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		}
 
 		return new DefaultScriptEvaluatorFactory( externalClassLoader );
+	}
+
+	private Duration getClockSkewTolerance(ConfigurationState configurationState, Map<String, String> properties) {
+		if ( configurationState instanceof ConfigurationImpl ) {
+			ConfigurationImpl hibernateSpecificConfig = (ConfigurationImpl) configurationState;
+			if ( hibernateSpecificConfig.getClockSkewTolerance() != null ) {
+				LOG.logClockSkewTolerance( hibernateSpecificConfig.getClockSkewTolerance() );
+				return hibernateSpecificConfig.getClockSkewTolerance();
+			}
+		}
+		String clockSkewToleranceProperty = properties.get( HibernateValidatorConfiguration.CLOCK_SKEW_TOLERANCE );
+		if ( clockSkewToleranceProperty != null ) {
+			try {
+				Duration tolerance = Duration.ofMillis( Long.parseLong( clockSkewToleranceProperty ) );
+				LOG.logClockSkewTolerance(  tolerance ) ;
+				return tolerance;
+			}
+			catch (Exception e) {
+				throw LOG.getUnableToParseClockSkewToleranceException( clockSkewToleranceProperty, e );
+			}
+		}
+
+		LOG.logClockSkewTolerance(  Duration.ZERO  );
+		return Duration.ZERO;
 	}
 
 	private static void registerCustomConstraintValidators(Set<DefaultConstraintMapping> constraintMappings,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -564,7 +564,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		if ( clockSkewToleranceProperty != null ) {
 			try {
 				Duration tolerance = Duration.ofMillis( Long.parseLong( clockSkewToleranceProperty ) );
-				LOG.logClockSkewTolerance(  tolerance ) ;
+				LOG.logClockSkewTolerance( tolerance );
 				return tolerance;
 			}
 			catch (Exception e) {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -14,6 +14,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -141,6 +142,12 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
 
 	/**
+	 * Defines allowed margin of error when comparing date/time during validation of {@code @Future} or {@code @Past}
+	 * constraints.
+	 */
+	private final Duration clockSkewTolerance;
+
+	/**
 	 * Indicates if validation has to be stopped on first constraint violation.
 	 */
 	private final boolean failFast;
@@ -163,7 +170,8 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 			ConstraintValidatorManager constraintValidatorManager,
 			ValidationOrderGenerator validationOrderGenerator,
 			boolean failFast,
-			boolean traversableResolverResultCacheEnabled) {
+			boolean traversableResolverResultCacheEnabled,
+			Duration clockSkewTolerance) {
 		this.constraintValidatorFactory = constraintValidatorFactory;
 		this.messageInterpolator = messageInterpolator;
 		this.traversableResolver = traversableResolver;
@@ -176,6 +184,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		this.validationOrderGenerator = validationOrderGenerator;
 		this.failFast = failFast;
 		this.traversableResolverResultCacheEnabled = traversableResolverResultCacheEnabled;
+		this.clockSkewTolerance = clockSkewTolerance;
 	}
 
 	@Override
@@ -351,7 +360,8 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 				TraversableResolvers.wrapWithCachingForSingleValidation( traversableResolver, traversableResolverResultCacheEnabled ),
 				clockProvider,
 				scriptEvaluatorFactory,
-				failFast
+				failFast,
+				clockSkewTolerance
 		);
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
@@ -33,8 +33,6 @@ import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
-import org.hibernate.validator.spi.scripting.ScriptEvaluator;
-import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
 
 /**
  * @author Hardy Ferentschik
@@ -49,18 +47,16 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 	private Map<String, Object> expressionVariables;
 	private final List<String> methodParameterNames;
 	private final ClockProvider clockProvider;
-	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
 	private final PathImpl basePath;
 	private final ConstraintDescriptor<?> constraintDescriptor;
 	private List<ConstraintViolationCreationContext> constraintViolationCreationContexts;
 	private boolean defaultDisabled;
 	private Object dynamicPayload;
 
-	public ConstraintValidatorContextImpl(List<String> methodParameterNames, ClockProvider clockProvider, ScriptEvaluatorFactory scriptEvaluatorFactory,
+	public ConstraintValidatorContextImpl(List<String> methodParameterNames, ClockProvider clockProvider,
 			PathImpl propertyPath, ConstraintDescriptor<?> constraintDescriptor) {
 		this.methodParameterNames = methodParameterNames;
 		this.clockProvider = clockProvider;
-		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
 		this.basePath = propertyPath;
 		this.constraintDescriptor = constraintDescriptor;
 	}
@@ -126,11 +122,6 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 	public HibernateConstraintValidatorContext withDynamicPayload(Object violationContext) {
 		this.dynamicPayload = violationContext;
 		return this;
-	}
-
-	@Override
-	public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
-		return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
 	}
 
 	public final ConstraintDescriptor<?> getConstraintDescriptor() {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.constraintvalidation;
 
+import java.time.Duration;
+
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.ValidationContext;
 import org.hibernate.validator.spi.scripting.ScriptEvaluator;
@@ -22,16 +24,26 @@ public class HibernateConstraintValidatorInitializationContextImpl implements
 		public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
 			return null;
 		}
+
+		@Override public Duration getClockSkewTolerance() {
+			return null;
+		}
 	};
 
 	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
 
-	private HibernateConstraintValidatorInitializationContextImpl(ScriptEvaluatorFactory scriptEvaluatorFactory) {
+	private final Duration clockSkewTolerance;
+
+	private HibernateConstraintValidatorInitializationContextImpl(ScriptEvaluatorFactory scriptEvaluatorFactory, Duration clockSkewTolerance) {
 		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
+		this.clockSkewTolerance = clockSkewTolerance;
 	}
 
 	public static HibernateConstraintValidatorInitializationContext from(ValidationContext<?> validationContext) {
-		return new HibernateConstraintValidatorInitializationContextImpl( validationContext.getScriptEvaluatorFactory() );
+		return new HibernateConstraintValidatorInitializationContextImpl(
+				validationContext.getScriptEvaluatorFactory(),
+				validationContext.getClockSkewTolerance()
+		);
 	}
 
 	public static HibernateConstraintValidatorInitializationContext dummyContext() {
@@ -41,6 +53,11 @@ public class HibernateConstraintValidatorInitializationContextImpl implements
 	@Override
 	public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
 		return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
+	}
+
+	@Override
+	public Duration getClockSkewTolerance() {
+		return clockSkewTolerance;
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.constraintvalidation;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
+import org.hibernate.validator.internal.engine.ValidationContext;
+import org.hibernate.validator.spi.scripting.ScriptEvaluator;
+import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
+
+/**
+ * @author Marko Bekhta
+ */
+public class HibernateConstraintValidatorInitializationContextImpl implements
+		HibernateConstraintValidatorInitializationContext {
+
+	private static final HibernateConstraintValidatorInitializationContext DUMMY_VALIDATOR_INIT_CONTEXT = new HibernateConstraintValidatorInitializationContext() {
+		@Override
+		public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
+			return null;
+		}
+	};
+
+	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
+
+	private HibernateConstraintValidatorInitializationContextImpl(ScriptEvaluatorFactory scriptEvaluatorFactory) {
+		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
+	}
+
+	public static HibernateConstraintValidatorInitializationContext from(ValidationContext<?> validationContext) {
+		return new HibernateConstraintValidatorInitializationContextImpl( validationContext.getScriptEvaluatorFactory() );
+	}
+
+	public static HibernateConstraintValidatorInitializationContext dummyContext() {
+		return DUMMY_VALIDATOR_INIT_CONTEXT;
+	}
+
+	@Override
+	public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
+		return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -49,6 +50,7 @@ import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.util.logging.formatter.ClassObjectFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.CollectionOfClassesObjectFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.CollectionOfObjectsToStringFormatter;
+import org.hibernate.validator.internal.util.logging.formatter.DurationFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.ExecutableFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.TypeFormatter;
 import org.hibernate.validator.internal.xml.ContainerElementTypePath;
@@ -816,4 +818,11 @@ public interface Log extends BasicLogger {
 	@LogMessage(level = DEBUG)
 	@Message(id = 234, value = "Using %1$s as ValidatorFactory-scoped %2$s.")
 	void logValidatorFactoryScopedConfiguration(@FormatWith(ClassObjectFormatter.class) Class<?> configuredClass, String configuredElement);
+
+	@LogMessage(level = INFO)
+	@Message(id = 235, value = "Compare operations for date/time constraints will accept tolerance of %1$s")
+	void logClockSkewTolerance(@FormatWith(DurationFormatter.class) Duration tolerance);
+
+	@Message(id = 236, value = "Unable to parse clock skew tolerance property %s. It should be a duration represented in milliseconds.")
+	ValidationException getUnableToParseClockSkewToleranceException(String toleranceProperty, @Cause Exception e);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/formatter/DurationFormatter.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/formatter/DurationFormatter.java
@@ -1,0 +1,32 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.util.logging.formatter;
+
+import java.time.Duration;
+
+/**
+ * Used with JBoss Logging to display class names in log messages.
+ *
+ * @author Marko Bekhta
+ */
+public class DurationFormatter {
+
+	private final String stringRepresentation;
+
+	public DurationFormatter(Duration duration) {
+		this.stringRepresentation = format( duration );
+	}
+
+	public static String format(Duration duration) {
+		return duration.toString();
+	}
+
+	@Override
+	public String toString() {
+		return stringRepresentation;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextImplTest.java
@@ -226,7 +226,7 @@ public class ConstraintValidatorContextImplTest {
 		PathImpl path = PathImpl.createRootPath();
 		path.addBeanNode();
 
-		ConstraintValidatorContextImpl context = new ConstraintValidatorContextImpl( null, null, null, path, null );
+		ConstraintValidatorContextImpl context = new ConstraintValidatorContextImpl( null, null, path, null );
 		context.disableDefaultConstraintViolation();
 		return context;
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/ClockToleranceTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/ClockToleranceTest.java
@@ -1,0 +1,121 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.constraintvalidators.bv.time;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.chrono.HijrahDate;
+import java.time.chrono.JapaneseDate;
+import java.time.chrono.MinguoDate;
+import java.time.chrono.ThaiBuddhistDate;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import javax.validation.Validator;
+import javax.validation.constraints.Future;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class ClockToleranceTest {
+
+	private Validator validator;
+	private Instant now;
+
+	@BeforeMethod
+	public void setUp() throws Exception {
+		now = Instant.now();
+		validator = getConfiguration()
+				.clockSkewTolerance( Duration.ofSeconds( 10 ) )
+				.clockProvider( () -> Clock.fixed( now, ZoneId.systemDefault() ) )
+				.buildValidatorFactory().getValidator();
+	}
+
+	@Test
+	public void testFutureTolerance() throws Exception {
+		FutureDummyEntity entity = new FutureDummyEntity( now.atZone( ZoneId.systemDefault() ).plusSeconds( 5 ) );
+		assertNoViolations( validator.validate( entity ) );
+	}
+
+	private static class FutureDummyEntity {
+
+		@Future
+		private Calendar calendar;
+
+		@Future
+		private Date date;
+
+		@Future
+		private HijrahDate hijrahDate;
+
+		@Future
+		private Instant instant;
+
+		@Future
+		private JapaneseDate japaneseDate;
+
+		@Future
+		private LocalDate localDate;
+
+		@Future
+		private LocalDateTime localDateTime;
+
+		@Future
+		private MinguoDate minguoDate;
+
+		@Future
+		private OffsetDateTime offsetDateTime;
+
+		@Future
+		private ThaiBuddhistDate thaiBuddhistDate;
+
+		@Future
+		private Year year;
+
+		@Future
+		private YearMonth yearMonth;
+
+		@Future
+		private ZonedDateTime zonedDateTime;
+
+		public FutureDummyEntity() {
+		}
+
+		public FutureDummyEntity(ZonedDateTime dateTime) {
+			calendar = GregorianCalendar.from( dateTime );
+			date = calendar.getTime();
+
+			instant = dateTime.toInstant();
+			localDateTime = dateTime.toLocalDateTime();
+
+			hijrahDate = HijrahDate.from( dateTime );
+			japaneseDate = JapaneseDate.from( dateTime );
+			localDate = LocalDate.from( dateTime );
+			minguoDate = MinguoDate.from( dateTime );
+			offsetDateTime = dateTime.toOffsetDateTime();
+			thaiBuddhistDate = ThaiBuddhistDate.from( dateTime );
+			year = Year.from( dateTime );
+			yearMonth = YearMonth.from( dateTime );
+			zonedDateTime = dateTime;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/ScriptAssertValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/ScriptAssertValidatorTest.java
@@ -10,6 +10,7 @@ import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertN
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+import static org.hibernate.validator.testutils.ConstraintValidatorInitializationHelper.initialize;
 import static org.testng.Assert.assertTrue;
 
 import java.time.Instant;
@@ -23,6 +24,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
 import org.hibernate.validator.constraints.ScriptAssert;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
 import org.hibernate.validator.internal.constraintvalidators.hv.ScriptAssertValidator;
 import org.hibernate.validator.internal.util.annotation.AnnotationDescriptor;
 import org.hibernate.validator.test.constraints.annotations.AbstractConstrainedTest;
@@ -203,8 +205,8 @@ public class ScriptAssertValidatorTest extends AbstractConstrainedTest {
 	 */
 	private ConstraintValidator<ScriptAssert, Object> getInitializedValidator(String lang, String script, String alias, String reportOn) {
 
-		ConstraintValidator<ScriptAssert, Object> validator = new ScriptAssertValidator();
-		validator.initialize( getScriptAssert( lang, script, alias, reportOn ) );
+		HibernateConstraintValidator<ScriptAssert, Object> validator = new ScriptAssertValidator();
+		initialize( validator, getScriptAssert( lang, script, alias, reportOn ) );
 
 		return validator;
 	}
@@ -217,7 +219,7 @@ public class ScriptAssertValidatorTest extends AbstractConstrainedTest {
 	 *
 	 * @return a {@link ScriptAssert} initialized with the given values.
 	 */
-	private ScriptAssert getScriptAssert(String lang, String script, String alias, String reportOn) {
+	private AnnotationDescriptor<ScriptAssert> getScriptAssert(String lang, String script, String alias, String reportOn) {
 		AnnotationDescriptor.Builder<ScriptAssert> descriptorBuilder = new AnnotationDescriptor.Builder<>( ScriptAssert.class );
 
 		descriptorBuilder.setAttribute( "lang", lang );
@@ -229,7 +231,7 @@ public class ScriptAssertValidatorTest extends AbstractConstrainedTest {
 			descriptorBuilder.setAttribute( "reportOn", reportOn );
 		}
 
-		return descriptorBuilder.build().getAnnotation();
+		return descriptorBuilder.build();
 	}
 
 	/**

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlMappingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlMappingTest.java
@@ -249,6 +249,25 @@ public class XmlMappingTest {
 	}
 
 	@Test
+	@TestForIssue( jiraKey = "HV-1463")
+	public void testClockSkewToleranceConfiguration() {
+		validationXmlTestHelper.runWithCustomValidationXml(
+				"clock-skew-tolerance-duration-validation.xml", () -> {
+					//given
+					BootstrapConfiguration bootstrapConfiguration = ValidatorUtil.getConfiguration()
+							.getBootstrapConfiguration();
+
+					//then
+					assertEquals(
+							bootstrapConfiguration.getProperties().get( HibernateValidatorConfiguration.CLOCK_SKEW_TOLERANCE ),
+							"123456"
+					);
+
+				}
+		);
+	}
+
+	@Test
 	@TestForIssue(jiraKey = "HV-707")
 	public void shouldReturnDefaultExecutableTypesForValidationXmlWithoutTypesGiven() {
 		validationXmlTestHelper.runWithCustomValidationXml(

--- a/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
+++ b/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
@@ -1,0 +1,59 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.testutils;
+
+import java.lang.annotation.Annotation;
+
+import javax.validation.metadata.ConstraintDescriptor;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
+import org.hibernate.validator.internal.engine.ValidationContext;
+import org.hibernate.validator.internal.engine.constraintvalidation.HibernateConstraintValidatorInitializationContextImpl;
+import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
+import org.hibernate.validator.internal.util.annotation.AnnotationDescriptor;
+
+/**
+ * @author Marko Bekhta
+ */
+public class ConstraintValidatorInitializationHelper {
+
+	private static final ConstraintHelper CONSTRAINT_HELPER = new ConstraintHelper();
+
+	private ConstraintValidatorInitializationHelper() {
+	}
+
+	public static <T extends Annotation> ConstraintDescriptor<T> descriptorFrom(AnnotationDescriptor<T> annotationDescriptor) {
+		return new ConstraintDescriptorImpl<>(
+				CONSTRAINT_HELPER,
+				null,
+				annotationDescriptor,
+				null
+		);
+	}
+
+	public static HibernateConstraintValidatorInitializationContext initializationContext(ValidationContext<?> validationContext) {
+		return HibernateConstraintValidatorInitializationContextImpl.from( validationContext );
+	}
+
+	public static <A extends Annotation, T> void initialize(
+			HibernateConstraintValidator<A, T> constraintValidator,
+			AnnotationDescriptor<A> annotationDescriptor
+	) {
+		initialize( constraintValidator, annotationDescriptor, HibernateConstraintValidatorInitializationContextImpl.dummyContext() );
+	}
+
+	public static <A extends Annotation, T> void initialize(
+			HibernateConstraintValidator<A, T> constraintValidator,
+			AnnotationDescriptor<A> annotationDescriptor,
+			HibernateConstraintValidatorInitializationContext initializationContext
+	) {
+		constraintValidator.initialize( descriptorFrom( annotationDescriptor ), initializationContext );
+	}
+
+}

--- a/engine/src/test/java/org/hibernate/validator/testutils/ValidatorUtil.java
+++ b/engine/src/test/java/org/hibernate/validator/testutils/ValidatorUtil.java
@@ -28,7 +28,6 @@ import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.internal.engine.DefaultClockProvider;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
-import org.hibernate.validator.internal.engine.scripting.DefaultScriptEvaluatorFactory;
 import org.hibernate.validator.testutil.DummyTraversableResolver;
 import org.hibernate.validator.testutil.ValidationInvocationHandler;
 
@@ -236,6 +235,6 @@ public final class ValidatorUtil {
 	}
 
 	public static HibernateConstraintValidatorContext getConstraintValidatorContext() {
-		return new ConstraintValidatorContextImpl( null, DefaultClockProvider.INSTANCE, new DefaultScriptEvaluatorFactory( null ), null, null );
+		return new ConstraintValidatorContextImpl( null, DefaultClockProvider.INSTANCE, null, null );
 	}
 }

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/clock-skew-tolerance-duration-validation.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/clock-skew-tolerance-duration-validation.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<validation-config
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/configuration"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/configuration
+            http://xmlns.jcp.org/xml/ns/validation/configuration/validation-configuration-2.0.xsd"
+        version="2.0">
+
+    <property name="hibernate.validator.clock_skew_tolerance">123456</property>
+</validation-config>


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1493

I took slightly different approach than @gunnarmorling  was suggesting in comments to https://hibernate.atlassian.net/browse/BVAL-700. It fits the current flows without changes, so that's why I'm thinking that it might work. 

@gunnarmorling @gsmet what do you think about it in general?

With some additional changes we would be able to reuse abstract validators for BV time constraints and for this new one. Though we would to have a list of implementations for all types for both BV and this new constraint...
