### PR TITLE
HV-1537 Reintroduce ReflectionParameterNameProvider to avoid API breakage

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/Incubating.java
+++ b/engine/src/main/java/org/hibernate/validator/Incubating.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
@@ -18,6 +19,7 @@ import java.lang.annotation.RetentionPolicy;
  *
  * @author Gunnar Morling
  */
+@Documented
 @Retention(RetentionPolicy.CLASS)
 public @interface Incubating {
 }

--- a/engine/src/main/java/org/hibernate/validator/parameternameprovider/ReflectionParameterNameProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/parameternameprovider/ReflectionParameterNameProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.parameternameprovider;
+
+import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.List;
+
+import javax.validation.ParameterNameProvider;
+
+/**
+ * Uses Java 8 reflection to get the parameter names.
+ *
+ * <p>For this provider to return the actual parameter names, classes must be compiled with the '-parameters' compiler
+ * argument. Otherwise, the JDK will return synthetic names in the form {@code arg0}, {@code arg1}, etc.</p>
+ *
+ * <p>See also <a href="http://openjdk.java.net/jeps/118">JEP 118</a></p>
+ * @author Khalid Alqinyah
+ *
+ * @since 5.2
+ */
+public class ReflectionParameterNameProvider implements ParameterNameProvider {
+
+	@Override
+	public List<String> getParameterNames(Constructor<?> constructor) {
+		return getParameterNames( constructor.getParameters() );
+	}
+
+	@Override
+	public List<String> getParameterNames(Method method) {
+		return getParameterNames( method.getParameters() );
+	}
+
+	private List<String> getParameterNames(Parameter[] parameters) {
+		List<String> parameterNames = newArrayList();
+
+		for ( Parameter parameter : parameters ) {
+			// If '-parameters' is used at compile time, actual names will be returned. Otherwise, it will be arg0, arg1...
+			parameterNames.add( parameter.getName() );
+		}
+
+		return parameterNames;
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/parameternameprovider/ReflectionParameterNameProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/parameternameprovider/ReflectionParameterNameProvider.java
@@ -25,7 +25,9 @@ import javax.validation.ParameterNameProvider;
  * @author Khalid Alqinyah
  *
  * @since 5.2
+ * @deprecated since 6.0 - getting the parameter names via reflection is now enabled by default
  */
+@Deprecated
 public class ReflectionParameterNameProvider implements ParameterNameProvider {
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/parameternameprovider/ReflectionParameterNameProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/parameternameprovider/ReflectionParameterNameProvider.java
@@ -16,16 +16,9 @@ import java.util.List;
 import javax.validation.ParameterNameProvider;
 
 /**
- * Uses Java 8 reflection to get the parameter names.
- *
- * <p>For this provider to return the actual parameter names, classes must be compiled with the '-parameters' compiler
- * argument. Otherwise, the JDK will return synthetic names in the form {@code arg0}, {@code arg1}, etc.</p>
- *
- * <p>See also <a href="http://openjdk.java.net/jeps/118">JEP 118</a></p>
  * @author Khalid Alqinyah
- *
  * @since 5.2
- * @deprecated since 6.0 - getting the parameter names via reflection is now enabled by default
+ * @deprecated since 6.0 - getting the parameter names via reflection is now enabled by default. Planned for removal.
  */
 @Deprecated
 public class ReflectionParameterNameProvider implements ParameterNameProvider {

--- a/engine/src/test/java/org/hibernate/validator/test/parameternameprovider/ReflectionParameterNameProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/parameternameprovider/ReflectionParameterNameProviderTest.java
@@ -1,0 +1,109 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.parameternameprovider;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.validation.ParameterNameProvider;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import org.hibernate.validator.parameternameprovider.ReflectionParameterNameProvider;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests for {@link org.hibernate.validator.parameternameprovider.ReflectionParameterNameProvider}.
+ *
+ * @author Khalid Alqinyah
+ */
+public class ReflectionParameterNameProviderTest {
+
+	private ParameterNameProvider parameterNameProvider;
+
+	@BeforeClass
+	public void setup() {
+		parameterNameProvider = new ReflectionParameterNameProvider();
+	}
+
+	@Test
+	public void testConstructorParametersZeroParameters() throws Exception {
+		List<String> expected = Collections.emptyList();
+		List<String> actual = parameterNameProvider.getParameterNames( Foo.class.getConstructor() );
+		assertEquals( actual, expected, "Constructor with zero parameters does not match expected" );
+	}
+
+	@Test
+	public void testConstructorParametersOneParameter() throws Exception {
+		List<String> expected = Arrays.asList( "bar" );
+		List<String> actual = parameterNameProvider.getParameterNames( Foo.class.getConstructor( String.class ) );
+		assertEquals( actual, expected, "Constructor with one parameter does not match expected" );
+	}
+
+	@Test
+	public void testConstructorParametersTwoParameters() throws Exception {
+		List<String> expected = Arrays.asList( "bar", "baz" );
+		List<String> actual = parameterNameProvider.getParameterNames(
+				Foo.class.getConstructor(
+						String.class,
+						String.class
+				)
+		);
+		assertEquals( actual, expected, "Constructor with two parameters does not match expected" );
+	}
+
+	@Test
+	public void testMethodParametersZeroParameters() throws Exception {
+		List<String> expected = Collections.emptyList();
+		List<String> actual = parameterNameProvider.getParameterNames( Foo.class.getMethod( "foo" ) );
+		assertEquals( actual, expected, "Method with zero parameters does not match expected" );
+	}
+
+	@Test
+	public void testMethodParametersOneParameter() throws Exception {
+		List<String> expected = Arrays.asList( "bar" );
+		List<String> actual = parameterNameProvider.getParameterNames( Foo.class.getMethod( "foo", String.class ) );
+		assertEquals( actual, expected, "Method with one parameter does not match expected" );
+	}
+
+	@Test
+	public void testMethodParametersTwoParameters() throws Exception {
+		List<String> expected = Arrays.asList( "bar", "baz" );
+		List<String> actual = parameterNameProvider.getParameterNames(
+				Foo.class.getMethod(
+						"foo",
+						String.class,
+						String.class
+				)
+		);
+		assertEquals( actual, expected, "Method with two parameters does not match expected" );
+	}
+
+	@SuppressWarnings("unused")
+	private static class Foo {
+		public Foo() {
+		}
+
+		public Foo(String bar) {
+		}
+
+		public Foo(String bar, String baz) {
+		}
+
+		public void foo() {
+		}
+
+		public void foo(String bar) {
+		}
+
+		public void foo(String bar, String baz) {
+		}
+	}
+}
+


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1537
 * https://hibernate.atlassian.net/browse/HV-1538

I decided to mark it as deprecated so that we can imagine removing it at some point.