### PR TITLE
HV-1568 Prevent possible NullPointerException in ValidatorFactoryScopedContext.Builder

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -45,6 +45,7 @@ import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.provider.MetaDataProvider;
 import org.hibernate.validator.internal.metadata.provider.ProgrammaticMetaDataProvider;
 import org.hibernate.validator.internal.metadata.provider.XmlMetaDataProvider;
+import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.ExecutableHelper;
 import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.StringHelper;
@@ -741,8 +742,9 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 			private boolean traversableResolverResultCacheEnabled;
 
 			Builder(ValidatorFactoryScopedContext defaultContext) {
-				this.defaultContext = defaultContext != null ? defaultContext : new ValidatorFactoryScopedContext( null, null, null, null, null, null, false, false );
+				Contracts.assertNotNull( defaultContext, "Default context cannot be null." );
 
+				this.defaultContext = defaultContext;
 				this.messageInterpolator = defaultContext.messageInterpolator;
 				this.traversableResolver = defaultContext.traversableResolver;
 				this.parameterNameProvider = defaultContext.parameterNameProvider;


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1568

As default context cannot be null at this point we should have an assertion
instead of initialization on null. I've also looked at the logic before this change - we had a reference to `ValidatorFactoryImpl` in `ValidatorContextImpl` which was used to get default values if a null was passed. Now that we have all those things grouped in the context object the context cannot be null as it is initialized in the constructor of `ValidatorFactoryImpl` hence that check in the builder constructor wasn't really needed.