### PR TITLE
HV-1542 Reduce the number of calls to ReflectionHelper#getValue()

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/AbstractConstraintMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/AbstractConstraintMetaData.java
@@ -6,15 +6,12 @@
  */
 package org.hibernate.validator.internal.metadata.aggregated;
 
-import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
-
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -83,11 +80,6 @@ public abstract class AbstractConstraintMetaData implements ConstraintMetaData {
 	@Override
 	public Type getType() {
 		return type;
-	}
-
-	@Override
-	public Iterator<MetaConstraint<?>> iterator() {
-		return allMetaConstraintsByLocation.values().stream().flatMap( Set::stream ).iterator();
 	}
 
 	public Map<ConstraintLocation, Set<MetaConstraint<?>>> getAllConstraints() {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaData.java
@@ -9,6 +9,7 @@ package org.hibernate.validator.internal.metadata.aggregated;
 import java.lang.reflect.Executable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -17,6 +18,7 @@ import javax.validation.metadata.BeanDescriptor;
 import org.hibernate.validator.internal.engine.groups.Sequence;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.facets.Validatable;
+import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 
 /**
  * Interface defining the meta data about the constraints defined in a given bean.
@@ -88,11 +90,20 @@ public interface BeanMetaData<T> extends Validatable {
 	Set<MetaConstraint<?>> getMetaConstraints();
 
 	/**
+	 * @return A map of {@code MetaConstraint} instances encapsulating the information of all the constraints
+	 * 		defined on the bean, grouped by constraint location. This collection includes constraints
+	 * 		from super classes as well
+	 */
+	Map<ConstraintLocation, Set<MetaConstraint<?>>> getMetaConstraintsByLocation();
+
+	/**
 	 * @return A set of {@code MetaConstraint} instances encapsulating the information of all the constraints
 	 *         defined on the bean directly (including constraints defined on implemented interfaces). It does not
 	 *         contain constraints from super classes or interfaces implemented by super classes
 	 */
 	Set<MetaConstraint<?>> getDirectMetaConstraints();
+
+	Map<ConstraintLocation, Set<MetaConstraint<?>>> getDirectMetaConstraintsByLocation();
 
 	/**
 	 * Returns the constraint-related metadata for the given executable of the

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaData.java
@@ -84,12 +84,6 @@ public interface BeanMetaData<T> extends Validatable {
 	boolean defaultGroupSequenceIsRedefined();
 
 	/**
-	 * @return A set of {@code MetaConstraint} instances encapsulating the information of all the constraints
-	 *         defined on the bean. This collection includes constraints from super classes as well
-	 */
-	Set<MetaConstraint<?>> getMetaConstraints();
-
-	/**
 	 * @return A map of {@code MetaConstraint} instances encapsulating the information of all the constraints
 	 * 		defined on the bean, grouped by constraint location. This collection includes constraints
 	 * 		from super classes as well
@@ -97,12 +91,10 @@ public interface BeanMetaData<T> extends Validatable {
 	Map<ConstraintLocation, Set<MetaConstraint<?>>> getMetaConstraintsByLocation();
 
 	/**
-	 * @return A set of {@code MetaConstraint} instances encapsulating the information of all the constraints
-	 *         defined on the bean directly (including constraints defined on implemented interfaces). It does not
-	 *         contain constraints from super classes or interfaces implemented by super classes
+	 * @return A map of {@code MetaConstraint} instances encapsulating the information of all the constraints
+	 *         defined on the bean directly (including constraints defined on implemented interfaces), grouped by constraint
+	 *         location. It does not contain constraints from super classes or interfaces implemented by super classes
 	 */
-	Set<MetaConstraint<?>> getDirectMetaConstraints();
-
 	Map<ConstraintLocation, Set<MetaConstraint<?>>> getDirectMetaConstraintsByLocation();
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -213,7 +213,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 		for ( PropertyMetaData propertyMetaData : propertyMetaDataSet ) {
 			propertyMetaDataMap.put( propertyMetaData.getName(), propertyMetaData );
 			cascadedProperties.addAll( propertyMetaData.getCascadables() );
-			allMetaConstraints.addAll( propertyMetaData.getAllConstraints() );
+			allMetaConstraints.addAll( propertyMetaData.getAllConstraints().values().stream().flatMap( Set::stream ).collect( Collectors.toSet() ) );
 		}
 
 		this.hasConstraints = hasConstraints;

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ConstraintMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ConstraintMetaData.java
@@ -12,8 +12,6 @@ import java.util.List;
 import javax.validation.ElementKind;
 import javax.validation.metadata.ElementDescriptor;
 
-import org.hibernate.validator.internal.metadata.core.MetaConstraint;
-
 /**
  * An aggregated view of the constraint related meta data for a given bean/type
  * element and all the elements in the inheritance hierarchy which it overrides
@@ -21,7 +19,7 @@ import org.hibernate.validator.internal.metadata.core.MetaConstraint;
  *
  * @author Gunnar Morling
  */
-public interface ConstraintMetaData extends Iterable<MetaConstraint<?>> {
+public interface ConstraintMetaData {
 
 	/**
 	 * Returns the name of this meta data object.

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ParameterMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ParameterMetaData.java
@@ -74,7 +74,7 @@ public class ParameterMetaData extends AbstractConstraintMetaData implements Cas
 				getType(),
 				index,
 				getName(),
-				asDescriptors( getDirectConstraints() ),
+				asDescriptors( getDirectConstraints().stream() ),
 				asContainerElementTypeDescriptors( getContainerElementsConstraints(), cascadingMetaData, defaultGroupSequenceRedefined, defaultGroupSequence ),
 				cascadingMetaData.isCascading(),
 				defaultGroupSequenceRedefined,

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/PropertyMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/PropertyMetaData.java
@@ -93,7 +93,7 @@ public class PropertyMetaData extends AbstractConstraintMetaData {
 		return new PropertyDescriptorImpl(
 				getType(),
 				getName(),
-				asDescriptors( getDirectConstraints() ),
+				asDescriptors( getDirectConstraints().stream() ),
 				asContainerElementTypeDescriptors( getContainerElementsConstraints(), firstCascadingMetaData, defaultGroupSequenceRedefined, defaultGroupSequence ),
 				firstCascadingMetaData != null ? firstCascadingMetaData.isCascading() : false,
 				defaultGroupSequenceRedefined,

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ReturnValueMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ReturnValueMetaData.java
@@ -70,7 +70,7 @@ public class ReturnValueMetaData extends AbstractConstraintMetaData
 	public ReturnValueDescriptor asDescriptor(boolean defaultGroupSequenceRedefined, List<Class<?>> defaultGroupSequence) {
 		return new ReturnValueDescriptorImpl(
 				getType(),
-				asDescriptors( getDirectConstraints() ),
+				asDescriptors( getDirectConstraints().stream() ),
 				asContainerElementTypeDescriptors( getContainerElementsConstraints(), cascadingMetaData, defaultGroupSequenceRedefined, defaultGroupSequence ),
 				cascadingMetaData.isCascading(),
 				defaultGroupSequenceRedefined,

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.validation.ParameterNameProvider;
@@ -28,10 +29,13 @@ import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.engine.valueextraction.ValueExtractorManager;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
+import org.hibernate.validator.internal.metadata.aggregated.AbstractConstraintMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ParameterMetaData;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
+import org.hibernate.validator.internal.metadata.core.MetaConstraint;
+import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.metadata.provider.MetaDataProvider;
 import org.hibernate.validator.internal.util.ExecutableHelper;
 import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
@@ -80,9 +84,9 @@ public class ParameterMetaDataTest {
 		assertTrue( parameterMetaData.isConstrained() );
 		assertEquals( parameterMetaData.getIndex(), 1 );
 		assertEquals( parameterMetaData.getName(), "lastName" );
-		assertThat( parameterMetaData ).hasSize( 1 );
+		assertThat( parameterMetaData.getAllConstraints() ).hasSize( 1 );
 		assertEquals(
-				parameterMetaData.iterator().next().getDescriptor().getAnnotation().annotationType(), NotNull.class
+				getSingleMetaConstraint( parameterMetaData ).getDescriptor().getAnnotation().annotationType(), NotNull.class
 		);
 	}
 
@@ -97,7 +101,7 @@ public class ParameterMetaDataTest {
 		assertTrue( parameterMetaData.isConstrained() );
 		assertEquals( parameterMetaData.getIndex(), 0 );
 		assertEquals( parameterMetaData.getName(), "customer" );
-		assertThat( parameterMetaData ).isEmpty();
+		assertThat( parameterMetaData.getAllConstraints() ).isEmpty();
 	}
 
 	@Test
@@ -144,9 +148,9 @@ public class ParameterMetaDataTest {
 
 		assertEquals( parameterMetaData.getIndex(), 0 );
 		assertEquals( parameterMetaData.getName(), "good", "Parameter name from Service should be used, nor ServiceImpl" );
-		assertThat( parameterMetaData ).hasSize( 1 );
+		assertThat( parameterMetaData.getAllConstraints() ).hasSize( 1 );
 		assertEquals(
-				parameterMetaData.iterator().next().getDescriptor().getAnnotation().annotationType(), NotNull.class
+				getSingleMetaConstraint( parameterMetaData ).getDescriptor().getAnnotation().annotationType(), NotNull.class
 		);
 	}
 
@@ -183,5 +187,13 @@ public class ParameterMetaDataTest {
 				return defaultProvider.getParameterNames( method );
 			}
 		}
+	}
+
+	private static MetaConstraint<?> getSingleMetaConstraint(AbstractConstraintMetaData metaData) {
+		return getSingleMetaConstraint( metaData.getAllConstraints() );
+	}
+
+	private static MetaConstraint<?> getSingleMetaConstraint(Map<ConstraintLocation, Set<MetaConstraint<?>>> metaConstraints) {
+		return metaConstraints.values().stream().flatMap( Set::stream ).findFirst().get();
 	}
 }


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1542

@gsmet I found that patch that I mentioned for this change... I run a few benchmarks for it and here are some of the results:
```bash
INFO: HV000001: Hibernate Validator 6.0.7.Final

# Run complete. Total time: 00:01:31

Benchmark                                            Mode  Cnt    Score   Error  Units
RawValidationSpeedBenchmark.testCascadedValidation  thrpt   30  202.036 ± 3.562  ops/s

# Run complete. Total time: 00:01:06

Benchmark                                                                   Mode  Cnt     Score     Error  Units
RawValidationSpeedWithMultipleConstraintsBenchmark.testCascadedValidation  thrpt   30  4373.006 ± 161.747  ops/s


INFO: HV000001: Hibernate Validator 6.0.8-SNAPSHOT

# Run complete. Total time: 00:01:32

Benchmark                                            Mode  Cnt    Score   Error  Units
RawValidationSpeedBenchmark.testCascadedValidation  thrpt   30  200.153 ± 6.807  ops/s

# Run complete. Total time: 00:01:06

Benchmark                                                                   Mode  Cnt     Score    Error  Units
RawValidationSpeedWithMultipleConstraintsBenchmark.testCascadedValidation  thrpt   30  4751.330 ± 69.204  ops/s
```

Some difference is more or less visible on the second benchmark. It's a very simple test where a bean has multiple constraints defined for the same property. Here's the relevant code for it:
```java
@Benchmark
@BenchmarkMode(Mode.Throughput)
@OutputTimeUnit(TimeUnit.SECONDS)
@Fork(value = 1)
@Threads(50)
@Warmup(iterations = 20) // it seems that as there are a lot of beans it takes some time to warmup
@Measurement(iterations = 30)
public void testCascadedValidation(RawValidationSpeedState state, Blackhole bh) {
    for ( Foo o : state.foos ) {
        Set<ConstraintViolation<Foo>> constraintViolations = state.validator.validate( o );
        bh.consume( constraintViolations );
    }
}

private static class Foo {

    private static final Random RANDOM = new Random();
    private static final String[] VALS = { null, "", "\t\t", "text", "email@mail.com", "1234567" };

    @NotNull
    @NotBlank
    @NotEmpty
    @Email
    @Size(max = 1000)
    @Pattern(regexp = ".*")
    private final String string;

    private Foo(String string) {
        this.string = string;
    }

    public static Foo random() {
        return new Foo( VALS[RANDOM.nextInt( VALS.length )] );
    }
}
```

where a list of foos - `state.foos` is initialized with 100 random `Foo`s