### PR TITLE
HV-1472 Update our WildFly integration to 11.0.0.Final

### DIFF
--- a/documentation/src/main/asciidoc/ch01.asciidoc
+++ b/documentation/src/main/asciidoc/ch01.asciidoc
@@ -124,23 +124,6 @@ In order to update the server modules for Bean Validation API and Hibernate Vali
 
 You can download the patch file from http://sourceforge.net/projects/hibernate/files/hibernate-validator[SourceForge] or from Maven Central using the following dependency:
 
-.Maven dependency for WildFly {wildflyVersion} patch file
-====
-[source, XML]
-[subs="verbatim,attributes"]
-----
-<dependency>
-    <groupId>org.hibernate.validator</groupId>
-    <artifactId>hibernate-validator-modules</artifactId>
-    <version>{hvVersion}</version>
-    <classifier>wildfly-{wildflyVersion}-patch</classifier>
-    <type>zip</type>
-</dependency>
-----
-====
-
-We also provide a patch for the version of WildFly currently under development:
-
 .Maven dependency for WildFly {wildflyNextVersion} patch file
 ====
 [source, XML]
@@ -156,6 +139,23 @@ We also provide a patch for the version of WildFly currently under development:
 ----
 ====
 
+We also provide a patch for the previous version of WildFly:
+
+.Maven dependency for WildFly {wildflyVersion} patch file
+====
+[source, XML]
+[subs="verbatim,attributes"]
+----
+<dependency>
+    <groupId>org.hibernate.validator</groupId>
+    <artifactId>hibernate-validator-modules</artifactId>
+    <version>{hvVersion}</version>
+    <classifier>wildfly-{wildflyVersion}-patch</classifier>
+    <type>zip</type>
+</dependency>
+----
+====
+
 Having downloaded the patch file, you can apply it to WildFly by running this command:
 
 .Applying the WildFly patch
@@ -163,7 +163,7 @@ Having downloaded the patch file, you can apply it to WildFly by running this co
 [source]
 [subs="verbatim,attributes"]
 ----
-$JBOSS_HOME/bin/jboss-cli.sh patch apply hibernate-validator-modules-{hvVersion}-wildfly-{wildflyVersion}-patch.zip
+$JBOSS_HOME/bin/jboss-cli.sh patch apply hibernate-validator-modules-{hvVersion}-wildfly-{wildflyNextVersion}-patch.zip
 ----
 ====
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <!-- Currently supported version of WildFly -->
         <wildfly.version>10.1.0.Final</wildfly.version>
         <!-- Used to create a patch file for WildFly next -->
-        <wildfly-next.version>11.0.0.CR1</wildfly-next.version>
+        <wildfly-next.version>11.0.0.Final</wildfly-next.version>
 
         <!--
             These dependencies should be aligned with the ones from the WildFly version we support


### PR DESCRIPTION
* https://hibernate.atlassian.net/browse/HV-1472

For now, we keep the 10.1 patch, waiting for the next development cycle
to start. Once it's started, we will switch to the next version.