### PR TITLE
HV-1493 Temporal validation tolerance

### DIFF
--- a/documentation/src/main/asciidoc/ch06.asciidoc
+++ b/documentation/src/main/asciidoc/ch06.asciidoc
@@ -116,8 +116,8 @@ While another name could be used, the Bean Validation specification recommends t
 ==== The constraint validator
 
 Having defined the annotation, you need to create a constraint validator, which is able to validate
-elements with a `@CheckCase` annotation. To do so, implement the interface `ConstraintValidator` as
-shown below:
+elements with a `@CheckCase` annotation. To do so, implement the Bean Validation interface `ConstraintValidator`
+as shown below:
 
 [[example-constraint-validator]]
 .Implementing a constraint validator for the constraint `@CheckCase`
@@ -175,6 +175,40 @@ Only after that the new constraint violation will be created.
 
 Refer to <<section-custom-property-paths>> to learn how to use the `ConstraintValidatorContext` API to
 control the property path of constraint violations for class-level constraints.
+
+[[constraint-validator-hibernateconstraintvalidator]]
+===== The `HibernateConstraintValidator` extension
+
+Hibernate Validator provides an extension to the `ConstraintValidator` contract: `HibernateConstraintValidator`.
+
+The purpose of this extension is to provide more contextual information to the `initialize()` method
+as, in the current `ConstraintValidator` contract, only the annotation is passed as parameter.
+
+The `initialize()` method of `HibernateConstraintValidator` takes two parameters:
+
+ * The `ConstraintDescriptor` of the constraint at hand.
+   You can get access to the annotation using `ConstraintDescriptor#getAnnotation()`.
+ * The `HibernateConstraintValidatorInitializationContext` which provides useful helpers and contextual
+   information, such as the clock provider or the temporal validation tolerance.
+
+This extension is marked as incubating so it might be subject to change.
+The plan is to standardize it and to include it in Bean Validation in the future.
+
+The example below shows how to base your validators on `HibernateConstraintValidator`:
+
+[[example-constraint-validator-hibernateconstraintvalidator]]
+.Using the `HibernateConstraintValidator` contract
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter06/MyFutureValidator.java[tags=include]
+----
+====
+
+[WARNING]
+====
+You should only implement one of the `initialize()` methods. Be aware that both are called when initializing the validator.
+====
 
 [[validator-customconstraints-errormessage]]
 ==== The error message

--- a/documentation/src/main/asciidoc/ch09.asciidoc
+++ b/documentation/src/main/asciidoc/ch09.asciidoc
@@ -351,7 +351,8 @@ When implementing your own temporal constraints, you might need to have access t
 
 It can be obtained by calling the `HibernateConstraintValidatorInitializationContext#getTemporalValidationTolerance()` method.
 
-Note that to get access to this context at initialization, your constraint validator has to implement the `HibernateConstraintValidator` contract.
+Note that to get access to this context at initialization, your constraint validator has to implement
+the `HibernateConstraintValidator` contract (see <<constraint-validator-hibernateconstraintvalidator>>).
 This contract is currently marked as incubating: it might be subject to change in the future.
 ====
 

--- a/documentation/src/main/asciidoc/ch09.asciidoc
+++ b/documentation/src/main/asciidoc/ch09.asciidoc
@@ -287,7 +287,7 @@ to learn more about this specific implementation.
 ====
 
 [[section-clock-provider]]
-==== `ClockProvider`
+==== `ClockProvider` and temporal validation tolerance
 
 For time related validation (`@Past` and `@Future` constraints for instance), it might be useful to define what is
 considered `now`.
@@ -324,6 +324,35 @@ You can obtain the `ClockProvider` in your validators by calling the
 
 For instance, this might be useful if you want to replace the default message of the `@Future`
 constraint with a more explicit one.
+====
+
+When dealing with distributed architectures, you might need some tolerance when applying temporal constraints
+such as `@Past` or `@Future`.
+
+You can set a temporal validation tolerance by bootstrapping your `ValidatorFactory` as below:
+
+[[example-using-temporal-validation-tolerance]]
+.Using temporal validation tolerance
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter09/BootstrappingTest.java[tags=temporalValidationTolerance]
+----
+====
+
+Alternatively, you can define it in the XML configuration by setting the `hibernate.validator.temporal_validation_tolerance` property
+in your _META-INF/validation.xml_.
+
+The value of this property must be a `long` defining the tolerance in milliseconds.
+
+[NOTE]
+====
+When implementing your own temporal constraints, you might need to have access to the temporal validation tolerance.
+
+It can be obtained by calling the `HibernateConstraintValidatorInitializationContext#getTemporalValidationTolerance()` method.
+
+Note that to get access to this context at initialization, your constraint validator has to implement the `HibernateConstraintValidator` contract.
+This contract is currently marked as incubating: it might be subject to change in the future.
 ====
 
 [[section-bootstrapping-valueextractors]]

--- a/documentation/src/main/asciidoc/index.asciidoc
+++ b/documentation/src/main/asciidoc/index.asciidoc
@@ -7,6 +7,7 @@ Hardy Ferentschik; Gunnar Morling; Guillaume Smet
 :anchor:
 :toc: left
 :toclevels: 3
+:sectnumlevels: 5
 :docinfodir: {docinfodir}
 :docinfo:
 :title-logo-image: image:hibernate_logo_a.png[align=left,pdfwidth=33%]

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter06/MyFuture.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter06/MyFuture.java
@@ -1,0 +1,44 @@
+package org.hibernate.validator.referenceguide.chapter06;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+import org.hibernate.validator.referenceguide.chapter06.MyFuture.List;
+
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@Repeatable(List.class)
+@Documented
+@Constraint(validatedBy = { })
+public @interface MyFuture {
+
+	String message() default "{org.hibernate.validator.referenceguide.chapter06.MyFuture." +
+			"message}";
+
+	Class<?>[] groups() default { };
+
+	Class<? extends Payload>[] payload() default { };
+
+	boolean orPresent() default false;
+
+	@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+	@Retention(RUNTIME)
+	@Documented
+	@interface List {
+
+		MyFuture[] value();
+	}
+}

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter06/MyFutureValidator.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter06/MyFutureValidator.java
@@ -1,0 +1,37 @@
+//tag::include[]
+package org.hibernate.validator.referenceguide.chapter06;
+
+//end::include[]
+
+import java.time.Clock;
+import java.time.Instant;
+
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.metadata.ConstraintDescriptor;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
+
+@SuppressWarnings("unused")
+//tag::include[]
+public class MyFutureValidator implements HibernateConstraintValidator<MyFuture, Instant> {
+
+	private Clock clock;
+
+	private boolean orPresent;
+
+	@Override
+	public void initialize(ConstraintDescriptor<MyFuture> constraintDescriptor,
+			HibernateConstraintValidatorInitializationContext initializationContext) {
+		this.orPresent = constraintDescriptor.getAnnotation().orPresent();
+		this.clock = initializationContext.getClockProvider().getClock();
+	}
+
+	@Override
+	public boolean isValid(Instant instant, ConstraintValidatorContext constraintContext) {
+		//...
+
+		return false;
+	}
+}
+//end::include[]

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter09/BootstrappingTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter09/BootstrappingTest.java
@@ -1,6 +1,7 @@
 package org.hibernate.validator.referenceguide.chapter09;
 
 import java.io.InputStream;
