### PR TITLE
HV-1461 ExecutableHelper#overrides does not work correctly with the method containing generic and non generic parameters

### DIFF
--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/ExecutableHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/ExecutableHelperTest.java
@@ -262,6 +262,36 @@ public class ExecutableHelperTest {
 		);
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HV-1461")
+	public void testNonGenericAndGenericParams() throws NoSuchMethodException {
+		assertTrue(
+				executableHelper.overrides(
+						BarEntityService.class.getMethod( "update", Bar.class ),
+						EntityService.class.getMethod( "update", Foo.class )
+				)
+		);
+
+		assertTrue(
+				executableHelper.overrides(
+						BarEntityService.class.getMethod( "update", Long.class, Bar.class ),
+						EntityService.class.getMethod( "update", Long.class, Foo.class )
+				)
+		);
+	}
+
+	interface EntityService<T extends Foo> {
+		void update(T entity);
+
+		void update(Long id, T entity);
+	}
+
+	interface BarEntityService extends EntityService<Bar> {
+		void update(Bar entity);
+
+		void update(Long id, Bar entity);
+	}
+
 	public abstract static class GenericServiceBase<T> {
 		public abstract void doSomething(T t);
 	}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1461

As it turned out the upgrade of classmate in https://github.com/hibernate/hibernate-validator/commit/da94fc5c30960dd7296673bd62ba7dad66a15148 from 1.3.1 to 1.3.3 done the trick. So I've just added a test case similar to the one in the JIRA. In case of 1.3.1 version in `ExecutableHelper#instanceMethodParametersResolveToSameTypes` you would get:
```
resolvedMethods[0].getArgumentType( i ) = {ResolvedObjectType@1491} "java.lang.Long"
resolvedMethods[1].getArgumentType( i ) = {ResolvedObjectType@1493} "java.lang.Long<org.hibernate.validator.test.internal.util.ExecutableHelperTest$Bar>"
```
and in case of 1.3.3:
```
resolvedMethods[0].getArgumentType( i ) = {ResolvedObjectType@1468} "java.lang.Long"
resolvedMethods[1].getArgumentType( i ) = {ResolvedObjectType@1470} "java.lang.Long"
```

If a backport for the fix is needed and we cannot upgrade the lib version a simple use of `.getErasedType()` on both sides of argument equals check:
```java
if ( !resolvedMethods[0].getArgumentType( i ).getErasedType().equals( resolvedMethods[1].getArgumentType( i ).getErasedType() ) ) {
	return false;
}
```
in that same method will do the trick.