### PR TITLE
HV-1494 Hibernate Validator specific @NotEmpty used on return type throws an exception

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/constraints/NotEmpty.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/NotEmpty.java
@@ -24,6 +24,8 @@ import javax.validation.Payload;
 import javax.validation.ReportAsSingleViolation;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
 
 import org.hibernate.validator.constraints.NotEmpty.List;
 
@@ -37,6 +39,7 @@ import org.hibernate.validator.constraints.NotEmpty.List;
  */
 @Documented
 @Constraint(validatedBy = { })
+@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
 @Repeatable(List.class)

--- a/engine/src/main/java/org/hibernate/validator/constraints/Range.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/Range.java
@@ -25,6 +25,8 @@ import javax.validation.Payload;
 import javax.validation.ReportAsSingleViolation;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
 
 import org.hibernate.validator.constraints.Range.List;
 
@@ -36,6 +38,7 @@ import org.hibernate.validator.constraints.Range.List;
  */
 @Documented
 @Constraint(validatedBy = { })
+@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
 @Repeatable(List.class)

--- a/engine/src/main/java/org/hibernate/validator/constraints/br/TituloEleitoral.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/br/TituloEleitoral.java
@@ -23,6 +23,8 @@ import javax.validation.Constraint;
 import javax.validation.Payload;
 import javax.validation.ReportAsSingleViolation;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
 
 import org.hibernate.validator.constraints.Mod11Check;
 import org.hibernate.validator.constraints.br.TituloEleitoral.List;
@@ -45,6 +47,7 @@ import org.hibernate.validator.constraints.br.TituloEleitoral.List;
 @ReportAsSingleViolation
 @Documented
 @Constraint(validatedBy = { })
+@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
 @Repeatable(List.class)

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/CustomCompositeConstrainedTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/CustomCompositeConstrainedTest.java
@@ -1,0 +1,170 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.methodvalidation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Set;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintViolation;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import javax.validation.constraintvalidation.SupportedValidationTarget;
+import javax.validation.constraintvalidation.ValidationTarget;
+
+import org.hibernate.validator.constraints.NotEmpty;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ValidatorUtil;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+@SuppressWarnings("deprecation")
+public class CustomCompositeConstrainedTest {
+	private Validator validator;
+	private Foo foo;
+
+	@BeforeMethod
+	public void setUp() throws Exception {
+		validator = ValidatorUtil.getValidator();
+		foo = new Foo( "" );
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HV-1494")
+	public void testNotEmptyInvalid() throws Exception {
+		Set<ConstraintViolation<Foo>> violations = validator.forExecutables()
+				.validateReturnValue(
+						foo,
+						Foo.class.getDeclaredMethod( "createBarString", String.class ),
+						""
+				);
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotEmpty.class )
+		);
+
+		violations = validator.forExecutables()
+				.validateReturnValue(
+						foo,
+						Foo.class.getDeclaredMethod( "createBarString", String.class ),
+						" "
+				);
+		assertNoViolations( violations );
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HV-1494")
+	public void testCustomComposingConstraintReturnValues() throws Exception {
+		Set<ConstraintViolation<Foo>> violations = validator.forExecutables()
+				.validateReturnValue(
+						foo,
+						Foo.class.getDeclaredMethod( "createCustomBarString", String.class ),
+						"a"
+				);
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( CustomCompositeConstraint.class )
+						.withPropertyPath( pathWith()
+							   .method( "createCustomBarString" )
+							   .returnValue()
+						)
+		);
+
+		violations = validator.forExecutables()
+				.validateReturnValue(
+						foo,
+						Foo.class.getDeclaredMethod( "createCustomBarString", String.class ),
+						"1"
+				);
+		assertNoViolations( violations );
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HV-1494")
+	public void testCustomComposingConstraintParameters() throws Exception {
+		Set<ConstraintViolation<Foo>> violations = validator.forExecutables()
+				.validateParameters(
+						foo,
+						Foo.class.getDeclaredMethod( "createCustomBarString", String.class ),
+						new String[] { "abc" }
+				);
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( CustomCompositeConstraint.class )
+						.withPropertyPath( pathWith()
+							   .method( "createCustomBarString" )
+							   .parameter( "a", 0 )
+						)
+		);
+
+		violations = validator.forExecutables()
+				.validateParameters(
+						foo,
+						Foo.class.getDeclaredMethod( "createCustomBarString", String.class ),
+						new String[] { "1" }
+				);
+		assertNoViolations( violations );
+	}
+
+	private static class Foo {
+
+		private String bar;
+
+		public Foo(String bar) {
+			this.bar = bar;
+		}
+
+		@NotEmpty
+		public String createBarString(String a) {
+			return bar;
+		}
+
+		@CustomCompositeConstraint
+		public String createCustomBarString(@CustomCompositeConstraint String a) {
+			return bar;
+		}
+	}
+
+
+	@Documented
+	@Constraint(validatedBy = { })
+	@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
+	@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+	@Retention(RUNTIME)
+	@ReportAsSingleViolation
+	@NotNull
+	@Size(min = 1)
+	@Pattern(regexp = "\\d*")
+	public @interface CustomCompositeConstraint {
+		String message() default "no message";
+
+		Class<?>[] groups() default { };
+
+		Class<? extends Payload>[] payload() default { };
+
+	}
+
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1494

I found that only `NotEmpty` `Range` and `TituloEleitoral` were the composite constraints without validators. So I've added `SupportedValidationTarget` for them.