### PR TITLE
HV-1497 Extend the ConstraintValidator#initialize() contract

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidator.java
@@ -30,8 +30,8 @@ public interface HibernateConstraintValidator<A extends Annotation, T> extends C
 	 * except annotation is needed to initialize a validator.
 	 * Note, when using {@link HibernateConstraintValidator} user should only override one of the methods, either
 	 * {@link #initialize(Annotation)} or {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)}.
-	 * It is guaranteed that in a case of the {@link HibernateConstraintValidator}, only the
-	 * {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)} will be called during initialization.
+	 * It is guaranteed that in the case of a {@link HibernateConstraintValidator}, only
+	 * {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)} is called during initialization.
 	 *
 	 * @param constraintDescriptor a constraint descriptor for a given constraint declaration
 	 * @param initializationContext an initialization context for a current {@link ConstraintValidatorFactory}

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidator.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.constraintvalidation;
+
+import java.lang.annotation.Annotation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintValidatorFactory;
+import javax.validation.metadata.ConstraintDescriptor;
+
+import org.hibernate.validator.Incubating;
+
+/**
+ * Hibernate Validator specific extension to the {@link ConstraintValidator} contract.
+ *
+ * @author Marko Bekhta
+ * @since 6.0.5
+ */
+@Incubating
+public interface HibernateConstraintValidator<A extends Annotation, T> extends ConstraintValidator<A, T> {
+
+	/**
+	 * Initializes the validator in preparation for {@link #isValid(Object, ConstraintValidatorContext)} calls.
+	 * It is an alternative to {@link #initialize(Annotation)} method. Should be used if any additional information
+	 * except annotation is needed to initialize a validator.
+	 * Note, when using {@link HibernateConstraintValidator} user should only override one of the methods, either
+	 * {@link #initialize(Annotation)} or {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)}.
+	 * It is guaranteed that in a case of the {@link HibernateConstraintValidator}, only the
+	 * {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)} will be called during initialization.
+	 *
+	 * @param constraintDescriptor a constraint descriptor for a given constraint declaration
+	 * @param initializationContext an initialization context for a current {@link ConstraintValidatorFactory}
+	 */
+	default void initialize(ConstraintDescriptor<A> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		initialize( constraintDescriptor.getAnnotation() );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorContext.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorContext.java
@@ -8,11 +8,6 @@ package org.hibernate.validator.constraintvalidation;
 
 import javax.validation.ConstraintValidatorContext;
 
-import org.hibernate.validator.Incubating;
-import org.hibernate.validator.spi.scripting.ScriptEvaluator;
-import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
-import org.hibernate.validator.spi.scripting.ScriptEvaluatorNotFoundException;
-
 /**
  * A custom {@link ConstraintValidatorContext} which allows to set additional message parameters for
  * interpolation.
@@ -112,19 +107,4 @@ public interface HibernateConstraintValidatorContext extends ConstraintValidator
 	 */
 	HibernateConstraintValidatorContext withDynamicPayload(Object payload);
 
-	/**
-	 * Returns a {@link ScriptEvaluator} created based on the {@link ScriptEvaluatorFactory}
-	 * passed at bootstrap.
-	 *
-	 * @param languageName the name of the scripting language
-	 *
-	 * @return a script executor for the given language. Never null.
-	 *
-	 * @throws ScriptEvaluatorNotFoundException in case no {@link ScriptEvaluator} was
-	 * found for a given {@code languageName}
-	 *
-	 * @since 6.0.3
-	 */
-	@Incubating
-	ScriptEvaluator getScriptEvaluatorForLanguage(String languageName);
 }

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
@@ -26,7 +26,7 @@ public interface HibernateConstraintValidatorInitializationContext {
 	 *
 	 * @param languageName the name of the scripting language
 	 *
-	 * @return a script executor for the given language. Never null.
+	 * @return a script evaluator for the given language. Never null.
 	 *
 	 * @throws ScriptEvaluatorNotFoundException in case no {@link ScriptEvaluator} was
 	 * found for a given {@code languageName}

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
@@ -1,0 +1,35 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.constraintvalidation;
+
+import org.hibernate.validator.Incubating;
+import org.hibernate.validator.spi.scripting.ScriptEvaluator;
+import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
+import org.hibernate.validator.spi.scripting.ScriptEvaluatorNotFoundException;
+
+/**
+ * Provides contextual data and operations when initializing a constraint validator.
+ *
+ * @author Marko Bekhta
+ * @since 6.0.5
+ */
+@Incubating
+public interface HibernateConstraintValidatorInitializationContext {
+
+	/**
+	 * Returns a {@link ScriptEvaluator} created by the {@link ScriptEvaluatorFactory}
+	 * passed at bootstrap.
+	 *
+	 * @param languageName the name of the scripting language
+	 *
+	 * @return a script executor for the given language. Never null.
+	 *
+	 * @throws ScriptEvaluatorNotFoundException in case no {@link ScriptEvaluator} was
+	 * found for a given {@code languageName}
+	 */
+	ScriptEvaluator getScriptEvaluatorForLanguage(String languageName);
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/AbstractScriptAssertValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/AbstractScriptAssertValidator.java
@@ -29,9 +29,7 @@ public abstract class AbstractScriptAssertValidator<A extends Annotation, T> imp
 	protected String escapedScript;
 	protected ScriptAssertContext scriptAssertContext;
 
-	protected void initialize(
-			String languageName, String script,
-			HibernateConstraintValidatorInitializationContext initializationContext) {
+	protected void initialize(String languageName, String script, HibernateConstraintValidatorInitializationContext initializationContext) {
 		this.script = script;
 		this.languageName = languageName;
 		this.escapedScript = InterpolationHelper.escapeMessageParameter( script );

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/ParameterScriptAssertValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/ParameterScriptAssertValidator.java
@@ -15,11 +15,12 @@ import java.util.Map;
 import javax.validation.ConstraintValidatorContext;
 import javax.validation.constraintvalidation.SupportedValidationTarget;
 import javax.validation.constraintvalidation.ValidationTarget;
+import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraints.ParameterScriptAssert;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
-import org.hibernate.validator.internal.engine.messageinterpolation.util.InterpolationHelper;
 import org.hibernate.validator.internal.util.Contracts;
 
 /**
@@ -33,11 +34,10 @@ import org.hibernate.validator.internal.util.Contracts;
 public class ParameterScriptAssertValidator extends AbstractScriptAssertValidator<ParameterScriptAssert, Object[]> {
 
 	@Override
-	public void initialize(ParameterScriptAssert constraintAnnotation) {
+	public void initialize(ConstraintDescriptor<ParameterScriptAssert> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		ParameterScriptAssert constraintAnnotation = constraintDescriptor.getAnnotation();
 		validateParameters( constraintAnnotation );
-		this.languageName = constraintAnnotation.lang();
-		this.script = constraintAnnotation.script();
-		this.escapedScript = InterpolationHelper.escapeMessageParameter( constraintAnnotation.script() );
+		initialize( constraintAnnotation.lang(), constraintAnnotation.script(), initializationContext );
 	}
 
 	@Override
@@ -51,7 +51,7 @@ public class ParameterScriptAssertValidator extends AbstractScriptAssertValidato
 
 		Map<String, Object> bindings = getBindings( arguments, parameterNames );
 
-		return getScriptAssertContext( constraintValidatorContext ).evaluateScriptAssertExpression( bindings );
+		return scriptAssertContext.evaluateScriptAssertExpression( bindings );
 	}
 
 	private Map<String, Object> getBindings(Object[] arguments, List<String> parameterNames) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/ScriptAssertValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/ScriptAssertValidator.java
@@ -9,10 +9,11 @@ package org.hibernate.validator.internal.constraintvalidators.hv;
 import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
 
 import javax.validation.ConstraintValidatorContext;
+import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraints.ScriptAssert;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
-import org.hibernate.validator.internal.engine.messageinterpolation.util.InterpolationHelper;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.util.Contracts;
 
 /**
@@ -23,7 +24,6 @@ import org.hibernate.validator.internal.util.Contracts;
  * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Marko Bekhta
  * @author Guillaume Smet
- * @author Marko Bekhta
  */
 public class ScriptAssertValidator extends AbstractScriptAssertValidator<ScriptAssert, Object> {
 
@@ -32,15 +32,14 @@ public class ScriptAssertValidator extends AbstractScriptAssertValidator<ScriptA
 	private String message;
 
 	@Override
-	public void initialize(ScriptAssert constraintAnnotation) {
+	public void initialize(ConstraintDescriptor<ScriptAssert> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		ScriptAssert constraintAnnotation = constraintDescriptor.getAnnotation();
 		validateParameters( constraintAnnotation );
+		initialize( constraintAnnotation.lang(), constraintAnnotation.script(), initializationContext );
 
 		this.alias = constraintAnnotation.alias();
 		this.reportOn = constraintAnnotation.reportOn();
 		this.message = constraintAnnotation.message();
-		this.languageName = constraintAnnotation.lang();
-		this.script = constraintAnnotation.script();
-		this.escapedScript = InterpolationHelper.escapeMessageParameter( constraintAnnotation.script() );
 	}
 
 	@Override
@@ -49,7 +48,7 @@ public class ScriptAssertValidator extends AbstractScriptAssertValidator<ScriptA
 			constraintValidatorContext.unwrap( HibernateConstraintValidatorContext.class ).addMessageParameter( "script", escapedScript );
 		}
 
-		boolean validationResult = getScriptAssertContext( constraintValidatorContext ).evaluateScriptAssertExpression( value, alias );
+		boolean validationResult = scriptAssertContext.evaluateScriptAssertExpression( value, alias );
 
 		if ( !validationResult && !reportOn.isEmpty() ) {
 			constraintValidatorContext.disableDefaultConstraintViolation();

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
@@ -136,7 +136,7 @@ public class ValidationContext<T> {
 	private final boolean failFast;
 
 	/**
-	 * A reference to constraint initialization context stored in {@link ValidatorImpl}
+	 * The constraint validator initialization context.
 	 */
 	private final HibernateConstraintValidatorInitializationContext constraintValidatorInitializationContext;
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
@@ -28,6 +28,7 @@ import javax.validation.TraversableResolver;
 import javax.validation.ValidationException;
 import javax.validation.metadata.ConstraintDescriptor;
 
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintViolationCreationContext;
@@ -38,7 +39,6 @@ import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
-import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
 
 /**
  * Context object keeping track of all required data for a validation call.
@@ -131,14 +131,14 @@ public class ValidationContext<T> {
 	private final ClockProvider clockProvider;
 
 	/**
-	 * Script evaluator factory which should be used in this context.
-	 */
-	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
-
-	/**
 	 * Whether or not validation should fail on the first constraint violation.
 	 */
 	private final boolean failFast;
+
+	/**
+	 * A reference to constraint initialization context stored in {@link ValidatorImpl}
+	 */
+	private final HibernateConstraintValidatorInitializationContext constraintValidatorInitializationContext;
 
 	/**
 	 * The name of the validated (leaf) property in case of a validateProperty()/validateValue() call.
@@ -151,7 +151,7 @@ public class ValidationContext<T> {
 			TraversableResolver traversableResolver,
 			ExecutableParameterNameProvider parameterNameProvider,
 			ClockProvider clockProvider,
-			ScriptEvaluatorFactory scriptEvaluatorFactory,
+			HibernateConstraintValidatorInitializationContext constraintValidatorInitializationContext,
 			boolean failFast,
 			T rootBean,
 			Class<T> rootBeanClass,
@@ -165,7 +165,7 @@ public class ValidationContext<T> {
 		this.traversableResolver = traversableResolver;
 		this.parameterNameProvider = parameterNameProvider;
 		this.clockProvider = clockProvider;
-		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
+		this.constraintValidatorInitializationContext = constraintValidatorInitializationContext;
 		this.failFast = failFast;
 
 		this.rootBean = rootBean;
@@ -187,7 +187,7 @@ public class ValidationContext<T> {
 			ConstraintValidatorFactory constraintValidatorFactory,
 			TraversableResolver traversableResolver,
 			ClockProvider clockProvider,
-			ScriptEvaluatorFactory scriptEvaluatorFactory,
+			HibernateConstraintValidatorInitializationContext constraintValidatorInitializationContext,
 			boolean failFast) {
 
 		return new ValidationContextBuilder(
@@ -197,7 +197,7 @@ public class ValidationContext<T> {
 				constraintValidatorFactory,
 				traversableResolver,
 				clockProvider,
-				scriptEvaluatorFactory,
+				constraintValidatorInitializationContext,
 				failFast
 		);
 	}
@@ -249,8 +249,8 @@ public class ValidationContext<T> {
 		return clockProvider;
 	}
 
-	public ScriptEvaluatorFactory getScriptEvaluatorFactory() {
-		return scriptEvaluatorFactory;
+	public HibernateConstraintValidatorInitializationContext getConstraintValidatorInitializationContext() {
+		return constraintValidatorInitializationContext;
 	}
 
 	public Set<ConstraintViolation<T>> createConstraintViolations(ValueContext<?, ?> localContext,
@@ -463,7 +463,7 @@ public class ValidationContext<T> {
 		private final ConstraintValidatorFactory constraintValidatorFactory;
 		private final TraversableResolver traversableResolver;
 		private final ClockProvider clockProvider;
-		private final ScriptEvaluatorFactory scriptEvaluatorFactory;
+		private final HibernateConstraintValidatorInitializationContext constraintValidatorInitializationContext;
 		private final boolean failFast;
 
 		private ValidationContextBuilder(
@@ -473,7 +473,7 @@ public class ValidationContext<T> {
 				ConstraintValidatorFactory constraintValidatorFactory,
 				TraversableResolver traversableResolver,
 				ClockProvider clockProvider,
-				ScriptEvaluatorFactory scriptEvaluatorFactory,
+				HibernateConstraintValidatorInitializationContext constraintValidatorInitializationContext,
 				boolean failFast) {
 			this.beanMetaDataManager = beanMetaDataManager;
 			this.constraintValidatorManager = constraintValidatorManager;
@@ -481,7 +481,7 @@ public class ValidationContext<T> {
 			this.constraintValidatorFactory = constraintValidatorFactory;
 			this.traversableResolver = traversableResolver;
 			this.clockProvider = clockProvider;
-			this.scriptEvaluatorFactory = scriptEvaluatorFactory;
+			this.constraintValidatorInitializationContext = constraintValidatorInitializationContext;
 			this.failFast = failFast;
 		}
 
@@ -495,7 +495,7 @@ public class ValidationContext<T> {
 					traversableResolver,
 					null, //parameter name provider
 					clockProvider,
-					scriptEvaluatorFactory,
+					constraintValidatorInitializationContext,
 					failFast,
 					rootBean,
 					rootBeanClass,
@@ -516,7 +516,7 @@ public class ValidationContext<T> {
 					traversableResolver,
 					null, //parameter name provider
 					clockProvider,
-					scriptEvaluatorFactory,
+					constraintValidatorInitializationContext,
 					failFast,
 					rootBean,
 					rootBeanClass,
@@ -535,7 +535,7 @@ public class ValidationContext<T> {
 					traversableResolver,
 					null, //parameter name provider
 					clockProvider,
-					scriptEvaluatorFactory,
+					constraintValidatorInitializationContext,
 					failFast,
 					null,
 					rootBeanClass, //root bean
@@ -560,7 +560,7 @@ public class ValidationContext<T> {
 					traversableResolver,
 					parameterNameProvider,
 					clockProvider,
-					scriptEvaluatorFactory,
+					constraintValidatorInitializationContext,
 					failFast,
 					rootBean,
 					rootBeanClass,
@@ -584,7 +584,7 @@ public class ValidationContext<T> {
 					traversableResolver,
 					null, //parameter name provider
 					clockProvider,
-					scriptEvaluatorFactory,
+					constraintValidatorInitializationContext,
 					failFast,
 					rootBean,
 					rootBeanClass,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -137,12 +137,6 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 	private final ClockProvider clockProvider;
 
 	/**
-	 * Used to get the {@code ScriptEvaluatorFactory} when validating {@code @ScriptAssert} and
-	 * {@code @ParameterScriptAssert} constraints.
-	 */
-	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
-
-	/**
 	 * Indicates if validation has to be stopped on first constraint violation.
 	 */
 	private final boolean failFast;
@@ -155,8 +149,8 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 	private final ValueExtractorManager valueExtractorManager;
 
 	/**
-	 * Constraint initialization context is stored at this level to prevent creating it each time when initializing
-	 * a new constraint validator, as for now it only stores {@code ScriptEvaluatorFactory}.
+	 * The constraint initialization context is stored at this level to prevent creating a new instance each time we
+	 * initialize a new constraint validator as, for now, it only contains Validator scoped objects.
 	 */
 	private final HibernateConstraintValidatorInitializationContext constraintValidatorInitializationContext;
 
@@ -178,7 +172,6 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		this.beanMetaDataManager = beanMetaDataManager;
 		this.parameterNameProvider = parameterNameProvider;
 		this.clockProvider = clockProvider;
-		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
 		this.valueExtractorManager = valueExtractorManager;
 		this.constraintValidatorManager = constraintValidatorManager;
 		this.validationOrderGenerator = validationOrderGenerator;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -37,8 +37,10 @@ import javax.validation.groups.Default;
 import javax.validation.metadata.BeanDescriptor;
 import javax.validation.valueextraction.ValueExtractor;
 
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.ValidationContext.ValidationContextBuilder;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
+import org.hibernate.validator.internal.engine.constraintvalidation.HibernateConstraintValidatorInitializationContextImpl;
 import org.hibernate.validator.internal.engine.groups.Group;
 import org.hibernate.validator.internal.engine.groups.GroupWithInheritance;
 import org.hibernate.validator.internal.engine.groups.Sequence;
@@ -152,6 +154,12 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 
 	private final ValueExtractorManager valueExtractorManager;
 
+	/**
+	 * Constraint initialization context is stored at this level to prevent creating it each time when initializing
+	 * a new constraint validator, as for now it only stores {@code ScriptEvaluatorFactory}.
+	 */
+	private final HibernateConstraintValidatorInitializationContext constraintValidatorInitializationContext;
+
 	public ValidatorImpl(ConstraintValidatorFactory constraintValidatorFactory,
 			MessageInterpolator messageInterpolator,
 			TraversableResolver traversableResolver,
@@ -176,6 +184,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		this.validationOrderGenerator = validationOrderGenerator;
 		this.failFast = failFast;
 		this.traversableResolverResultCacheEnabled = traversableResolverResultCacheEnabled;
+		this.constraintValidatorInitializationContext = new HibernateConstraintValidatorInitializationContextImpl( scriptEvaluatorFactory );
 	}
 
 	@Override
@@ -350,7 +359,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 				constraintValidatorFactory,
 				TraversableResolvers.wrapWithCachingForSingleValidation( traversableResolver, traversableResolverResultCacheEnabled ),
 				clockProvider,
-				scriptEvaluatorFactory,
+				constraintValidatorInitializationContext,
 				failFast
 		);
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 
 import javax.validation.ConstraintDeclarationException;
 import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorFactory;
 import javax.validation.ConstraintViolation;
 import javax.validation.ValidationException;
 
@@ -61,7 +60,7 @@ public class ConstraintTree<A extends Annotation> {
 
 	/**
 	 * Either the initialized constraint validator for the default constraint validator factory or
-	 * {@link #DUMMY_CONSTRAINT_VALIDATOR}.
+	 * {@link ConstraintValidatorManager#DUMMY_CONSTRAINT_VALIDATOR}.
 	 */
 	private volatile ConstraintValidator<A, ?> constraintValidatorForDefaultConstraintValidatorFactory;
 
@@ -119,7 +118,6 @@ public class ConstraintTree<A extends Annotation> {
 			ConstraintValidatorContextImpl constraintValidatorContext = new ConstraintValidatorContextImpl(
 					validationContext.getParameterNames(),
 					validationContext.getClockProvider(),
-					validationContext.getScriptEvaluatorFactory(),
 					valueContext.getPropertyPath(),
 					descriptor
 			);
@@ -184,8 +182,7 @@ public class ConstraintTree<A extends Annotation> {
 				synchronized ( this ) {
 					validator = constraintValidatorForDefaultConstraintValidatorFactory;
 					if ( validator == null ) {
-						validator = getInitializedConstraintValidator( validationContext.getConstraintValidatorManager(),
-								validationContext.getConstraintValidatorFactory() );
+						validator = getInitializedConstraintValidator( validationContext );
 						constraintValidatorForDefaultConstraintValidatorFactory = validator;
 					}
 				}
@@ -196,8 +193,7 @@ public class ConstraintTree<A extends Annotation> {
 			// factory. Creating a lot of CHM for that cache might not be a good idea and we prefer being conservative
 			// for now. Note that we have the ConstraintValidatorManager cache that mitigates the situation.
 			// If you come up with a use case where it makes sense, please reach out to us.
-			validator = getInitializedConstraintValidator( validationContext.getConstraintValidatorManager(),
-					validationContext.getConstraintValidatorFactory() );
+			validator = getInitializedConstraintValidator( validationContext );
 		}
 
 		if ( validator == DUMMY_CONSTRAINT_VALIDATOR ) {
@@ -208,12 +204,13 @@ public class ConstraintTree<A extends Annotation> {
 	}
 
 	@SuppressWarnings("unchecked")
-	private ConstraintValidator<A, ?> getInitializedConstraintValidator(ConstraintValidatorManager constraintValidatorManager,
-			ConstraintValidatorFactory constraintValidatorFactory) {
-		ConstraintValidator<A, ?> validator = constraintValidatorManager.getInitializedValidator(
+	private ConstraintValidator<A, ?> getInitializedConstraintValidator(ValidationContext<?> validationContext) {
+		ConstraintValidator<A, ?> validator = validationContext.getConstraintValidatorManager().getInitializedValidator(
 				validatedValueType,
 				descriptor,
-				constraintValidatorFactory );
+				validationContext.getConstraintValidatorFactory(),
+				validationContext.getConstraintValidatorInitializationContext()
+		);
 
 		if ( validator != null ) {
 			return validator;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
@@ -33,8 +33,6 @@ import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
-import org.hibernate.validator.spi.scripting.ScriptEvaluator;
-import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
 
 /**
  * @author Hardy Ferentschik
@@ -49,18 +47,16 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 	private Map<String, Object> expressionVariables;
 	private final List<String> methodParameterNames;
 	private final ClockProvider clockProvider;
-	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
 	private final PathImpl basePath;
 	private final ConstraintDescriptor<?> constraintDescriptor;
 	private List<ConstraintViolationCreationContext> constraintViolationCreationContexts;
 	private boolean defaultDisabled;
 	private Object dynamicPayload;
 
-	public ConstraintValidatorContextImpl(List<String> methodParameterNames, ClockProvider clockProvider, ScriptEvaluatorFactory scriptEvaluatorFactory,
+	public ConstraintValidatorContextImpl(List<String> methodParameterNames, ClockProvider clockProvider,
 			PathImpl propertyPath, ConstraintDescriptor<?> constraintDescriptor) {
 		this.methodParameterNames = methodParameterNames;
 		this.clockProvider = clockProvider;
-		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
 		this.basePath = propertyPath;
 		this.constraintDescriptor = constraintDescriptor;
 	}
@@ -126,11 +122,6 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 	public HibernateConstraintValidatorContext withDynamicPayload(Object violationContext) {
 		this.dynamicPayload = violationContext;
 		return this;
-	}
-
-	@Override
-	public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
-		return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
 	}
 
 	public final ConstraintDescriptor<?> getConstraintDescriptor() {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
@@ -94,9 +94,8 @@ public class ConstraintValidatorManager {
 	 * @param validatedValueType the type of the value to be validated. Cannot be {@code null}.
 	 * @param descriptor the constraint descriptor for which to get an initialized constraint validator. Cannot be {@code null}
 	 * @param constraintValidatorFactory constraint factory used to instantiate the constraint validator. Cannot be {@code null}.
+	 * @param initializationContext context used on constraint validator initialization
 	 * @param <A> the annotation type
-	 * @param initializationContext {@link HibernateConstraintValidatorInitializationContext} to be used in
-	 * {@link HibernateConstraintValidator#initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)}
 	 *
 	 * @return an initialized constraint validator for the given type and annotation of the value to be validated.
 	 * {@code null} is returned if no matching constraint validator could be found.
@@ -239,7 +238,7 @@ public class ConstraintValidatorManager {
 			HibernateConstraintValidatorInitializationContext initializationContext) {
 		try {
 			if ( constraintValidator instanceof HibernateConstraintValidator ) {
-				( (HibernateConstraintValidator) constraintValidator ).initialize( descriptor, initializationContext );
+				( (HibernateConstraintValidator<A, ?>) constraintValidator ).initialize( descriptor, initializationContext );
 			}
 			else {
 				constraintValidator.initialize( descriptor.getAnnotation() );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
@@ -25,5 +25,4 @@ public class HibernateConstraintValidatorInitializationContextImpl implements Hi
 	public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
 		return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
 	}
-
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.constraintvalidation;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
+import org.hibernate.validator.spi.scripting.ScriptEvaluator;
+import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
+
+/**
+ * @author Marko Bekhta
+ */
+public class HibernateConstraintValidatorInitializationContextImpl implements HibernateConstraintValidatorInitializationContext {
+
+	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
+
+	public HibernateConstraintValidatorInitializationContextImpl(ScriptEvaluatorFactory scriptEvaluatorFactory) {
+		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
+	}
+
+	@Override
+	public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
+		return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
+	}
+
+}

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextImplTest.java
@@ -226,7 +226,7 @@ public class ConstraintValidatorContextImplTest {
 		PathImpl path = PathImpl.createRootPath();
 		path.addBeanNode();
 
-		ConstraintValidatorContextImpl context = new ConstraintValidatorContextImpl( null, null, null, path, null );
+		ConstraintValidatorContextImpl context = new ConstraintValidatorContextImpl( null, null, path, null );
 		context.disableDefaultConstraintViolation();
 		return context;
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/ScriptAssertValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/ScriptAssertValidatorTest.java
@@ -10,6 +10,7 @@ import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertN
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+import static org.hibernate.validator.testutils.ConstraintValidatorInitializationHelper.initialize;
 import static org.testng.Assert.assertTrue;
 
 import java.time.Instant;
@@ -23,6 +24,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 
 import org.hibernate.validator.constraints.ScriptAssert;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
 import org.hibernate.validator.internal.constraintvalidators.hv.ScriptAssertValidator;
 import org.hibernate.validator.internal.util.annotation.AnnotationDescriptor;
 import org.hibernate.validator.test.constraints.annotations.AbstractConstrainedTest;
@@ -203,8 +205,8 @@ public class ScriptAssertValidatorTest extends AbstractConstrainedTest {
 	 */
 	private ConstraintValidator<ScriptAssert, Object> getInitializedValidator(String lang, String script, String alias, String reportOn) {
 
-		ConstraintValidator<ScriptAssert, Object> validator = new ScriptAssertValidator();
-		validator.initialize( getScriptAssert( lang, script, alias, reportOn ) );
+		HibernateConstraintValidator<ScriptAssert, Object> validator = new ScriptAssertValidator();
+		initialize( validator, getScriptAssert( lang, script, alias, reportOn ) );
 
 		return validator;
 	}
@@ -217,7 +219,7 @@ public class ScriptAssertValidatorTest extends AbstractConstrainedTest {
 	 *
 	 * @return a {@link ScriptAssert} initialized with the given values.
 	 */
-	private ScriptAssert getScriptAssert(String lang, String script, String alias, String reportOn) {
+	private AnnotationDescriptor<ScriptAssert> getScriptAssert(String lang, String script, String alias, String reportOn) {
 		AnnotationDescriptor.Builder<ScriptAssert> descriptorBuilder = new AnnotationDescriptor.Builder<>( ScriptAssert.class );
 
 		descriptorBuilder.setAttribute( "lang", lang );
@@ -229,7 +231,7 @@ public class ScriptAssertValidatorTest extends AbstractConstrainedTest {
 			descriptorBuilder.setAttribute( "reportOn", reportOn );
 		}
 
-		return descriptorBuilder.build().getAnnotation();
+		return descriptorBuilder.build();
 	}
 
 	/**

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.test.internal.engine.constraintvalidation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.validator.testutils.ConstraintValidatorInitializationHelper.getDummyValidatorInitContext;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 import static org.testng.Assert.assertEquals;
@@ -64,7 +65,8 @@ public class ConstraintValidatorManagerTest {
 		ConstraintValidator<?, ?> constraintValidator = constraintValidatorManager.getInitializedValidator(
 				String.class,
 				constraintDescriptor,
-				constraintValidatorFactory
+				constraintValidatorFactory,
+				getDummyValidatorInitContext()
 		);
 
 		assertTrue( constraintValidator instanceof NotNullValidator, "Unexpected validator type" );
@@ -77,7 +79,8 @@ public class ConstraintValidatorManagerTest {
 		constraintValidatorManager.getInitializedValidator(
 				null,
 				constraintDescriptor,
-				constraintValidatorFactory
+				constraintValidatorFactory,
+				getDummyValidatorInitContext()
 		);
 	}
 
@@ -86,7 +89,8 @@ public class ConstraintValidatorManagerTest {
 		constraintValidatorManager.getInitializedValidator(
 				String.class,
 				null,
-				constraintValidatorFactory
+				constraintValidatorFactory,
+				getDummyValidatorInitContext()
 		);
 	}
 
@@ -97,7 +101,8 @@ public class ConstraintValidatorManagerTest {
 		constraintValidatorManager.getInitializedValidator(
 				String.class,
 				constraintDescriptor,
-				null
+				null,
+				getDummyValidatorInitContext()
 		);
 	}
 
@@ -108,7 +113,8 @@ public class ConstraintValidatorManagerTest {
 		ConstraintValidator<?, ?> constraintValidator = constraintValidatorManager.getInitializedValidator(
 				Object.class,
 				constraintDescriptor,
-				constraintValidatorFactory
+				constraintValidatorFactory,
+				getDummyValidatorInitContext()
 		);
 		assertNull( constraintValidator, "there should be no matching constraint validator" );
 	}
@@ -120,7 +126,8 @@ public class ConstraintValidatorManagerTest {
 		ConstraintValidator<?, ?> constraintValidator1 = constraintValidatorManager.getInitializedValidator(
 				String.class,
 				constraintDescriptor,
-				constraintValidatorFactory
+				constraintValidatorFactory,
+				getDummyValidatorInitContext()
 		);
 
 		assertTrue(
@@ -131,7 +138,8 @@ public class ConstraintValidatorManagerTest {
 		ConstraintValidator<?, ?> constraintValidator2 = constraintValidatorManager.getInitializedValidator(
 				String.class,
 				constraintDescriptor,
-				new MyCustomValidatorFactory()
+				new MyCustomValidatorFactory(),
+				getDummyValidatorInitContext()
 		);
 
 		assertTrue(
@@ -154,7 +162,8 @@ public class ConstraintValidatorManagerTest {
 			constraintValidatorManager.getInitializedValidator(
 					String.class,
 					constraintDescriptor,
-					new MyCustomValidatorFactory()
+					new MyCustomValidatorFactory(),
+					getDummyValidatorInitContext()
 			);
 
 			assertEquals(
@@ -193,17 +202,20 @@ public class ConstraintValidatorManagerTest {
 		ConstraintValidator<?, ?> notNullValidatorForFirstName1 = constraintValidatorManager.getInitializedValidator(
 				String.class,
 				notNullOnFirstNameDescriptor,
-				constraintValidatorFactory
+				constraintValidatorFactory,
+				getDummyValidatorInitContext()
 		);
 		ConstraintValidator<?, ?> notNullValidatorForFirstName2 = constraintValidatorManager.getInitializedValidator(
 				String.class,
 				notNullOnFirstNameDescriptor,
-				constraintValidatorFactory
+				constraintValidatorFactory,
+				getDummyValidatorInitContext()
 		);
 		ConstraintValidator<?, ?> notNullValidatorForLastName = constraintValidatorManager.getInitializedValidator(
 				String.class,
 				notNullOnLastNameDescriptor,
-				constraintValidatorFactory
+				constraintValidatorFactory,
+				getDummyValidatorInitContext()
 		);
 
 		assertThat( notNullValidatorForFirstName1 ).isSameAs( notNullValidatorForFirstName2 );
@@ -233,13 +245,13 @@ public class ConstraintValidatorManagerTest {
 		);
 
 		ConstraintValidator<?, ?> sizeValidatorForMiddleName = constraintValidatorManager.getInitializedValidator(
-				String.class, sizeOnMiddleNameDescriptor, constraintValidatorFactory
+				String.class, sizeOnMiddleNameDescriptor, constraintValidatorFactory, getDummyValidatorInitContext()
 		);
 		ConstraintValidator<?, ?> sizeValidatorForAddress1 = constraintValidatorManager.getInitializedValidator(
-				String.class, sizeOnAddress1Descriptor, constraintValidatorFactory
+				String.class, sizeOnAddress1Descriptor, constraintValidatorFactory, getDummyValidatorInitContext()
 		);
 		ConstraintValidator<?, ?> sizeValidatorForAddress2 = constraintValidatorManager.getInitializedValidator(
-				String.class, sizeOnAddress2Descriptor, constraintValidatorFactory
+				String.class, sizeOnAddress2Descriptor, constraintValidatorFactory, getDummyValidatorInitContext()
 		);
 
 		assertThat( sizeValidatorForMiddleName ).isNotSameAs( sizeValidatorForAddress1 );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
@@ -7,7 +7,7 @@
 package org.hibernate.validator.test.internal.engine.constraintvalidation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.validator.testutils.ConstraintValidatorInitializationHelper.getDummyValidatorInitContext;
+import static org.hibernate.validator.testutils.ConstraintValidatorInitializationHelper.getDummyConstraintValidatorInitializationContext;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 import static org.testng.Assert.assertEquals;
@@ -66,7 +66,7 @@ public class ConstraintValidatorManagerTest {
 				String.class,
 				constraintDescriptor,
 				constraintValidatorFactory,
-				getDummyValidatorInitContext()
+				getDummyConstraintValidatorInitializationContext()
 		);
 
 		assertTrue( constraintValidator instanceof NotNullValidator, "Unexpected validator type" );
@@ -80,7 +80,7 @@ public class ConstraintValidatorManagerTest {
 				null,
 				constraintDescriptor,
 				constraintValidatorFactory,
-				getDummyValidatorInitContext()
+				getDummyConstraintValidatorInitializationContext()
 		);
 	}
 
@@ -90,7 +90,7 @@ public class ConstraintValidatorManagerTest {
 				String.class,
 				null,
 				constraintValidatorFactory,
-				getDummyValidatorInitContext()
+				getDummyConstraintValidatorInitializationContext()
 		);
 	}
 
@@ -102,7 +102,7 @@ public class ConstraintValidatorManagerTest {
 				String.class,
 				constraintDescriptor,
 				null,
-				getDummyValidatorInitContext()
+				getDummyConstraintValidatorInitializationContext()
 		);
 	}
 
@@ -114,7 +114,7 @@ public class ConstraintValidatorManagerTest {
 				Object.class,
 				constraintDescriptor,
 				constraintValidatorFactory,
-				getDummyValidatorInitContext()
+				getDummyConstraintValidatorInitializationContext()
 		);
 		assertNull( constraintValidator, "there should be no matching constraint validator" );
 	}
@@ -127,7 +127,7 @@ public class ConstraintValidatorManagerTest {
 				String.class,
 				constraintDescriptor,
 				constraintValidatorFactory,
-				getDummyValidatorInitContext()
+				getDummyConstraintValidatorInitializationContext()
 		);
 
 		assertTrue(
@@ -139,7 +139,7 @@ public class ConstraintValidatorManagerTest {
 				String.class,
 				constraintDescriptor,
 				new MyCustomValidatorFactory(),
-				getDummyValidatorInitContext()
+				getDummyConstraintValidatorInitializationContext()
 		);
 
 		assertTrue(
@@ -163,7 +163,7 @@ public class ConstraintValidatorManagerTest {
 					String.class,
 					constraintDescriptor,
 					new MyCustomValidatorFactory(),
-					getDummyValidatorInitContext()
+					getDummyConstraintValidatorInitializationContext()
 			);
 
 			assertEquals(
@@ -203,19 +203,19 @@ public class ConstraintValidatorManagerTest {
 				String.class,
 				notNullOnFirstNameDescriptor,
 				constraintValidatorFactory,
-				getDummyValidatorInitContext()
+				getDummyConstraintValidatorInitializationContext()
 		);
 		ConstraintValidator<?, ?> notNullValidatorForFirstName2 = constraintValidatorManager.getInitializedValidator(
 				String.class,
 				notNullOnFirstNameDescriptor,
 				constraintValidatorFactory,
-				getDummyValidatorInitContext()
+				getDummyConstraintValidatorInitializationContext()
 		);
 		ConstraintValidator<?, ?> notNullValidatorForLastName = constraintValidatorManager.getInitializedValidator(
 				String.class,
 				notNullOnLastNameDescriptor,
 				constraintValidatorFactory,
-				getDummyValidatorInitContext()
+				getDummyConstraintValidatorInitializationContext()
 		);
 
 		assertThat( notNullValidatorForFirstName1 ).isSameAs( notNullValidatorForFirstName2 );
@@ -245,13 +245,13 @@ public class ConstraintValidatorManagerTest {
 		);
 
 		ConstraintValidator<?, ?> sizeValidatorForMiddleName = constraintValidatorManager.getInitializedValidator(
-				String.class, sizeOnMiddleNameDescriptor, constraintValidatorFactory, getDummyValidatorInitContext()
+				String.class, sizeOnMiddleNameDescriptor, constraintValidatorFactory, getDummyConstraintValidatorInitializationContext()
 		);
 		ConstraintValidator<?, ?> sizeValidatorForAddress1 = constraintValidatorManager.getInitializedValidator(
-				String.class, sizeOnAddress1Descriptor, constraintValidatorFactory, getDummyValidatorInitContext()
+				String.class, sizeOnAddress1Descriptor, constraintValidatorFactory, getDummyConstraintValidatorInitializationContext()
 		);
 		ConstraintValidator<?, ?> sizeValidatorForAddress2 = constraintValidatorManager.getInitializedValidator(
-				String.class, sizeOnAddress2Descriptor, constraintValidatorFactory, getDummyValidatorInitContext()
+				String.class, sizeOnAddress2Descriptor, constraintValidatorFactory, getDummyConstraintValidatorInitializationContext()
 		);
 
 		assertThat( sizeValidatorForMiddleName ).isNotSameAs( sizeValidatorForAddress1 );

--- a/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
+++ b/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
@@ -26,7 +26,8 @@ public class ConstraintValidatorInitializationHelper {
 
 	private static final ConstraintHelper CONSTRAINT_HELPER = new ConstraintHelper();
 
-	private static final HibernateConstraintValidatorInitializationContext DUMMY_VALIDATOR_INIT_CONTEXT = new HibernateConstraintValidatorInitializationContext() {
+	private static final HibernateConstraintValidatorInitializationContext DUMMY_CONSTRAINT_VALIDATOR_INITIALIZATION_CONTEXT
+			= new HibernateConstraintValidatorInitializationContext() {
 
 		private ScriptEvaluatorFactory scriptEvaluatorFactory = new DefaultScriptEvaluatorFactory( null );
 
@@ -52,7 +53,7 @@ public class ConstraintValidatorInitializationHelper {
 			HibernateConstraintValidator<A, T> constraintValidator,
 			AnnotationDescriptor<A> annotationDescriptor
 	) {
-		initialize( constraintValidator, annotationDescriptor, getDummyValidatorInitContext() );
+		initialize( constraintValidator, annotationDescriptor, getDummyConstraintValidatorInitializationContext() );
 	}
 
 	public static <A extends Annotation, T> void initialize(
@@ -63,7 +64,7 @@ public class ConstraintValidatorInitializationHelper {
 		constraintValidator.initialize( descriptorFrom( annotationDescriptor ), initializationContext );
 	}
 
-	public static HibernateConstraintValidatorInitializationContext getDummyValidatorInitContext() {
-		return DUMMY_VALIDATOR_INIT_CONTEXT;
+	public static HibernateConstraintValidatorInitializationContext getDummyConstraintValidatorInitializationContext() {
+		return DUMMY_CONSTRAINT_VALIDATOR_INITIALIZATION_CONTEXT;
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
+++ b/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
@@ -1,0 +1,69 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.testutils;
+
+import java.lang.annotation.Annotation;
+
+import javax.validation.metadata.ConstraintDescriptor;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
+import org.hibernate.validator.internal.engine.scripting.DefaultScriptEvaluatorFactory;
+import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
+import org.hibernate.validator.internal.util.annotation.AnnotationDescriptor;
+import org.hibernate.validator.spi.scripting.ScriptEvaluator;
+import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
+
+/**
+ * @author Marko Bekhta
+ */
+public class ConstraintValidatorInitializationHelper {
+
+	private static final ConstraintHelper CONSTRAINT_HELPER = new ConstraintHelper();
+
+	private static final HibernateConstraintValidatorInitializationContext DUMMY_VALIDATOR_INIT_CONTEXT = new HibernateConstraintValidatorInitializationContext() {
+
+		private ScriptEvaluatorFactory scriptEvaluatorFactory = new DefaultScriptEvaluatorFactory( null );
+
+		@Override
+		public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
+			return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
+		}
+	};
+
+	private ConstraintValidatorInitializationHelper() {
+	}
+
+	public static <T extends Annotation> ConstraintDescriptor<T> descriptorFrom(AnnotationDescriptor<T> annotationDescriptor) {
+		return new ConstraintDescriptorImpl<>(
+				CONSTRAINT_HELPER,
+				null,
+				annotationDescriptor,
+				null
+		);
+	}
+
+	public static <A extends Annotation, T> void initialize(
+			HibernateConstraintValidator<A, T> constraintValidator,
+			AnnotationDescriptor<A> annotationDescriptor
+	) {
+		initialize( constraintValidator, annotationDescriptor, getDummyValidatorInitContext() );
+	}
+
+	public static <A extends Annotation, T> void initialize(
+			HibernateConstraintValidator<A, T> constraintValidator,
+			AnnotationDescriptor<A> annotationDescriptor,
+			HibernateConstraintValidatorInitializationContext initializationContext
+	) {
+		constraintValidator.initialize( descriptorFrom( annotationDescriptor ), initializationContext );
+	}
+
+	public static HibernateConstraintValidatorInitializationContext getDummyValidatorInitContext() {
+		return DUMMY_VALIDATOR_INIT_CONTEXT;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/testutils/ValidatorUtil.java
+++ b/engine/src/test/java/org/hibernate/validator/testutils/ValidatorUtil.java
@@ -28,7 +28,6 @@ import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 import org.hibernate.validator.internal.engine.DefaultClockProvider;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
-import org.hibernate.validator.internal.engine.scripting.DefaultScriptEvaluatorFactory;
 import org.hibernate.validator.testutil.DummyTraversableResolver;
 import org.hibernate.validator.testutil.ValidationInvocationHandler;
 
@@ -236,6 +235,6 @@ public final class ValidatorUtil {
 	}
 
 	public static HibernateConstraintValidatorContext getConstraintValidatorContext() {
-		return new ConstraintValidatorContextImpl( null, DefaultClockProvider.INSTANCE, new DefaultScriptEvaluatorFactory( null ), null, null );
+		return new ConstraintValidatorContextImpl( null, DefaultClockProvider.INSTANCE, null, null );
 	}
 }


### PR DESCRIPTION
Hi @gunnarmorling , @gsmet so I wanted to finish that other task for time tolerance constraints before moving to the other ones. I liked the idea of having a possibility to pass more information to init method of constraint validator. After thinking about it - this idea of callbacks came to my mind. What if instead of adding another method for initialization, which we initially were thinking about, we add a "callback" methods like postInit and maybe preInit. At the moment I cannot think of a good use case for a preInit though :).

I think it can be a good alternative to our initial approach. This would definitely solve the problem of having multiple init methods which Gunnar mentioned and would be probably much easier to add to BV later. 

So I made the changes in this PR (just for the postInit) and updated the `ScriptAssert` constraints as an example of using such postInit callback.