+import java.time.Duration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -106,6 +107,18 @@ public class BootstrappingTest {
 				.buildValidatorFactory();
 		Validator validator = validatorFactory.getValidator();
 		//end::clockProvider[]
+	}
+
+	@Test
+	@SuppressWarnings("unused")
+	public void temporalValidationTolerance() {
+		//tag::temporalValidationTolerance[]
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.temporalValidationTolerance( Duration.ofMillis( 10 ) )
+				.buildValidatorFactory();
+		Validator validator = validatorFactory.getValidator();
+		//end::temporalValidationTolerance[]
 	}
 
 	@Test

--- a/engine/src/main/java/org/hibernate/validator/HibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/HibernateValidatorConfiguration.java
@@ -6,10 +6,15 @@
  */
 package org.hibernate.validator;
 
+import java.time.Duration;
 import java.util.Set;
 
 import javax.validation.Configuration;
 import javax.validation.TraversableResolver;
+import javax.validation.constraints.Future;
+import javax.validation.constraints.FutureOrPresent;
+import javax.validation.constraints.Past;
+import javax.validation.constraints.PastOrPresent;
 import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.cfg.ConstraintMapping;
@@ -85,6 +90,15 @@ public interface HibernateValidatorConfiguration extends Configuration<Hibernate
 	 */
 	@Incubating
 	String SCRIPT_EVALUATOR_FACTORY_CLASSNAME = "hibernate.validator.script_evaluator_factory";
+
+	/**
+	 * Property for configuring temporal validation tolerance, allowing to set the acceptable margin of error when
+	 * comparing date/time in temporal constraints. In milliseconds.
+	 *
+	 * @since 6.0.5
+	 */
+	@Incubating
+	String TEMPORAL_VALIDATION_TOLERANCE = "hibernate.validator.temporal_validation_tolerance";
 
 	/**
 	 * <p>
@@ -264,4 +278,17 @@ public interface HibernateValidatorConfiguration extends Configuration<Hibernate
 	 */
 	@Incubating
 	HibernateValidatorConfiguration scriptEvaluatorFactory(ScriptEvaluatorFactory scriptEvaluatorFactory);
+
+	/**
+	 * Allows to set the acceptable margin of error when comparing date/time in temporal constraints such as
+	 * {@link Past}/{@link PastOrPresent} and {@link Future}/{@link FutureOrPresent}.
+	 *
+	 * @param temporalValidationTolerance the acceptable tolerance
+	 *
+	 * @return {@code this} following the chaining method pattern
+	 *
+	 * @since 6.0.5
+	 */
+	@Incubating
+	HibernateValidatorConfiguration temporalValidationTolerance(Duration temporalValidationTolerance);
 }

--- a/engine/src/main/java/org/hibernate/validator/HibernateValidatorContext.java
+++ b/engine/src/main/java/org/hibernate/validator/HibernateValidatorContext.java
@@ -7,6 +7,8 @@
 
 package org.hibernate.validator;
 
+import java.time.Duration;
+
 import javax.validation.ClockProvider;
 import javax.validation.ConstraintValidatorFactory;
 import javax.validation.MessageInterpolator;
@@ -138,4 +140,17 @@ public interface HibernateValidatorContext extends ValidatorContext {
 	 * @since 6.0.3
 	 */
 	HibernateValidatorContext enableTraversableResolverResultCache(boolean enabled);
+
+	/**
+	 * Define the temporal validation tolerance i.e. the acceptable margin of error
+	 * when comparing date/time in temporal constraints.
+	 *
+	 * @param temporalValidationTolerance the tolerance
+	 *
+	 * @return {@code this} following the chaining method pattern
+	 *
+	 * @since 6.0.5
+	 */
+	@Incubating
+	HibernateValidatorContext temporalValidationTolerance(Duration temporalValidationTolerance);
 }

--- a/engine/src/main/java/org/hibernate/validator/HibernateValidatorFactory.java
+++ b/engine/src/main/java/org/hibernate/validator/HibernateValidatorFactory.java
@@ -7,6 +7,8 @@
 
 package org.hibernate.validator;
 
+import java.time.Duration;
+
 import javax.validation.ValidatorFactory;
 
 import org.hibernate.validator.constraints.ParameterScriptAssert;
