### PR TITLE
HV-1497 Call both initialize() methods of HibernateConstraintValidator

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidator.java
@@ -29,14 +29,13 @@ public interface HibernateConstraintValidator<A extends Annotation, T> extends C
 	 * It is an alternative to {@link #initialize(Annotation)} method. Should be used if any additional information
 	 * except annotation is needed to initialize a validator.
 	 * Note, when using {@link HibernateConstraintValidator} user should only override one of the methods, either
-	 * {@link #initialize(Annotation)} or {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)}.
-	 * It is guaranteed that in the case of a {@link HibernateConstraintValidator}, only
-	 * {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)} is called during initialization.
+	 * {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)} or {@link #initialize(Annotation)}.
+	 * Both methods will be called during initialization, starting with
+	 * {@link #initialize(ConstraintDescriptor, HibernateConstraintValidatorInitializationContext)}.
 	 *
 	 * @param constraintDescriptor a constraint descriptor for a given constraint declaration
 	 * @param initializationContext an initialization context for a current {@link ConstraintValidatorFactory}
 	 */
 	default void initialize(ConstraintDescriptor<A> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
-		initialize( constraintDescriptor.getAnnotation() );
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
@@ -240,9 +240,7 @@ public class ConstraintValidatorManager {
 			if ( constraintValidator instanceof HibernateConstraintValidator ) {
 				( (HibernateConstraintValidator<A, ?>) constraintValidator ).initialize( descriptor, initializationContext );
 			}
-			else {
-				constraintValidator.initialize( descriptor.getAnnotation() );
-			}
+			constraintValidator.initialize( descriptor.getAnnotation() );
 		}
 		catch (RuntimeException e) {
 			if ( e instanceof ConstraintDeclarationException ) {

--- a/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
+++ b/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
@@ -61,7 +61,9 @@ public class ConstraintValidatorInitializationHelper {
 			ConstraintAnnotationDescriptor<A> annotationDescriptor,
 			HibernateConstraintValidatorInitializationContext initializationContext
 	) {
-		constraintValidator.initialize( descriptorFrom( annotationDescriptor ), initializationContext );
+		ConstraintDescriptor<A> constraintDescriptor = descriptorFrom( annotationDescriptor );
+		constraintValidator.initialize( constraintDescriptor, initializationContext );
+		constraintValidator.initialize( constraintDescriptor.getAnnotation() );
 	}
 
 	public static HibernateConstraintValidatorInitializationContext getDummyConstraintValidatorInitializationContext() {


### PR DESCRIPTION
We used to call only one and cascade to the other with a default method
but it's easier to call both.