### PR TITLE
HV-1558 Put the distribution files to upload into distribution/target/dir so that release scripts find them

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -89,6 +89,19 @@
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-validator-modules</artifactId>
+            <classifier>wildfly-${wildfly.version}-patch</classifier>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-validator-modules</artifactId>
+            <classifier>wildfly-${wildfly-next.version}-patch</classifier>
+            <type>zip</type>
+        </dependency>
     </dependencies>
 
     <build>
@@ -154,6 +167,7 @@
                     </descriptors>
                     <finalName>hibernate-validator-${project.version}</finalName>
                     <tarLongFileMode>gnu</tarLongFileMode>
+                    <outputDirectory>${project.build.directory}/dist/</outputDirectory>
                 </configuration>
                 <executions>
                     <execution>
@@ -165,10 +179,29 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-jbossmodules-to-dist</id>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <phase>install</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/dist/</outputDirectory>
+                            <includeGroupIds>${project.groupId}</includeGroupIds>
+                            <includeArtifactIds>hibernate-validator-modules</includeArtifactIds>
+                            <includeTypes>zip</includeTypes>
+                            <excludeTransitive>true</excludeTransitive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>
-    <profile>
+        <profile>
             <id>jdk9</id>
             <activation>
                 <jdk>9</jdk>

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -11,7 +11,10 @@
     <formats>
         <format>tar.gz</format>
         <format>zip</format>
+        <!-- Uncomment the following line to simplify content inspection: -->
+        <!--
         <format>dir</format>
+        -->
     </formats>
 
     <!-- Configure the artifacts to include  -->

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,13 @@
                 <type>zip</type>
             </dependency>
             <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>hibernate-validator-modules</artifactId>
+                <version>${project.version}</version>
+                <classifier>wildfly-${wildfly-next.version}-patch</classifier>
+                <type>zip</type>
+            </dependency>
+            <dependency>
                 <groupId>javax.validation</groupId>
                 <artifactId>validation-api</artifactId>
                 <version>${bv.api.version}</version>


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HV-1558

See also https://github.com/hibernate/hibernate-noorm-release-scripts/pull/4 for more information about how this `dist` directory will be uploaded.

Note this also fixes an issue: the WildFly patch files were not being uploaded to Sourceforge. Now they will.