@@ -33,6 +35,17 @@ public interface HibernateValidatorFactory extends ValidatorFactory {
 	 */
 	@Incubating
 	ScriptEvaluatorFactory getScriptEvaluatorFactory();
+
+	/**
+	 * Returns the temporal validation tolerance i.e. the acceptable margin of error when comparing date/time in
+	 * temporal constraints.
+	 *
+	 * @return the tolerance
+	 *
+	 * @since 6.0.5
+	 */
+	@Incubating
+	Duration getTemporalValidationTolerance();
 
 	/**
 	 * Returns a context for validator configuration via options from the

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
@@ -6,7 +6,10 @@
  */
 package org.hibernate.validator.constraintvalidation;
 
+import java.time.Clock;
 import java.time.Duration;
+
+import javax.validation.ClockProvider;
 
 import org.hibernate.validator.Incubating;
 import org.hibernate.validator.spi.scripting.ScriptEvaluator;
@@ -34,6 +37,16 @@ public interface HibernateConstraintValidatorInitializationContext {
 	 * found for a given {@code languageName}
 	 */
 	ScriptEvaluator getScriptEvaluatorForLanguage(String languageName);
+
+	/**
+	 * Returns the provider for obtaining the current time in the form of a {@link Clock}, e.g. when validating the
+	 * {@code Future} and {@code Past} constraints.
+	 *
+	 * @return the provider for obtaining the current time, never {@code null}. If no specific provider has been
+	 * configured during bootstrap, a default implementation using the current system time and the current default time
+	 * zone as returned by {@link Clock#systemDefaultZone()} will be returned.
+	 */
+	ClockProvider getClockProvider();
 
 	/**
 	 * Returns the temporal validation tolerance i.e. the acceptable margin of error when comparing date/time in

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.constraintvalidation;
 
+import java.time.Duration;
+
 import org.hibernate.validator.Incubating;
 import org.hibernate.validator.spi.scripting.ScriptEvaluator;
 import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
@@ -32,4 +34,12 @@ public interface HibernateConstraintValidatorInitializationContext {
 	 * found for a given {@code languageName}
 	 */
 	ScriptEvaluator getScriptEvaluatorForLanguage(String languageName);
+
+	/**
+	 * Returns the temporal validation tolerance i.e. the acceptable margin of error when comparing date/time in
+	 * temporal constraints.
+	 *
+	 * @return the tolerance
+	 */
+	Duration getTemporalValidationTolerance();
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/AbstractInstantBasedTimeValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/AbstractInstantBasedTimeValidator.java
@@ -9,12 +9,14 @@ package org.hibernate.validator.internal.constraintvalidators.bv.time;
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 
-import javax.validation.ClockProvider;
-import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import javax.validation.metadata.ConstraintDescriptor;
 
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
@@ -24,9 +26,24 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
  * @author Alaa Nassef
  * @author Guillaume Smet
  */
-public abstract class AbstractInstantBasedTimeValidator<C extends Annotation, T> implements ConstraintValidator<C, T> {
+public abstract class AbstractInstantBasedTimeValidator<C extends Annotation, T> implements HibernateConstraintValidator<C, T> {
 
 	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
+
+	protected Clock referenceClock;
+
+	@Override
+	public void initialize(ConstraintDescriptor<C> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		try {
+			this.referenceClock  = Clock.offset(
+					initializationContext.getClockProvider().getClock(),
+					getEffectiveTemporalValidationTolerance( initializationContext.getTemporalValidationTolerance() )
+			);
+		}
+		catch (Exception e) {
+			throw LOG.getUnableToGetCurrentTimeFromClockProvider( e );
+		}
+	}
 
 	@Override
 	public boolean isValid(T value, ConstraintValidatorContext context) {
@@ -35,20 +52,15 @@ public abstract class AbstractInstantBasedTimeValidator<C extends Annotation, T>
 			return true;
 		}
 
-		Clock reference;
-
-		try {
-			ClockProvider clockProvider = context.getClockProvider();
-			reference = clockProvider.getClock();
-		}
-		catch (Exception e) {
-			throw LOG.getUnableToGetCurrentTimeFromClockProvider( e );
-		}
-
-		int result = getInstant( value ).compareTo( reference.instant() );
+		int result = getInstant( value ).compareTo( referenceClock.instant() );
 
 		return isValid( result );
 	}
+
+	/**
+	 * Returns the temporal validation tolerance to apply.
+	 */
+	protected abstract Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance);
 
 	/**
 	 * Returns the {@link Instant} measured from Epoch.

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/AbstractJavaTimeValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/AbstractJavaTimeValidator.java
@@ -9,12 +9,15 @@ package org.hibernate.validator.internal.constraintvalidators.bv.time;
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
 
 import javax.validation.ClockProvider;
-import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
+import javax.validation.metadata.ConstraintDescriptor;
 
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
@@ -24,9 +27,25 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
  * @author Alaa Nassef
  * @author Guillaume Smet
  */
-public abstract class AbstractJavaTimeValidator<C extends Annotation, T extends TemporalAccessor & Comparable<? super T>> implements ConstraintValidator<C, T> {
+public abstract class AbstractJavaTimeValidator<C extends Annotation, T extends TemporalAccessor & Comparable<? super T>>
+		implements HibernateConstraintValidator<C, T> {
 
 	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
+
+	protected Clock referenceClock;
+
+	@Override
+	public void initialize(ConstraintDescriptor<C> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		try {
+			this.referenceClock  = Clock.offset(
+					initializationContext.getClockProvider().getClock(),
+					getEffectiveTemporalValidationTolerance( initializationContext.getTemporalValidationTolerance() )
+			);
+		}
+		catch (Exception e) {
+			throw LOG.getUnableToGetCurrentTimeFromClockProvider( e );
+		}
+	}
 
 	@Override
 	public boolean isValid(T value, ConstraintValidatorContext context) {
@@ -35,20 +54,15 @@ public abstract class AbstractJavaTimeValidator<C extends Annotation, T extends 
 			return true;
 		}
 
-		Clock reference;
-
-		try {
-			ClockProvider clockProvider = context.getClockProvider();
-			reference = clockProvider.getClock();
-		}
-		catch (Exception e) {
-			throw LOG.getUnableToGetCurrentTimeFromClockProvider( e );
-		}
-
-		int result = value.compareTo( getReferenceValue( reference ) );
+		int result = value.compareTo( getReferenceValue( referenceClock ) );
 
 		return isValid( result );
 	}
+
+	/**
+	 * Returns the temporal validation tolerance to apply.
+	 */
+	protected abstract Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance);
 
 	/**
 	 * Returns an object of the validated type corresponding to the current time reference as provided by the

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureEpochBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureEpochBasedValidator.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.future;
 
+import java.time.Duration;
+
 import javax.validation.constraints.Future;
 
 import org.hibernate.validator.internal.constraintvalidators.bv.time.AbstractEpochBasedTimeValidator;
@@ -23,4 +25,8 @@ public abstract class AbstractFutureEpochBasedValidator<T> extends AbstractEpoch
 		return result > 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance.negated();
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureInstantBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureInstantBasedValidator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.future;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import javax.validation.constraints.Future;
@@ -25,4 +26,8 @@ public abstract class AbstractFutureInstantBasedValidator<T> extends AbstractIns
 		return result > 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance.negated();
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureJavaTimeValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/future/AbstractFutureJavaTimeValidator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.future;
 
+import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
 
 import javax.validation.constraints.Future;
@@ -25,4 +26,8 @@ public abstract class AbstractFutureJavaTimeValidator<T extends TemporalAccessor
 		return result > 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance.negated();
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentEpochBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentEpochBasedValidator.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent;
 
+import java.time.Duration;
+
 import javax.validation.constraints.FutureOrPresent;
 
 import org.hibernate.validator.internal.constraintvalidators.bv.time.AbstractEpochBasedTimeValidator;
@@ -23,4 +25,8 @@ public abstract class AbstractFutureOrPresentEpochBasedValidator<T> extends Abst
 		return result >= 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance.negated();
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentInstantBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentInstantBasedValidator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import javax.validation.constraints.FutureOrPresent;
@@ -25,4 +26,8 @@ public abstract class AbstractFutureOrPresentInstantBasedValidator<T> extends Ab
 		return result >= 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance.negated();
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentJavaTimeValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/futureorpresent/AbstractFutureOrPresentJavaTimeValidator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.futureorpresent;
 
+import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
 
 import javax.validation.constraints.FutureOrPresent;
@@ -25,4 +26,8 @@ public abstract class AbstractFutureOrPresentJavaTimeValidator<T extends Tempora
 		return result >= 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance.negated();
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastEpochBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastEpochBasedValidator.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.past;
 
+import java.time.Duration;
+
 import javax.validation.constraints.Past;
 
 import org.hibernate.validator.internal.constraintvalidators.bv.time.AbstractEpochBasedTimeValidator;
@@ -23,4 +25,8 @@ public abstract class AbstractPastEpochBasedValidator<T> extends AbstractEpochBa
 		return result < 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance;
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastInstantBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastInstantBasedValidator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.past;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import javax.validation.constraints.Past;
@@ -25,4 +26,8 @@ public abstract class AbstractPastInstantBasedValidator<T> extends AbstractInsta
 		return result < 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance;
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastJavaTimeValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/past/AbstractPastJavaTimeValidator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.past;
 
+import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
 
 import javax.validation.constraints.Past;
@@ -25,4 +26,8 @@ public abstract class AbstractPastJavaTimeValidator<T extends TemporalAccessor &
 		return result < 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance;
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentEpochBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentEpochBasedValidator.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent;
 
+import java.time.Duration;
+
 import javax.validation.constraints.PastOrPresent;
 
 import org.hibernate.validator.internal.constraintvalidators.bv.time.AbstractEpochBasedTimeValidator;
@@ -23,4 +25,8 @@ public abstract class AbstractPastOrPresentEpochBasedValidator<T> extends Abstra
 		return result <= 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance;
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentInstantBasedValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentInstantBasedValidator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import javax.validation.constraints.PastOrPresent;
@@ -25,4 +26,8 @@ public abstract class AbstractPastOrPresentInstantBasedValidator<T> extends Abst
 		return result <= 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance;
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentJavaTimeValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/time/pastorpresent/AbstractPastOrPresentJavaTimeValidator.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.time.pastorpresent;
 
+import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
 
 import javax.validation.constraints.PastOrPresent;
@@ -26,4 +27,8 @@ public abstract class AbstractPastOrPresentJavaTimeValidator<T extends TemporalA
 		return result <= 0;
 	}
 
+	@Override
+	protected Duration getEffectiveTemporalValidationTolerance(Duration absoluteTemporalValidationTolerance) {
+		return absoluteTemporalValidationTolerance;
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,6 +101,7 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 	private final MethodValidationConfiguration.Builder methodValidationConfigurationBuilder = new MethodValidationConfiguration.Builder();
 	private boolean traversableResolverResultCacheEnabled = true;
 	private ScriptEvaluatorFactory scriptEvaluatorFactory;
+	private Duration temporalValidationTolerance;
 
 	public ConfigurationImpl(BootstrapState state) {
 		this();
@@ -275,6 +277,14 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 		return this;
 	}
 
+	@Override
+	public HibernateValidatorConfiguration temporalValidationTolerance(Duration temporalValidationTolerance) {
+		Contracts.assertNotNull( temporalValidationTolerance, MESSAGES.parameterMustNotBeNull( "temporalValidationTolerance" ) );
+
+		this.temporalValidationTolerance = temporalValidationTolerance.abs();
+		return this;
+	}
+
 	public boolean isAllowParallelMethodsDefineParameterConstraints() {
 		return this.methodValidationConfigurationBuilder.isAllowParallelMethodsDefineParameterConstraints();
 	}
@@ -421,6 +431,10 @@ public class ConfigurationImpl implements HibernateValidatorConfiguration, Confi
 
 	public ScriptEvaluatorFactory getScriptEvaluatorFactory() {
 		return scriptEvaluatorFactory;
+	}
+
+	public Duration getTemporalValidationTolerance() {
+		return temporalValidationTolerance;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine;
 
 import java.lang.invoke.MethodHandles;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,6 +46,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 	private ExecutableParameterNameProvider parameterNameProvider;
 	private ClockProvider clockProvider;
 	private ScriptEvaluatorFactory scriptEvaluatorFactory;
+	private Duration temporalValidationTolerance;
 	private boolean failFast;
 	private boolean traversableResolverResultCacheEnabled;
 	private final ValueExtractorManager valueExtractorManager;
@@ -59,6 +61,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 		this.parameterNameProvider = validatorFactory.getExecutableParameterNameProvider();
 		this.clockProvider = validatorFactory.getClockProvider();
 		this.scriptEvaluatorFactory = validatorFactory.getScriptEvaluatorFactory();
+		this.temporalValidationTolerance = validatorFactory.getTemporalValidationTolerance();
 		this.failFast = validatorFactory.isFailFast();
 		this.traversableResolverResultCacheEnabled = validatorFactory.isTraversableResolverResultCacheEnabled();
 		this.methodValidationConfigurationBuilder = new MethodValidationConfiguration.Builder( validatorFactory.getMethodValidationConfiguration() );
@@ -173,6 +176,7 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 				clockProvider,
 				scriptEvaluatorFactory,
 				failFast,
+				temporalValidationTolerance,
 				valueExtractorDescriptors.isEmpty() ? valueExtractorManager : new ValueExtractorManager( valueExtractorManager, valueExtractorDescriptors ),
 				methodValidationConfigurationBuilder.build(),
 				traversableResolverResultCacheEnabled

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorContextImpl.java
@@ -167,6 +167,12 @@ public class ValidatorContextImpl implements HibernateValidatorContext {
 	}
 
 	@Override
+	public HibernateValidatorContext temporalValidationTolerance(Duration temporalValidationTolerance) {
+		this.temporalValidationTolerance = temporalValidationTolerance == null ? Duration.ZERO : temporalValidationTolerance.abs();
+		return this;
+	}
+
+	@Override
 	public Validator getValidator() {
 		return validatorFactory.createValidator(
 				constraintValidatorFactory,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -13,6 +13,7 @@ import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -92,6 +93,12 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 	 * Provider for the current time when validating {@code @Future} or {@code @Past}
 	 */
 	private final ClockProvider clockProvider;
+
+	/**
+	 * Defines the temporal validation tolerance i.e. the allowed margin of error when comparing date/time in temporal
+	 * constraints.
+	 */
+	private final Duration temporalValidationTolerance;
 
 	/**
 	 * Used to get the {@code ScriptEvaluatorFactory} when validating {@code @ScriptAssert} and
@@ -259,6 +266,8 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 
 		this.scriptEvaluatorFactory = getScriptEvaluatorFactory( configurationState, properties, externalClassLoader );
 
+		this.temporalValidationTolerance = getTemporalValidationTolerance( configurationState, properties );
+
 		if ( LOG.isDebugEnabled() ) {
 			logValidatorFactoryScopedConfiguration( configurationState, this.scriptEvaluatorFactory.getClass() );
 		}
@@ -311,6 +320,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 				clockProvider,
 				scriptEvaluatorFactory,
 				failFast,
+				temporalValidationTolerance,
 				valueExtractorManager,
 				methodValidationConfiguration,
 				traversableResolverResultCacheEnabled
@@ -349,6 +359,11 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 	@Override
 	public ScriptEvaluatorFactory getScriptEvaluatorFactory() {
 		return scriptEvaluatorFactory;
+	}
+
+	@Override
+	public Duration getTemporalValidationTolerance() {
+		return temporalValidationTolerance;
 	}
 
 	public boolean isFailFast() {
@@ -398,6 +413,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 			ClockProvider clockProvider,
 			ScriptEvaluatorFactory scriptEvaluatorFactory,
 			boolean failFast,
+			Duration temporalValidationTolerance,
 			ValueExtractorManager valueExtractorManager,
 			MethodValidationConfiguration methodValidationConfiguration,
 			boolean traversableResolverResultCacheEnabled) {
@@ -430,7 +446,8 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 				constraintValidatorManager,
 				validationOrderGenerator,
 				failFast,
-				traversableResolverResultCacheEnabled
+				traversableResolverResultCacheEnabled,
+				temporalValidationTolerance
 		);
 	}
 
@@ -533,6 +550,30 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		}
 
 		return new DefaultScriptEvaluatorFactory( externalClassLoader );
+	}
+
+	private Duration getTemporalValidationTolerance(ConfigurationState configurationState, Map<String, String> properties) {
+		if ( configurationState instanceof ConfigurationImpl ) {
+			ConfigurationImpl hibernateSpecificConfig = (ConfigurationImpl) configurationState;
+			if ( hibernateSpecificConfig.getTemporalValidationTolerance() != null ) {
+				LOG.logTemporalValidationTolerance( hibernateSpecificConfig.getTemporalValidationTolerance() );
+				return hibernateSpecificConfig.getTemporalValidationTolerance();
+			}
+		}
+		String temporalValidationToleranceProperty = properties.get( HibernateValidatorConfiguration.TEMPORAL_VALIDATION_TOLERANCE );
+		if ( temporalValidationToleranceProperty != null ) {
+			try {
+				Duration tolerance = Duration.ofMillis( Long.parseLong( temporalValidationToleranceProperty ) ).abs();
+				LOG.logTemporalValidationTolerance( tolerance );
+				return tolerance;
+			}
+			catch (Exception e) {
+				throw LOG.getUnableToParseTemporalValidationToleranceException( temporalValidationToleranceProperty, e );
+			}
+		}
+
+		LOG.logTemporalValidationTolerance( Duration.ZERO );
+		return Duration.ZERO;
 	}
 
 	private static void registerCustomConstraintValidators(Set<DefaultConstraintMapping> constraintMappings,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -179,7 +179,8 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		this.validationOrderGenerator = validationOrderGenerator;
 		this.failFast = failFast;
 		this.traversableResolverResultCacheEnabled = traversableResolverResultCacheEnabled;
-		this.constraintValidatorInitializationContext = new HibernateConstraintValidatorInitializationContextImpl( scriptEvaluatorFactory, temporalValidationTolerance );
+		this.constraintValidatorInitializationContext = new HibernateConstraintValidatorInitializationContextImpl( scriptEvaluatorFactory, clockProvider,
+				temporalValidationTolerance );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -14,6 +14,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -165,7 +166,8 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 			ConstraintValidatorManager constraintValidatorManager,
 			ValidationOrderGenerator validationOrderGenerator,
 			boolean failFast,
-			boolean traversableResolverResultCacheEnabled) {
+			boolean traversableResolverResultCacheEnabled,
+			Duration temporalValidationTolerance) {
 		this.constraintValidatorFactory = constraintValidatorFactory;
 		this.messageInterpolator = messageInterpolator;
 		this.traversableResolver = traversableResolver;
@@ -177,7 +179,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		this.validationOrderGenerator = validationOrderGenerator;
 		this.failFast = failFast;
 		this.traversableResolverResultCacheEnabled = traversableResolverResultCacheEnabled;
-		this.constraintValidatorInitializationContext = new HibernateConstraintValidatorInitializationContextImpl( scriptEvaluatorFactory );
+		this.constraintValidatorInitializationContext = new HibernateConstraintValidatorInitializationContextImpl( scriptEvaluatorFactory, temporalValidationTolerance );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.constraintvalidation;
 
+import java.time.Duration;
+
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.spi.scripting.ScriptEvaluator;
 import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
@@ -17,12 +19,20 @@ public class HibernateConstraintValidatorInitializationContextImpl implements Hi
 
 	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
 
-	public HibernateConstraintValidatorInitializationContextImpl(ScriptEvaluatorFactory scriptEvaluatorFactory) {
+	private final Duration temporalValidationTolerance;
+
+	public HibernateConstraintValidatorInitializationContextImpl(ScriptEvaluatorFactory scriptEvaluatorFactory, Duration temporalValidationTolerance) {
 		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
+		this.temporalValidationTolerance = temporalValidationTolerance;
 	}
 
 	@Override
 	public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
 		return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
+	}
+
+	@Override
+	public Duration getTemporalValidationTolerance() {
+		return temporalValidationTolerance;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
@@ -8,6 +8,8 @@ package org.hibernate.validator.internal.engine.constraintvalidation;
 
 import java.time.Duration;
 
+import javax.validation.ClockProvider;
+
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.spi.scripting.ScriptEvaluator;
 import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
@@ -19,16 +21,25 @@ public class HibernateConstraintValidatorInitializationContextImpl implements Hi
 
 	private final ScriptEvaluatorFactory scriptEvaluatorFactory;
 
+	private final ClockProvider clockProvider;
+
 	private final Duration temporalValidationTolerance;
 
-	public HibernateConstraintValidatorInitializationContextImpl(ScriptEvaluatorFactory scriptEvaluatorFactory, Duration temporalValidationTolerance) {
+	public HibernateConstraintValidatorInitializationContextImpl(ScriptEvaluatorFactory scriptEvaluatorFactory, ClockProvider clockProvider,
+			Duration temporalValidationTolerance) {
 		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
+		this.clockProvider = clockProvider;
 		this.temporalValidationTolerance = temporalValidationTolerance;
 	}
 
 	@Override
 	public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
 		return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
+	}
+
+	@Override
+	public ClockProvider getClockProvider() {
+		return clockProvider;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -50,6 +51,7 @@ import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.util.logging.formatter.ClassObjectFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.CollectionOfClassesObjectFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.CollectionOfObjectsToStringFormatter;
+import org.hibernate.validator.internal.util.logging.formatter.DurationFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.ExecutableFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.ObjectArrayFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.TypeFormatter;
@@ -828,4 +830,11 @@ public interface Log extends BasicLogger {
 	@Message(id = 237, value = "Unable to access method %3$s of class %2$s with parameters %4$s using lookup %1$s.")
 	ValidationException getUnableToAccessMethodException(Lookup lookup, @FormatWith(ClassObjectFormatter.class) Class<?> clazz, String methodName,
 			@FormatWith(ObjectArrayFormatter.class) Object[] parameterTypes, @Cause Throwable e);
+
+	@LogMessage(level = INFO)
+	@Message(id = 238, value = "Temporal validation tolerance set to %1$s.")
+	void logTemporalValidationTolerance(@FormatWith(DurationFormatter.class) Duration tolerance);
+
+	@Message(id = 239, value = "Unable to parse the temporal validation tolerance property %s. It should be a duration represented in milliseconds.")
+	ValidationException getUnableToParseTemporalValidationToleranceException(String toleranceProperty, @Cause Exception e);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/formatter/DurationFormatter.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/formatter/DurationFormatter.java
@@ -1,0 +1,61 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.util.logging.formatter;
+
+import java.time.Duration;
+
+/**
+ * Used with JBoss Logging to display durations in log messages.
+ *
+ * @author Marko Bekhta
+ * @author Guillaume Smet
+ */
+public class DurationFormatter {
+
+	private final String stringRepresentation;
+
+	public DurationFormatter(Duration duration) {
+		if ( Duration.ZERO.equals( duration ) ) {
+			this.stringRepresentation = "0";
+		}
+		else {
+			long seconds = duration.getSeconds();
+			long days = seconds / ( 24 * 3_600 );
+			long hours = seconds / 3_600 % 24;
+			long minutes = seconds / 60 % 60;
+			int millis = duration.getNano() / 1_000_000;
+			int nanos = duration.getNano() % 1_000_000;
+
+			StringBuilder formattedDuration = new StringBuilder();
+			appendTimeUnit( formattedDuration, days, "days", "day" );
+			appendTimeUnit( formattedDuration, hours, "hours", "hour" );
+			appendTimeUnit( formattedDuration, minutes, "minutes", "minute" );
+			appendTimeUnit( formattedDuration, seconds % 60, "seconds", "second" );
+			appendTimeUnit( formattedDuration, millis, "milliseconds", "millisecond" );
+			appendTimeUnit( formattedDuration, nanos, "nanoseconds", "nanosecond" );
+
+			this.stringRepresentation = formattedDuration.toString();
+		}
+	}
+
+	private void appendTimeUnit(StringBuilder sb, long number, String pluralLabel, String singularLabel) {
+		if ( number == 0 ) {
+			return;
+		}
+		if ( sb.length() > 0 ) {
+			sb.append( " " );
+		}
+		sb.append( number )
+				.append( " " )
+				.append( number == 1 ? singularLabel : pluralLabel );
+	}
+
+	@Override
+	public String toString() {
+		return stringRepresentation;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/TemporalValidationToleranceTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/time/TemporalValidationToleranceTest.java
@@ -1,0 +1,440 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.constraintvalidators.bv.time;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.chrono.HijrahDate;
+import java.time.chrono.JapaneseDate;
+import java.time.chrono.MinguoDate;
+import java.time.chrono.ThaiBuddhistDate;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import javax.validation.Validator;
+import javax.validation.constraints.Future;
+import javax.validation.constraints.FutureOrPresent;
+import javax.validation.constraints.Past;
+import javax.validation.constraints.PastOrPresent;
+
+import org.hibernate.validator.testutil.TestForIssue;
+import org.joda.time.ReadableInstant;
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ * @author Guillaume Smet
+ */
+@TestForIssue(jiraKey = "HV-1493")
+public class TemporalValidationToleranceTest {
+
+	@Test
+	public void testFutureTolerance() throws Exception {
+		ZonedDateTime reference = ZonedDateTime.of( 2017, 1, 1, 0, 0, 7, 0, ZoneId.systemDefault() );
+		FutureDummyEntity entity = new FutureDummyEntity( reference.minus( Duration.ofSeconds( 5 ) ) );
+
+		Validator validator = getNoTemporalValidationToleranceValidator( reference );
+
+		assertThat( validator.validate( entity ) ).containsOnlyViolations(
+				violationOf( Future.class ).withProperty( "calendar" ),
+				violationOf( Future.class ).withProperty( "date" ),
+				violationOf( Future.class ).withProperty( "hijrahDate" ),
+				violationOf( Future.class ).withProperty( "instant" ),
+				violationOf( Future.class ).withProperty( "japaneseDate" ),
+				violationOf( Future.class ).withProperty( "localDate" ),
+				violationOf( Future.class ).withProperty( "localDateTime" ),
+				violationOf( Future.class ).withProperty( "minguoDate" ),
+				violationOf( Future.class ).withProperty( "offsetDateTime" ),
+				violationOf( Future.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( Future.class ).withProperty( "year" ),
+				violationOf( Future.class ).withProperty( "yearMonth" ),
+				violationOf( Future.class ).withProperty( "zonedDateTime" ),
+				violationOf( Future.class ).withProperty( "readableInstant" )
+		);
+
+		validator = getTenSecondsTemporalValidationToleranceValidator( reference );
+
+		assertNoViolations( validator.validate( entity ) );
+	}
+
+	@Test
+	public void testFutureOrPresentTolerance() throws Exception {
+		ZonedDateTime reference = ZonedDateTime.of( 2017, 1, 1, 0, 0, 7, 0, ZoneId.systemDefault() );
+		FutureOrPresentDummyEntity entity = new FutureOrPresentDummyEntity( reference.minus( Duration.ofDays( 600 ) ) );
+
+		Validator validator = getNoTemporalValidationToleranceValidator( reference );
+
+		assertThat( validator.validate( entity ) ).containsOnlyViolations(
+				violationOf( FutureOrPresent.class ).withProperty( "calendar" ),
+				violationOf( FutureOrPresent.class ).withProperty( "date" ),
+				violationOf( FutureOrPresent.class ).withProperty( "hijrahDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "instant" ),
+				violationOf( FutureOrPresent.class ).withProperty( "japaneseDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "localDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "localDateTime" ),
+				violationOf( FutureOrPresent.class ).withProperty( "minguoDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "offsetDateTime" ),
+				violationOf( FutureOrPresent.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( FutureOrPresent.class ).withProperty( "year" ),
+				violationOf( FutureOrPresent.class ).withProperty( "yearMonth" ),
+				violationOf( FutureOrPresent.class ).withProperty( "zonedDateTime" ),
+				violationOf( FutureOrPresent.class ).withProperty( "readableInstant" )
+		);
+
+		validator = get2YearsTemporalValidationToleranceValidator( reference );
+
+		assertNoViolations( validator.validate( entity ) );
+	}
+
+	@Test
+	public void testPastTolerance() throws Exception {
+		ZonedDateTime reference = ZonedDateTime.of( 2017, 12, 31, 23, 59, 53, 0, ZoneId.systemDefault() );
+		PastDummyEntity entity = new PastDummyEntity( reference.plus( Duration.ofSeconds( 5 ) ) );
+
+		Validator validator = getNoTemporalValidationToleranceValidator( reference );
+
+		assertThat( validator.validate( entity ) ).containsOnlyViolations(
+				violationOf( Past.class ).withProperty( "calendar" ),
+				violationOf( Past.class ).withProperty( "date" ),
+				violationOf( Past.class ).withProperty( "hijrahDate" ),
+				violationOf( Past.class ).withProperty( "instant" ),
+				violationOf( Past.class ).withProperty( "japaneseDate" ),
+				violationOf( Past.class ).withProperty( "localDate" ),
+				violationOf( Past.class ).withProperty( "localDateTime" ),
+				violationOf( Past.class ).withProperty( "minguoDate" ),
+				violationOf( Past.class ).withProperty( "offsetDateTime" ),
+				violationOf( Past.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( Past.class ).withProperty( "year" ),
+				violationOf( Past.class ).withProperty( "yearMonth" ),
+				violationOf( Past.class ).withProperty( "zonedDateTime" ),
+				violationOf( Past.class ).withProperty( "readableInstant" )
+		);
+
+		validator = getTenSecondsTemporalValidationToleranceValidator( reference );
+
+		assertNoViolations( validator.validate( entity ) );
+	}
+
+	@Test
+	public void testPastOrPresentTolerance() throws Exception {
+		ZonedDateTime reference = ZonedDateTime.of( 2017, 1, 1, 0, 0, 7, 0, ZoneId.systemDefault() );
+		PastOrPresentDummyEntity entity = new PastOrPresentDummyEntity( reference.plus( Duration.ofDays( 600 ) ) );
+
+		Validator validator = getNoTemporalValidationToleranceValidator( reference );
+
+		assertThat( validator.validate( entity ) ).containsOnlyViolations(
+				violationOf( PastOrPresent.class ).withProperty( "calendar" ),
+				violationOf( PastOrPresent.class ).withProperty( "date" ),
+				violationOf( PastOrPresent.class ).withProperty( "hijrahDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "instant" ),
+				violationOf( PastOrPresent.class ).withProperty( "japaneseDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "localDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "localDateTime" ),
+				violationOf( PastOrPresent.class ).withProperty( "minguoDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "offsetDateTime" ),
+				violationOf( PastOrPresent.class ).withProperty( "thaiBuddhistDate" ),
+				violationOf( PastOrPresent.class ).withProperty( "year" ),
+				violationOf( PastOrPresent.class ).withProperty( "yearMonth" ),
+				violationOf( PastOrPresent.class ).withProperty( "zonedDateTime" ),
+				violationOf( PastOrPresent.class ).withProperty( "readableInstant" )
+		);
+
+		validator = get2YearsTemporalValidationToleranceValidator( reference );
+
+		assertNoViolations( validator.validate( entity ) );
+	}
+
+	private Validator getNoTemporalValidationToleranceValidator(ZonedDateTime reference) {
+		return getConfiguration()
+				.clockProvider( () -> Clock.fixed( reference.toInstant(), reference.getZone() ) )
+				.buildValidatorFactory().getValidator();
+	}
+
+	private Validator getTenSecondsTemporalValidationToleranceValidator(ZonedDateTime reference) {
+		return getConfiguration()
+				.temporalValidationTolerance( Duration.ofSeconds( 10 ) )
+				.clockProvider( () -> Clock.fixed( reference.toInstant(), reference.getZone() ) )
+				.buildValidatorFactory().getValidator();
+	}
+
+	private Validator get2YearsTemporalValidationToleranceValidator(ZonedDateTime reference) {
+		return getConfiguration()
+				.temporalValidationTolerance( Duration.ofDays( 365 * 2 ) )
+				.clockProvider( () -> Clock.fixed( reference.toInstant(), reference.getZone() ) )
+				.buildValidatorFactory().getValidator();
+	}
+
+	private static class FutureDummyEntity {
+
+		@Future
+		private Calendar calendar;
+
+		@Future
+		private Date date;
+
+		@Future
+		private HijrahDate hijrahDate;
+
+		@Future
+		private Instant instant;
+
+		@Future
+		private JapaneseDate japaneseDate;
+
+		@Future
+		private LocalDate localDate;
+
+		@Future
+		private LocalDateTime localDateTime;
+
+		@Future
+		private MinguoDate minguoDate;
+
+		@Future
+		private OffsetDateTime offsetDateTime;
+
+		@Future
+		private ThaiBuddhistDate thaiBuddhistDate;
+
+		@Future
+		private Year year;
+
+		@Future
+		private YearMonth yearMonth;
+
+		@Future
+		private ZonedDateTime zonedDateTime;
+
+		@Future
+		private ReadableInstant readableInstant;
+
+		public FutureDummyEntity(ZonedDateTime dateTime) {
+			calendar = GregorianCalendar.from( dateTime );
+			date = calendar.getTime();
+
+			instant = dateTime.toInstant();
+			localDateTime = dateTime.toLocalDateTime();
+
+			hijrahDate = HijrahDate.from( dateTime );
+			japaneseDate = JapaneseDate.from( dateTime );
+			localDate = LocalDate.from( dateTime );
+			minguoDate = MinguoDate.from( dateTime );
+			offsetDateTime = dateTime.toOffsetDateTime();
+			thaiBuddhistDate = ThaiBuddhistDate.from( dateTime );
+			year = Year.from( dateTime );
+			yearMonth = YearMonth.from( dateTime );
+			zonedDateTime = dateTime;
+			readableInstant = new org.joda.time.DateTime( dateTime.toEpochSecond() * 1_000 );
+		}
+	}
+
+	private static class FutureOrPresentDummyEntity {
+
+		@FutureOrPresent
+		private Calendar calendar;
+
+		@FutureOrPresent
+		private Date date;
+
+		@FutureOrPresent
+		private HijrahDate hijrahDate;
+
+		@FutureOrPresent
+		private Instant instant;
+
+		@FutureOrPresent
+		private JapaneseDate japaneseDate;
+
+		@FutureOrPresent
+		private LocalDate localDate;
+
+		@FutureOrPresent
+		private LocalDateTime localDateTime;
+
+		@FutureOrPresent
+		private MinguoDate minguoDate;
+
+		@FutureOrPresent
+		private OffsetDateTime offsetDateTime;
+
+		@FutureOrPresent
+		private ThaiBuddhistDate thaiBuddhistDate;
+
+		@FutureOrPresent
+		private Year year;
+
+		@FutureOrPresent
+		private YearMonth yearMonth;
+
+		@FutureOrPresent
+		private ZonedDateTime zonedDateTime;
+
+		@FutureOrPresent
+		private ReadableInstant readableInstant;
+
+		public FutureOrPresentDummyEntity(ZonedDateTime dateTime) {
+			calendar = GregorianCalendar.from( dateTime );
+			date = calendar.getTime();
+
+			instant = dateTime.toInstant();
+			localDateTime = dateTime.toLocalDateTime();
+
+			hijrahDate = HijrahDate.from( dateTime );
+			japaneseDate = JapaneseDate.from( dateTime );
+			localDate = LocalDate.from( dateTime );
+			minguoDate = MinguoDate.from( dateTime );
+			offsetDateTime = dateTime.toOffsetDateTime();
+			thaiBuddhistDate = ThaiBuddhistDate.from( dateTime );
+			year = Year.from( dateTime );
+			yearMonth = YearMonth.from( dateTime );
+			zonedDateTime = dateTime;
+			readableInstant = new org.joda.time.DateTime( dateTime.toEpochSecond() * 1_000 );
+		}
+	}
+
+	private static class PastDummyEntity {
+
+		@Past
+		private Calendar calendar;
+
+		@Past
+		private Date date;
+
+		@Past
+		private HijrahDate hijrahDate;
+
+		@Past
+		private Instant instant;
+
+		@Past
+		private JapaneseDate japaneseDate;
+
+		@Past
+		private LocalDate localDate;
+
+		@Past
+		private LocalDateTime localDateTime;
+
+		@Past
+		private MinguoDate minguoDate;
+
+		@Past
+		private OffsetDateTime offsetDateTime;
+
+		@Past
+		private ThaiBuddhistDate thaiBuddhistDate;
+
+		@Past
+		private Year year;
+
+		@Past
+		private YearMonth yearMonth;
+
+		@Past
+		private ZonedDateTime zonedDateTime;
+
+		@Past
+		private ReadableInstant readableInstant;
+
+		public PastDummyEntity(ZonedDateTime dateTime) {
+			calendar = GregorianCalendar.from( dateTime );
+			date = calendar.getTime();
+
+			instant = dateTime.toInstant();
+			localDateTime = dateTime.toLocalDateTime();
+
+			hijrahDate = HijrahDate.from( dateTime );
+			japaneseDate = JapaneseDate.from( dateTime );
+			localDate = LocalDate.from( dateTime );
+			minguoDate = MinguoDate.from( dateTime );
+			offsetDateTime = dateTime.toOffsetDateTime();
+			thaiBuddhistDate = ThaiBuddhistDate.from( dateTime );
+			year = Year.from( dateTime );
+			yearMonth = YearMonth.from( dateTime );
+			zonedDateTime = dateTime;
+			readableInstant = new org.joda.time.DateTime( dateTime.toEpochSecond() * 1_000 );
+		}
+	}
+
+	private static class PastOrPresentDummyEntity {
+
+		@PastOrPresent
+		private Calendar calendar;
+
+		@PastOrPresent
+		private Date date;
+
+		@PastOrPresent
+		private HijrahDate hijrahDate;
+
+		@PastOrPresent
+		private Instant instant;
+
+		@PastOrPresent
+		private JapaneseDate japaneseDate;
+
+		@PastOrPresent
+		private LocalDate localDate;
+
+		@PastOrPresent
+		private LocalDateTime localDateTime;
+
+		@PastOrPresent
+		private MinguoDate minguoDate;
+
+		@PastOrPresent
+		private OffsetDateTime offsetDateTime;
+
+		@PastOrPresent
+		private ThaiBuddhistDate thaiBuddhistDate;
+
+		@PastOrPresent
+		private Year year;
+
+		@PastOrPresent
+		private YearMonth yearMonth;
+
+		@PastOrPresent
+		private ZonedDateTime zonedDateTime;
+
+		@PastOrPresent
+		private ReadableInstant readableInstant;
+
+		public PastOrPresentDummyEntity(ZonedDateTime dateTime) {
+			calendar = GregorianCalendar.from( dateTime );
+			date = calendar.getTime();
+
+			instant = dateTime.toInstant();
+			localDateTime = dateTime.toLocalDateTime();
+
+			hijrahDate = HijrahDate.from( dateTime );
+			japaneseDate = JapaneseDate.from( dateTime );
+			localDate = LocalDate.from( dateTime );
+			minguoDate = MinguoDate.from( dateTime );
+			offsetDateTime = dateTime.toOffsetDateTime();
+			thaiBuddhistDate = ThaiBuddhistDate.from( dateTime );
+			year = Year.from( dateTime );
+			yearMonth = YearMonth.from( dateTime );
+			zonedDateTime = dateTime;
+			readableInstant = new org.joda.time.DateTime( dateTime.toEpochSecond() * 1_000 );
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/DurationFormatterTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/DurationFormatterTest.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.hibernate.validator.internal.util.logging.formatter.DurationFormatter;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class DurationFormatterTest {
+
+	@Test
+	public void testDurationFormatting() throws Exception {
+		assertThat( new DurationFormatter( Duration.ZERO ).toString() ).isEqualTo( "0" );
+		assertThat( new DurationFormatter( Duration.ofSeconds( 62, 100 ) ).toString() ).isEqualTo( "1 minute 2 seconds 100 nanoseconds" );
+		assertThat( new DurationFormatter( Duration.ofHours( 49 ).plusSeconds( 121 ) ).toString() ).isEqualTo( "2 days 1 hour 2 minutes 1 second" );
+		assertThat( new DurationFormatter( Duration.ofDays( 1 ).plusHours( 10 ).plusMinutes( 15 ).plusSeconds( 20 ).plusMillis( 25 ) ).toString() )
+				.isEqualTo( "1 day 10 hours 15 minutes 20 seconds 25 milliseconds" );
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlMappingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlMappingTest.java
@@ -230,7 +230,7 @@ public class XmlMappingTest {
 	}
 
 	@Test
-	@TestForIssue( jiraKey = "HV-1463")
+	@TestForIssue(jiraKey = "HV-1463")
 	public void testScriptEvaluatorFactoryConfiguration() {
 		validationXmlTestHelper.runWithCustomValidationXml(
 				"script-evaluator-factory-validation.xml", () -> {
@@ -242,6 +242,25 @@ public class XmlMappingTest {
 					assertEquals(
 							bootstrapConfiguration.getProperties().get( HibernateValidatorConfiguration.SCRIPT_EVALUATOR_FACTORY_CLASSNAME ),
 							CustomScriptEvaluatorFactory.class.getName()
+					);
+
+				}
+		);
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1493")
+	public void testTemporalValidationToleranceConfiguration() {
+		validationXmlTestHelper.runWithCustomValidationXml(
+				"temporal-validation-tolerance-duration-validation.xml", () -> {
+					//given
+					BootstrapConfiguration bootstrapConfiguration = ValidatorUtil.getConfiguration()
+							.getBootstrapConfiguration();
+
+					//then
+					assertEquals(
+							bootstrapConfiguration.getProperties().get( HibernateValidatorConfiguration.TEMPORAL_VALIDATION_TOLERANCE ),
+							"123456"
 					);
 
 				}

--- a/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
+++ b/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
@@ -9,10 +9,12 @@ package org.hibernate.validator.testutils;
 import java.lang.annotation.Annotation;
 import java.time.Duration;
 
+import javax.validation.ClockProvider;
 import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
+import org.hibernate.validator.internal.engine.DefaultClockProvider;
 import org.hibernate.validator.internal.engine.scripting.DefaultScriptEvaluatorFactory;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
@@ -35,6 +37,11 @@ public class ConstraintValidatorInitializationHelper {
 		@Override
 		public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
 			return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
+		}
+
+		@Override
+		public ClockProvider getClockProvider() {
+			return DefaultClockProvider.INSTANCE;
 		}
 
 		@Override

--- a/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
+++ b/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.testutils;
 
 import java.lang.annotation.Annotation;
+import java.time.Duration;
 
 import javax.validation.metadata.ConstraintDescriptor;
 
@@ -34,6 +35,11 @@ public class ConstraintValidatorInitializationHelper {
 		@Override
 		public ScriptEvaluator getScriptEvaluatorForLanguage(String languageName) {
 			return scriptEvaluatorFactory.getScriptEvaluatorByLanguageName( languageName );
+		}
+
+		@Override
+		public Duration getTemporalValidationTolerance() {
+			return Duration.ZERO;
 		}
 	};
 

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/temporal-validation-tolerance-duration-validation.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/temporal-validation-tolerance-duration-validation.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<validation-config
+        xmlns="http://xmlns.jcp.org/xml/ns/validation/configuration"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/configuration
+            http://xmlns.jcp.org/xml/ns/validation/configuration/validation-configuration-2.0.xsd"
+        version="2.0">
+
+    <property name="hibernate.validator.temporal_validation_tolerance">123456</property>
+</validation-config>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1493

@marko-bekhta @danielwegener

So here is my attempt at tackling the clock skew tolerance issue after my discussion with Daniel.

I think it now works as expected with very minimal changes to the validators.

@marko-bekhta it's based on what you did and it includes the fact that the `Clock` is now defined at initialization time. After giving it some thoughts, I don't see an issue with it, even spec-wise.

Feedback welcome.