### PR TITLE
HV-1373 Validator calls objects hashCode() after failed @NotNull validation

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConstraintViolationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConstraintViolationImpl.java
@@ -327,9 +327,9 @@ public class ConstraintViolationImpl<T> implements HibernateConstraintViolation<
 	private int createHashCode() {
 		int result = interpolatedMessage != null ? interpolatedMessage.hashCode() : 0;
 		result = 31 * result + ( propertyPath != null ? propertyPath.hashCode() : 0 );
-		result = 31 * result + ( rootBean != null ? rootBean.hashCode() : 0 );
-		result = 31 * result + ( leafBeanInstance != null ? leafBeanInstance.hashCode() : 0 );
-		result = 31 * result + ( value != null ? value.hashCode() : 0 );
+		result = 31 * result + System.identityHashCode( rootBean );
+		result = 31 * result + System.identityHashCode( leafBeanInstance );
+		result = 31 * result + System.identityHashCode( value );
 		result = 31 * result + ( constraintDescriptor != null ? constraintDescriptor.hashCode() : 0 );
 		result = 31 * result + ( messageTemplate != null ? messageTemplate.hashCode() : 0 );
 		result = 31 * result + ( rootBeanClass != null ? rootBeanClass.hashCode() : 0 );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/ConstraintViolationImplIdentityTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/ConstraintViolationImplIdentityTest.java
@@ -9,14 +9,19 @@ package org.hibernate.validator.test.internal.engine;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 
+import java.util.ArrayList;
 import java.util.Set;
+
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.hibernate.validator.testutil.TestForIssue;
+
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -45,9 +50,70 @@ public class ConstraintViolationImplIdentityTest {
 		);
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HV-1373")
+	public void testHashCodeOfBeanInstanceIsNotCalled() throws Exception {
+		Set<ConstraintViolation<Bar>> violations = validator.validate( new Bar( null ) );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1373")
+	public void testHashCodeOfBeanInstanceValuesIsNotCalled() throws Exception {
+		Set<ConstraintViolation<FooBar>> violations = validator.validate( new FooBar( new FooList() ) );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotEmpty.class )
+		);
+	}
+
 	private static class Foo {
 		@Size(min = 2, message = "must be 2 at least")
 		@DecimalMin(value = "2", message = "must be 2 at least")
 		String name = "1";
 	}
+
+	private static class Bar {
+		@NotNull
+		private final String property;
+
+		private Bar(String property) {
+			this.property = property;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			return super.equals( o );
+		}
+
+		@Override
+		public int hashCode() {
+			throw new IllegalStateException( "Bean's hash code shouldn't be called" );
+		}
+	}
+
+	private class FooBar {
+
+		@NotEmpty
+		private final FooList list;
+
+		private FooBar(FooList list) {
+			this.list = list;
+		}
+	}
+
+	private static class FooList extends ArrayList<String> {
+
+		@Override
+		public boolean equals(Object o) {
+			return super.equals( o );
+		}
+
+		@Override
+		public int hashCode() {
+			throw new IllegalStateException( "Bean's value hash code shouldn't be called" );
+		}
+	}
+
 }


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1373

It turned out that those 3 `*.hashcode()`calls were potentially dangerous as any of them could throw an exception - so I replaced all of them with `System#identityHashCode()`