### PR TITLE
HV-1522 Improve performance of CV hashCode method

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConstraintViolationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConstraintViolationImpl.java
@@ -278,28 +278,25 @@ public class ConstraintViolationImpl<T> implements HibernateConstraintViolation<
 		if ( interpolatedMessage != null ? !interpolatedMessage.equals( that.interpolatedMessage ) : that.interpolatedMessage != null ) {
 			return false;
 		}
+		if ( messageTemplate != null ? !messageTemplate.equals( that.messageTemplate ) : that.messageTemplate != null ) {
+			return false;
+		}
 		if ( propertyPath != null ? !propertyPath.equals( that.propertyPath ) : that.propertyPath != null ) {
 			return false;
 		}
-		if ( rootBean != null ? !rootBean.equals( that.rootBean ) : that.rootBean != null ) {
+		if ( rootBean != null ? ( rootBean != that.rootBean ) : that.rootBean != null ) {
 			return false;
 		}
-		if ( leafBeanInstance != null ? !leafBeanInstance.equals( that.leafBeanInstance ) : that.leafBeanInstance != null ) {
+		if ( leafBeanInstance != null ? ( leafBeanInstance != that.leafBeanInstance ) : that.leafBeanInstance != null ) {
+			return false;
+		}
+		if ( value != null ? ( value != that.value ) : that.value != null ) {
 			return false;
 		}
 		if ( constraintDescriptor != null ? !constraintDescriptor.equals( that.constraintDescriptor ) : that.constraintDescriptor != null ) {
 			return false;
 		}
 		if ( elementType != null ? !elementType.equals( that.elementType ) : that.elementType != null ) {
-			return false;
-		}
-		if ( messageTemplate != null ? !messageTemplate.equals( that.messageTemplate ) : that.messageTemplate != null ) {
-			return false;
-		}
-		if ( rootBeanClass != null ? !rootBeanClass.equals( that.rootBeanClass ) : that.rootBeanClass != null ) {
-			return false;
-		}
-		if ( value != null ? !value.equals( that.value ) : that.value != null ) {
 			return false;
 		}
 
@@ -334,7 +331,6 @@ public class ConstraintViolationImpl<T> implements HibernateConstraintViolation<
 		result = 31 * result + System.identityHashCode( value );
 		result = 31 * result + ( constraintDescriptor != null ? constraintDescriptor.hashCode() : 0 );
 		result = 31 * result + ( messageTemplate != null ? messageTemplate.hashCode() : 0 );
-		result = 31 * result + ( rootBeanClass != null ? rootBeanClass.hashCode() : 0 );
 		result = 31 * result + ( elementType != null ? elementType.hashCode() : 0 );
 		return result;
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/MessageInterpolatorContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/MessageInterpolatorContext.java
@@ -101,7 +101,7 @@ public class MessageInterpolatorContext implements HibernateMessageInterpolatorC
 		if ( rootBeanType != null ? !rootBeanType.equals( that.rootBeanType ) : that.rootBeanType != null ) {
 			return false;
 		}
-		if ( validatedValue != null ? !validatedValue.equals( that.validatedValue ) : that.validatedValue != null ) {
+		if ( validatedValue != null ? ( validatedValue != that.validatedValue ) : that.validatedValue != null ) {
 			return false;
 		}
 
@@ -111,7 +111,7 @@ public class MessageInterpolatorContext implements HibernateMessageInterpolatorC
 	@Override
 	public int hashCode() {
 		int result = constraintDescriptor != null ? constraintDescriptor.hashCode() : 0;
-		result = 31 * result + ( validatedValue != null ? validatedValue.hashCode() : 0 );
+		result = 31 * result + System.identityHashCode( validatedValue );
 		result = 31 * result + ( rootBeanType != null ? rootBeanType.hashCode() : 0 );
 		return result;
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/resolver/AbstractTraversableHolder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/resolver/AbstractTraversableHolder.java
@@ -31,7 +31,7 @@ abstract class AbstractTraversableHolder {
 
 		AbstractTraversableHolder that = (AbstractTraversableHolder) o;
 
-		if ( traversableObject != null ? !traversableObject.equals( that.traversableObject ) : that.traversableObject != null ) {
+		if ( traversableObject != null ? ( traversableObject != that.traversableObject ) : that.traversableObject != null ) {
 			return false;
 		}
 		if ( !traversableProperty.equals( that.traversableProperty ) ) {

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/AbstractMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/AbstractMessageInterpolator.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.messageinterpolation;
 
+import static org.hibernate.validator.internal.util.ConcurrentReferenceHashMap.ReferenceType.SOFT;
+
 import java.lang.invoke.MethodHandles;
 import java.util.EnumSet;
 import java.util.List;
@@ -30,8 +32,6 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
 
-import static org.hibernate.validator.internal.util.ConcurrentReferenceHashMap.ReferenceType.SOFT;
-
 /**
  * Resource bundle backed message interpolator.
  *
@@ -39,6 +39,7 @@ import static org.hibernate.validator.internal.util.ConcurrentReferenceHashMap.R
  * @author Hardy Ferentschik
  * @author Gunnar Morling
  * @author Adam Stawicki
+ * @author Marko Bekhta
  *
  * @since 5.2
  */
@@ -238,9 +239,9 @@ public abstract class AbstractMessageInterpolator implements MessageInterpolator
 
 	/**
 	 * Runs the message interpolation according to algorithm specified in the Bean Validation specification.
-	 * <br/>
+	 * <p>
 	 * Note:
-	 * <br/>
+	 * <p>
 	 * Look-ups in user bundles is recursive whereas look-ups in default bundle are not!
 	 *
 	 * @param message the message to interpolate
@@ -249,105 +250,34 @@ public abstract class AbstractMessageInterpolator implements MessageInterpolator
 	 *
 	 * @return the interpolated message.
 	 */
-	private String interpolateMessage(String message, Context context, Locale locale)
-			throws MessageDescriptorFormatException {
-		LocalizedMessage localisedMessage = new LocalizedMessage( message, locale );
+	private String interpolateMessage(String message, Context context, Locale locale) throws MessageDescriptorFormatException {
 		String resolvedMessage = null;
 
+		// either retrieve message from cache, or if message is not yet there or caching is disabled,
+		// perform message resolution algorithm (step 1)
 		if ( cachingEnabled ) {
-			resolvedMessage = resolvedMessages.get( localisedMessage );
+			resolvedMessage = resolvedMessages.computeIfAbsent( new LocalizedMessage( message, locale ), lm -> resolveMessage( message, locale ) );
+		}
+		else {
+			resolvedMessage = resolveMessage( message, locale );
 		}
 
-		// if the message is not already in the cache we have to run step 1-3 of the message resolution
-		if ( resolvedMessage == null ) {
-			ResourceBundle userResourceBundle = userResourceBundleLocator
-					.getResourceBundle( locale );
+		// there's no need for steps 2-3 unless there's `{param}`/`${expr}` in the message
+		if ( resolvedMessage.indexOf( '{' ) > -1 ) {
+			// resolve parameter expressions (step 2)
+			resolvedMessage = interpolateExpression(
+					new TokenIterator( getParameterTokens( resolvedMessage, tokenizedParameterMessages, InterpolationTermType.PARAMETER ) ),
+					context,
+					locale
+			);
 
-			ResourceBundle constraintContributorResourceBundle = contributorResourceBundleLocator
-					.getResourceBundle( locale );
-
-			ResourceBundle defaultResourceBundle = defaultResourceBundleLocator
-					.getResourceBundle( locale );
-
-			String userBundleResolvedMessage;
-			resolvedMessage = message;
-			boolean evaluatedDefaultBundleOnce = false;
-			do {
-				// search the user bundle recursive (step1)
-				userBundleResolvedMessage = interpolateBundleMessage(
-						resolvedMessage, userResourceBundle, locale, true
-				);
-
-				// search the constraint contributor bundle recursive (only if the user did not define a message)
-				if ( !hasReplacementTakenPlace( userBundleResolvedMessage, resolvedMessage ) ) {
-					userBundleResolvedMessage = interpolateBundleMessage(
-							resolvedMessage, constraintContributorResourceBundle, locale, true
-					);
-				}
-
-				// exit condition - we have at least tried to validate against the default bundle and there was no
-				// further replacements
-				if ( evaluatedDefaultBundleOnce
-						&& !hasReplacementTakenPlace( userBundleResolvedMessage, resolvedMessage ) ) {
-					break;
-				}
-
-				// search the default bundle non recursive (step2)
-				resolvedMessage = interpolateBundleMessage(
-						userBundleResolvedMessage,
-						defaultResourceBundle,
-						locale,
-						false
-				);
-				evaluatedDefaultBundleOnce = true;
-			} while ( true );
+			// resolve EL expressions (step 3)
+			resolvedMessage = interpolateExpression(
+					new TokenIterator( getParameterTokens( resolvedMessage, tokenizedELMessages, InterpolationTermType.EL ) ),
+					context,
+					locale
+			);
 		}
-
-		// cache resolved message
-		if ( cachingEnabled ) {
-			String cachedResolvedMessage = resolvedMessages.putIfAbsent( localisedMessage, resolvedMessage );
-			if ( cachedResolvedMessage != null ) {
-				resolvedMessage = cachedResolvedMessage;
-			}
-		}
-
-		// resolve parameter expressions (step 4)
-		List<Token> tokens = null;
-		if ( cachingEnabled ) {
-			tokens = tokenizedParameterMessages.get( resolvedMessage );
-		}
-		if ( tokens == null ) {
-			TokenCollector tokenCollector = new TokenCollector( resolvedMessage, InterpolationTermType.PARAMETER );
-			tokens = tokenCollector.getTokenList();
-
-			if ( cachingEnabled ) {
-				tokenizedParameterMessages.putIfAbsent( resolvedMessage, tokens );
-			}
-		}
-		resolvedMessage = interpolateExpression(
-				new TokenIterator( tokens ),
-				context,
-				locale
-		);
-
-		// resolve EL expressions (step 5)
-		tokens = null;
-		if ( cachingEnabled ) {
-			tokens = tokenizedELMessages.get( resolvedMessage );
-		}
-		if ( tokens == null ) {
-			TokenCollector tokenCollector = new TokenCollector( resolvedMessage, InterpolationTermType.EL );
-			tokens = tokenCollector.getTokenList();
-
-			if ( cachingEnabled ) {
-				tokenizedELMessages.putIfAbsent( resolvedMessage, tokens );
-			}
-		}
-		resolvedMessage = interpolateExpression(
-				new TokenIterator( tokens ),
-				context,
-				locale
-		);
 
 		// last but not least we have to take care of escaped literals
 		resolvedMessage = replaceEscapedLiterals( resolvedMessage );
@@ -355,11 +285,76 @@ public abstract class AbstractMessageInterpolator implements MessageInterpolator
 		return resolvedMessage;
 	}
 
+	private List<Token> getParameterTokens(String resolvedMessage, ConcurrentReferenceHashMap<String, List<Token>> cache, InterpolationTermType termType) {
+		if ( cachingEnabled ) {
+			return cache.computeIfAbsent(
+					resolvedMessage,
+					rm -> new TokenCollector( resolvedMessage, termType ).getTokenList()
+			);
+		}
+		else {
+			return new TokenCollector( resolvedMessage, termType ).getTokenList();
+		}
+	}
+
+	private String resolveMessage(String message, Locale locale) {
+		//if message does not contain something like "{message.key}" we can ignore next steps and just return the message
+		if ( message.indexOf( '{' ) < 0 ) {
+			return message;
+		}
+
+		String resolvedMessage = message;
+
+		ResourceBundle userResourceBundle = userResourceBundleLocator
+				.getResourceBundle( locale );
+
+		ResourceBundle constraintContributorResourceBundle = contributorResourceBundleLocator
+				.getResourceBundle( locale );
+
+		ResourceBundle defaultResourceBundle = defaultResourceBundleLocator
+				.getResourceBundle( locale );
+
+		String userBundleResolvedMessage;
+		boolean evaluatedDefaultBundleOnce = false;
+		do {
+			// search the user bundle recursive (step 1.1)
+			userBundleResolvedMessage = interpolateBundleMessage(
+					resolvedMessage, userResourceBundle, locale, true
+			);
+
+			// search the constraint contributor bundle recursive (only if the user did not define a message)
+			if ( !hasReplacementTakenPlace( userBundleResolvedMessage, resolvedMessage ) ) {
+				userBundleResolvedMessage = interpolateBundleMessage(
+						resolvedMessage, constraintContributorResourceBundle, locale, true
+				);
+			}
+
+			// exit condition - we have at least tried to validate against the default bundle and there was no
+			// further replacements
+			if ( evaluatedDefaultBundleOnce && !hasReplacementTakenPlace( userBundleResolvedMessage, resolvedMessage ) ) {
+				break;
+			}
+
+			// search the default bundle non recursive (step 1.2)
+			resolvedMessage = interpolateBundleMessage(
+					userBundleResolvedMessage,
+					defaultResourceBundle,
+					locale,
+					false
+			);
+			evaluatedDefaultBundleOnce = true;
+		} while ( true );
+
+		return resolvedMessage;
+	}
+
 	private String replaceEscapedLiterals(String resolvedMessage) {
-		resolvedMessage = LEFT_BRACE.matcher( resolvedMessage ).replaceAll( "{" );
-		resolvedMessage = RIGHT_BRACE.matcher( resolvedMessage ).replaceAll( "}" );
-		resolvedMessage = SLASH.matcher( resolvedMessage ).replaceAll( Matcher.quoteReplacement( "\\" ) );
-		resolvedMessage = DOLLAR.matcher( resolvedMessage ).replaceAll( Matcher.quoteReplacement( "$" ) );
+		if ( resolvedMessage.indexOf( '\\' ) > -1 ) {
+			resolvedMessage = LEFT_BRACE.matcher( resolvedMessage ).replaceAll( "{" );
+			resolvedMessage = RIGHT_BRACE.matcher( resolvedMessage ).replaceAll( "}" );
+			resolvedMessage = SLASH.matcher( resolvedMessage ).replaceAll( Matcher.quoteReplacement( "\\" ) );
+			resolvedMessage = DOLLAR.matcher( resolvedMessage ).replaceAll( Matcher.quoteReplacement( "$" ) );
+		}
 		return resolvedMessage;
 	}
 


### PR DESCRIPTION
So the problematic method turned out to be `System#identityHashCode()`. I gave it some thought and I think that we can skip evaluating those hashcodes. It will not break the hash/equals contract only might cause additional calls to equals. As for the equals method, I thought about two things 

- the order of those "if checks" is important so the less expensive checks should go first 
- using equals methods on value/rootBean/leafBeanInstance is probably not good. We don't know the implementation of those methods, hence their performance, as they are user defined. I think that for the CV it is enough to do == check instead. 

after such changes the profiling picture looks like this:
![hash_after_change](https://user-images.githubusercontent.com/4004823/32981071-ce0c3cde-cc72-11e7-9dd1-ac05a59c102b.png)
`ConstraintViolationImpl#hashCode` completely disappeared. And here are some results running the `SimpleValidation#testSimpleBeanValidation` before the change:
```
# Run complete. Total time: 00:00:37

Benchmark                                   Mode  Cnt    Score    Error   Units
SimpleValidation.testSimpleBeanValidation  thrpt   20  585.949 ± 42.153  ops/ms
```

and after:
```
# Run complete. Total time: 00:00:36

Benchmark                                   Mode  Cnt    Score    Error   Units
SimpleValidation.testSimpleBeanValidation  thrpt   20  657.163 ± 53.447  ops/ms
```
