### PR TITLE
HV-1543 Investigate if we can short circuit ConstraintTree#passesCompositionTypeRequirement() when not in the composition case

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ComposingConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ComposingConstraintTree.java
@@ -1,0 +1,289 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.constraintvalidation;
+
+import static org.hibernate.validator.constraints.CompositionType.ALL_FALSE;
+import static org.hibernate.validator.constraints.CompositionType.AND;
+import static org.hibernate.validator.constraints.CompositionType.OR;
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
+
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintViolation;
+
+import org.hibernate.validator.constraints.CompositionType;
+import org.hibernate.validator.internal.engine.ValidationContext;
+import org.hibernate.validator.internal.engine.ValueContext;
+import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
+import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.internal.util.logging.Log;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
+import org.hibernate.validator.internal.util.stereotypes.Immutable;
+
+/**
+ * A constraint tree for composing constraints. Has children corresponding to the composed constraints.
+ *
+ * @author Hardy Ferentschik
+ * @author Federico Mancini
+ * @author Dag Hovland
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2012 SERLI
+ * @author Guillaume Smet
+ * @author Marko Bekhta
+ */
+class ComposingConstraintTree<B extends Annotation> extends ConstraintTree<B> {
+
+	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
+
+	@Immutable
+	private final List<ConstraintTree<?>> children;
+
+	public ComposingConstraintTree(ConstraintDescriptorImpl<B> descriptor, Type validatedValueType) {
+		super( descriptor, validatedValueType );
+		this.children = descriptor.getComposingConstraintImpls().stream()
+				.map( desc -> createConstraintTree( desc ) )
+				.collect( Collectors.collectingAndThen( Collectors.toList(), CollectionHelper::toImmutableList ) );
+	}
+
+	private <U extends Annotation> ConstraintTree<U> createConstraintTree(ConstraintDescriptorImpl<U> composingDescriptor) {
+		if ( composingDescriptor.getComposingConstraintImpls().isEmpty() ) {
+			return new SimpleConstraintTree<>( composingDescriptor, getValidatedValueType() );
+		}
+		else {
+			return new ComposingConstraintTree<>( composingDescriptor, getValidatedValueType() );
+		}
+	}
+
+	@Override
+	protected <T> void validateConstraints(ValidationContext<T> validationContext,
+			ValueContext<?, ?> valueContext,
+			Set<ConstraintViolation<T>> constraintViolations) {
+		CompositionResult compositionResult = validateComposingConstraints(
+				validationContext, valueContext, constraintViolations
+		);
+
+		Set<ConstraintViolation<T>> localViolations;
+
+		// After all children are validated the actual ConstraintValidator of the constraint itself is executed
+		if ( mainConstraintNeedsEvaluation( validationContext, constraintViolations ) ) {
+
+			if ( LOG.isTraceEnabled() ) {
+				LOG.tracef(
+						"Validating value %s against constraint defined by %s.",
+						valueContext.getCurrentValidatedValue(),
+						descriptor
+				);
+			}
+
+			// find the right constraint validator
+			ConstraintValidator<B, ?> validator = getInitializedConstraintValidator( validationContext, valueContext );
+
+			// create a constraint validator context
+			ConstraintValidatorContextImpl constraintValidatorContext = new ConstraintValidatorContextImpl(
+					validationContext.getParameterNames(),
+					validationContext.getClockProvider(),
+					valueContext.getPropertyPath(),
+					descriptor
+			);
+
+			// validate
+			localViolations = validateSingleConstraint(
+					validationContext,
+					valueContext,
+					constraintValidatorContext,
+					validator
+			);
+
+			// We re-evaluate the boolean composition by taking into consideration also the violations
+			// from the local constraintValidator
+			if ( localViolations.isEmpty() ) {
+				compositionResult.setAtLeastOneTrue( true );
+			}
+			else {
+				compositionResult.setAllTrue( false );
+			}
+		}
+		else {
+			localViolations = Collections.emptySet();
+		}
+
+		if ( !passesCompositionTypeRequirement( constraintViolations, compositionResult ) ) {
+			prepareFinalConstraintViolations(
+					validationContext, valueContext, constraintViolations, localViolations
+			);
+		}
+	}
+
+	private <T> boolean mainConstraintNeedsEvaluation(ValidationContext<T> executionContext,
+			Set<ConstraintViolation<T>> constraintViolations) {
+		// we are dealing with a composing constraint with no validator for the main constraint
+		if ( !descriptor.getComposingConstraints().isEmpty() && descriptor.getMatchingConstraintValidatorDescriptors().isEmpty() ) {
+			return false;
+		}
+
+		if ( constraintViolations.isEmpty() ) {
+			return true;
+		}
+
+		// report as single violation and there is already a violation
+		if ( descriptor.isReportAsSingleViolation() && descriptor.getCompositionType() == AND ) {
+			return false;
+		}
+
+		// explicit fail fast mode
+		if ( executionContext.isFailFastModeEnabled() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Before the final constraint violations can be reported back we need to check whether we have a composing
+	 * constraint whose result should be reported as single violation.
+	 *
+	 * @param executionContext meta data about top level validation
+	 * @param valueContext meta data for currently validated value
+	 * @param constraintViolations used to accumulate constraint violations
+	 * @param localViolations set of constraint violations of top level constraint
+	 */
+	private <T> void prepareFinalConstraintViolations(ValidationContext<T> executionContext,
+			ValueContext<?, ?> valueContext,
+			Set<ConstraintViolation<T>> constraintViolations,
+			Set<ConstraintViolation<T>> localViolations) {
+		if ( reportAsSingleViolation() ) {
+			// We clear the current violations list anyway
+			constraintViolations.clear();
+
+			// But then we need to distinguish whether the local ConstraintValidator has reported
+			// violations or not (or if there is no local ConstraintValidator at all).
+			// If not we create a violation
+			// using the error message in the annotation declaration at top level.
+			if ( localViolations.isEmpty() ) {
+				final String message = getDescriptor().getMessageTemplate();
+				ConstraintViolationCreationContext constraintViolationCreationContext = new ConstraintViolationCreationContext(
+						message,
+						valueContext.getPropertyPath()
+				);
+				ConstraintViolation<T> violation = executionContext.createConstraintViolation(
+						valueContext, constraintViolationCreationContext, descriptor
+				);
+				constraintViolations.add( violation );
+			}
+		}
+
+		// Now, if there were some violations reported by
+		// the local ConstraintValidator, they need to be added to constraintViolations.
+		// Whether we need to report them as a single constraint or just add them to the other violations
+		// from the composing constraints, has been taken care of in the previous conditional block.
+		// This takes also care of possible custom error messages created by the constraintValidator,
+		// as checked in test CustomErrorMessage.java
+		// If no violations have been reported from the local ConstraintValidator, or no such validator exists,
+		// then we just add an empty list.
+		constraintViolations.addAll( localViolations );
+	}
+
+	/**
+	 * Validates all composing constraints recursively.
+	 *
+	 * @param executionContext Meta data about top level validation
+	 * @param valueContext Meta data for currently validated value
+	 * @param constraintViolations Used to accumulate constraint violations
+	 *
+	 * @return Returns an instance of {@code CompositionResult} relevant for boolean composition of constraints
+	 */
+	private <T> CompositionResult validateComposingConstraints(ValidationContext<T> executionContext,
+			ValueContext<?, ?> valueContext,
+			Set<ConstraintViolation<T>> constraintViolations) {
+		CompositionResult compositionResult = new CompositionResult( true, false );
+		for ( ConstraintTree<?> tree : children ) {
+			Set<ConstraintViolation<T>> tmpViolations = newHashSet( 5 );
+			tree.validateConstraints( executionContext, valueContext, tmpViolations );
+			constraintViolations.addAll( tmpViolations );
+
+			if ( tmpViolations.isEmpty() ) {
+				compositionResult.setAtLeastOneTrue( true );
+				// no need to further validate constraints, because at least one validation passed
+				if ( descriptor.getCompositionType() == OR ) {
+					break;
+				}
+			}
+			else {
+				compositionResult.setAllTrue( false );
+				if ( descriptor.getCompositionType() == AND
+						&& ( executionContext.isFailFastModeEnabled() || descriptor.isReportAsSingleViolation() ) ) {
+					break;
+				}
+			}
+		}
+		return compositionResult;
+	}
+
+	private boolean passesCompositionTypeRequirement(Set<?> constraintViolations, CompositionResult compositionResult) {
+		CompositionType compositionType = getDescriptor().getCompositionType();
+		boolean passedValidation = false;
+		switch ( compositionType ) {
+			case OR:
+				passedValidation = compositionResult.isAtLeastOneTrue();
+				break;
+			case AND:
+				passedValidation = compositionResult.isAllTrue();
+				break;
+			case ALL_FALSE:
+				passedValidation = !compositionResult.isAtLeastOneTrue();
+				break;
+		}
+		assert ( !passedValidation || !( compositionType == AND ) || constraintViolations.isEmpty() );
+		if ( passedValidation ) {
+			constraintViolations.clear();
+		}
+		return passedValidation;
+	}
+
+	/**
+	 * @return {@code} true if the current constraint should be reported as single violation, {@code false otherwise}.
+	 * 		When using negation, we only report the single top-level violation, as
+	 * 		it is hard, especially for ALL_FALSE to give meaningful reports
+	 */
+	private boolean reportAsSingleViolation() {
+		return getDescriptor().isReportAsSingleViolation()
+				|| getDescriptor().getCompositionType() == ALL_FALSE;
+	}
+
+	private static final class CompositionResult {
+
+		private boolean allTrue;
+		private boolean atLeastOneTrue;
+
+		CompositionResult(boolean allTrue, boolean atLeastOneTrue) {
+			this.allTrue = allTrue;
+			this.atLeastOneTrue = atLeastOneTrue;
+		}
+
+		public boolean isAllTrue() {
+			return allTrue;
+		}
+
+		public boolean isAtLeastOneTrue() {
+			return atLeastOneTrue;
+		}
+
+		public void setAllTrue(boolean allTrue) {
+			this.allTrue = allTrue;
+		}
+
+		public void setAtLeastOneTrue(boolean atLeastOneTrue) {
+			this.atLeastOneTrue = atLeastOneTrue;
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.validator.internal.engine.constraintvalidation;
 
-import static org.hibernate.validator.constraints.CompositionType.ALL_FALSE;
-import static org.hibernate.validator.constraints.CompositionType.AND;
-import static org.hibernate.validator.constraints.CompositionType.OR;
 import static org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager.DUMMY_CONSTRAINT_VALIDATOR;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 
@@ -16,23 +13,18 @@ import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Type;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.validation.ConstraintDeclarationException;
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintViolation;
 import javax.validation.ValidationException;
 
-import org.hibernate.validator.constraints.CompositionType;
 import org.hibernate.validator.internal.engine.ValidationContext;
 import org.hibernate.validator.internal.engine.ValueContext;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
-import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
-import org.hibernate.validator.internal.util.stereotypes.Immutable;
 
 /**
  * Due to constraint composition a single constraint annotation can lead to a whole constraint tree being validated.
@@ -43,18 +35,16 @@ import org.hibernate.validator.internal.util.stereotypes.Immutable;
  * @author Dag Hovland
  * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2012 SERLI
  * @author Guillaume Smet
+ * @author Marko Bekhta
  */
-public class ConstraintTree<A extends Annotation> {
+public abstract class ConstraintTree<A extends Annotation> {
 
 	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
-
-	@Immutable
-	private final List<ConstraintTree<?>> children;
 
 	/**
 	 * The constraint descriptor for the constraint represented by this constraint tree.
 	 */
-	private final ConstraintDescriptorImpl<A> descriptor;
+	protected final ConstraintDescriptorImpl<A> descriptor;
 
 	private final Type validatedValueType;
 
@@ -64,24 +54,21 @@ public class ConstraintTree<A extends Annotation> {
 	 */
 	private volatile ConstraintValidator<A, ?> constraintValidatorForDefaultConstraintValidatorFactory;
 
-	public ConstraintTree(ConstraintDescriptorImpl<A> descriptor, Type validatedValueType) {
+	protected ConstraintTree(ConstraintDescriptorImpl<A> descriptor, Type validatedValueType) {
 		this.descriptor = descriptor;
 		this.validatedValueType = validatedValueType;
-		this.children = descriptor.getComposingConstraintImpls().stream()
-				.map( desc -> createConstraintTree( desc ) )
-				.collect( Collectors.collectingAndThen( Collectors.toList(), CollectionHelper::toImmutableList ) );
 	}
 
-	private <U extends Annotation> ConstraintTree<U> createConstraintTree(ConstraintDescriptorImpl<U> composingDescriptor) {
-		return new ConstraintTree<>( composingDescriptor, this.validatedValueType );
+	public static <U extends Annotation> ConstraintTree<U> of(ConstraintDescriptorImpl<U> composingDescriptor, Type validatedValueType) {
+		if ( composingDescriptor.getComposingConstraintImpls().isEmpty() ) {
+			return new SimpleConstraintTree<>( composingDescriptor, validatedValueType );
+		}
+		else {
+			return new ComposingConstraintTree<>( composingDescriptor, validatedValueType );
+		}
 	}
 
-	public final ConstraintDescriptorImpl<A> getDescriptor() {
-		return descriptor;
-	}
-
-	public final <T> boolean validateConstraints(ValidationContext<T> executionContext,
-			ValueContext<?, ?> valueContext) {
+	public final <T> boolean validateConstraints(ValidationContext<T> executionContext, ValueContext<?, ?> valueContext) {
 		Set<ConstraintViolation<T>> constraintViolations = newHashSet( 5 );
 		validateConstraints( executionContext, valueContext, constraintViolations );
 		if ( !constraintViolations.isEmpty() ) {
@@ -91,63 +78,14 @@ public class ConstraintTree<A extends Annotation> {
 		return true;
 	}
 
-	private <T> void validateConstraints(ValidationContext<T> validationContext,
-			ValueContext<?, ?> valueContext,
-			Set<ConstraintViolation<T>> constraintViolations) {
-		CompositionResult compositionResult = validateComposingConstraints(
-				validationContext, valueContext, constraintViolations
-		);
+	protected abstract <T> void validateConstraints(ValidationContext<T> executionContext, ValueContext<?, ?> valueContext, Set<ConstraintViolation<T>> constraintViolations);
 
-		Set<ConstraintViolation<T>> localViolations;
+	public final ConstraintDescriptorImpl<A> getDescriptor() {
+		return descriptor;
+	}
 
-		// After all children are validated the actual ConstraintValidator of the constraint itself is executed
-		if ( mainConstraintNeedsEvaluation( validationContext, constraintViolations ) ) {
-
-			if ( LOG.isTraceEnabled() ) {
-				LOG.tracef(
-						"Validating value %s against constraint defined by %s.",
-						valueContext.getCurrentValidatedValue(),
-						descriptor
-				);
-			}
-
-			// find the right constraint validator
-			ConstraintValidator<A, ?> validator = getInitializedConstraintValidator( validationContext, valueContext );
-
-			// create a constraint validator context
-			ConstraintValidatorContextImpl constraintValidatorContext = new ConstraintValidatorContextImpl(
-					validationContext.getParameterNames(),
-					validationContext.getClockProvider(),
-					valueContext.getPropertyPath(),
-					descriptor
-			);
-
-			// validate
-			localViolations = validateSingleConstraint(
-					validationContext,
-					valueContext,
-					constraintValidatorContext,
-					validator
-			);
-
-			// We re-evaluate the boolean composition by taking into consideration also the violations
-			// from the local constraintValidator
-			if ( localViolations.isEmpty() ) {
-				compositionResult.setAtLeastOneTrue( true );
-			}
-			else {
-				compositionResult.setAllTrue( false );
-			}
-		}
-		else {
-			localViolations = Collections.emptySet();
-		}
-
-		if ( !passesCompositionTypeRequirement( constraintViolations, compositionResult ) ) {
-			prepareFinalConstraintViolations(
-					validationContext, valueContext, constraintViolations, localViolations
-			);
-		}
+	public final Type getValidatedValueType() {
+		return this.validatedValueType;
 	}
 
 	private ValidationException getExceptionForNullValidator(Type validatedValueType, String path) {
@@ -171,8 +109,7 @@ public class ConstraintTree<A extends Annotation> {
 		}
 	}
 
-	private <T> ConstraintValidator<A, ?> getInitializedConstraintValidator(ValidationContext<T> validationContext,
-			ValueContext<?, ?> valueContext) {
+	protected final <T> ConstraintValidator<A, ?> getInitializedConstraintValidator(ValidationContext<T> validationContext, ValueContext<?, ?> valueContext) {
 		ConstraintValidator<A, ?> validator;
 
 		if ( validationContext.getConstraintValidatorFactory() == validationContext.getConstraintValidatorManager().getDefaultConstraintValidatorFactory() ) {
@@ -220,133 +157,7 @@ public class ConstraintTree<A extends Annotation> {
 		}
 	}
 
-	private <T> boolean mainConstraintNeedsEvaluation(ValidationContext<T> executionContext,
-			Set<ConstraintViolation<T>> constraintViolations) {
-		// we are dealing with a composing constraint with no validator for the main constraint
-		if ( !descriptor.getComposingConstraints().isEmpty() && descriptor.getMatchingConstraintValidatorDescriptors().isEmpty() ) {
-			return false;
-		}
-
-		if ( constraintViolations.isEmpty() ) {
-			return true;
-		}
-
-		// report as single violation and there is already a violation
-		if ( descriptor.isReportAsSingleViolation() && descriptor.getCompositionType() == AND ) {
-			return false;
-		}
-
-		// explicit fail fast mode
-		if ( executionContext.isFailFastModeEnabled() ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Before the final constraint violations can be reported back we need to check whether we have a composing
-	 * constraint whose result should be reported as single violation.
-	 *
-	 * @param executionContext meta data about top level validation
-	 * @param valueContext meta data for currently validated value
-	 * @param constraintViolations used to accumulate constraint violations
-	 * @param localViolations set of constraint violations of top level constraint
-	 */
-	private <T> void prepareFinalConstraintViolations(ValidationContext<T> executionContext,
-			ValueContext<?, ?> valueContext,
-			Set<ConstraintViolation<T>> constraintViolations,
-			Set<ConstraintViolation<T>> localViolations) {
-		if ( reportAsSingleViolation() ) {
-			// We clear the current violations list anyway
-			constraintViolations.clear();
-
-			// But then we need to distinguish whether the local ConstraintValidator has reported
-			// violations or not (or if there is no local ConstraintValidator at all).
-			// If not we create a violation
-			// using the error message in the annotation declaration at top level.
-			if ( localViolations.isEmpty() ) {
-				final String message = getDescriptor().getMessageTemplate();
-				ConstraintViolationCreationContext constraintViolationCreationContext = new ConstraintViolationCreationContext(
-						message,
-						valueContext.getPropertyPath()
-				);
-				ConstraintViolation<T> violation = executionContext.createConstraintViolation(
-						valueContext, constraintViolationCreationContext, descriptor
-				);
-				constraintViolations.add( violation );
-			}
-		}
-
-		// Now, if there were some violations reported by
-		// the local ConstraintValidator, they need to be added to constraintViolations.
-		// Whether we need to report them as a single constraint or just add them to the other violations
-		// from the composing constraints, has been taken care of in the previous conditional block.
-		// This takes also care of possible custom error messages created by the constraintValidator,
-		// as checked in test CustomErrorMessage.java
-		// If no violations have been reported from the local ConstraintValidator, or no such validator exists,
-		// then we just add an empty list.
-		constraintViolations.addAll( localViolations );
-	}
-
-	/**
-	 * Validates all composing constraints recursively.
-	 *
-	 * @param executionContext Meta data about top level validation
-	 * @param valueContext Meta data for currently validated value
-	 * @param constraintViolations Used to accumulate constraint violations
-	 *
-	 * @return Returns an instance of {@code CompositionResult} relevant for boolean composition of constraints
-	 */
-	private <T> CompositionResult validateComposingConstraints(ValidationContext<T> executionContext,
-			ValueContext<?, ?> valueContext,
-			Set<ConstraintViolation<T>> constraintViolations) {
-		CompositionResult compositionResult = new CompositionResult( true, false );
-		for ( ConstraintTree<?> tree : children ) {
-			Set<ConstraintViolation<T>> tmpViolations = newHashSet( 5 );
-			tree.validateConstraints( executionContext, valueContext, tmpViolations );
-			constraintViolations.addAll( tmpViolations );
-
-			if ( tmpViolations.isEmpty() ) {
-				compositionResult.setAtLeastOneTrue( true );
-				// no need to further validate constraints, because at least one validation passed
-				if ( descriptor.getCompositionType() == OR ) {
-					break;
-				}
-			}
-			else {
-				compositionResult.setAllTrue( false );
-				if ( descriptor.getCompositionType() == AND
-						&& ( executionContext.isFailFastModeEnabled() || descriptor.isReportAsSingleViolation() ) ) {
-					break;
-				}
-			}
-		}
-		return compositionResult;
-	}
-
-	private boolean passesCompositionTypeRequirement(Set<?> constraintViolations, CompositionResult compositionResult) {
-		CompositionType compositionType = getDescriptor().getCompositionType();
-		boolean passedValidation = false;
-		switch ( compositionType ) {
-			case OR:
-				passedValidation = compositionResult.isAtLeastOneTrue();
-				break;
-			case AND:
-				passedValidation = compositionResult.isAllTrue();
-				break;
-			case ALL_FALSE:
-				passedValidation = !compositionResult.isAtLeastOneTrue();
-				break;
-		}
-		assert ( !passedValidation || !( compositionType == AND ) || constraintViolations.isEmpty() );
-		if ( passedValidation ) {
-			constraintViolations.clear();
-		}
-		return passedValidation;
-	}
-
-	private <T, V> Set<ConstraintViolation<T>> validateSingleConstraint(ValidationContext<T> executionContext,
+	protected final <T, V> Set<ConstraintViolation<T>> validateSingleConstraint(ValidationContext<T> executionContext,
 			ValueContext<?, ?> valueContext,
 			ConstraintValidatorContextImpl constraintValidatorContext,
 			ConstraintValidator<A, V> validator) {
@@ -372,16 +183,6 @@ public class ConstraintTree<A extends Annotation> {
 		return Collections.emptySet();
 	}
 
-	/**
-	 * @return {@code} true if the current constraint should be reported as single violation, {@code false otherwise}.
-	 * When using negation, we only report the single top-level violation, as
-	 * it is hard, especially for ALL_FALSE to give meaningful reports
-	 */
-	private boolean reportAsSingleViolation() {
-		return getDescriptor().isReportAsSingleViolation()
-				|| getDescriptor().getCompositionType() == ALL_FALSE;
-	}
-
 	@Override
 	public String toString() {
 		final StringBuilder sb = new StringBuilder();
@@ -391,29 +192,4 @@ public class ConstraintTree<A extends Annotation> {
 		return sb.toString();
 	}
 
-	private static final class CompositionResult {
-		private boolean allTrue;
-		private boolean atLeastOneTrue;
-
-		CompositionResult(boolean allTrue, boolean atLeastOneTrue) {
-			this.allTrue = allTrue;
-			this.atLeastOneTrue = atLeastOneTrue;
-		}
-
-		public boolean isAllTrue() {
-			return allTrue;
-		}
-
-		public boolean isAtLeastOneTrue() {
-			return atLeastOneTrue;
-		}
-
-		public void setAllTrue(boolean allTrue) {
-			this.allTrue = allTrue;
-		}
-
-		public void setAtLeastOneTrue(boolean atLeastOneTrue) {
-			this.atLeastOneTrue = atLeastOneTrue;
-		}
-	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/SimpleConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/SimpleConstraintTree.java
@@ -1,0 +1,75 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.constraintvalidation;
+
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintViolation;
+
+import org.hibernate.validator.internal.engine.ValidationContext;
+import org.hibernate.validator.internal.engine.ValueContext;
+import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
+import org.hibernate.validator.internal.util.logging.Log;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
+
+/**
+ * A constraint tree for a simple constraint i.e. not a composing one.
+ *
+ * @author Hardy Ferentschik
+ * @author Federico Mancini
+ * @author Dag Hovland
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2012 SERLI
+ * @author Guillaume Smet
+ * @author Marko Bekhta
+ */
+class SimpleConstraintTree<B extends Annotation> extends ConstraintTree<B> {
+
+	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
+
+	public SimpleConstraintTree(ConstraintDescriptorImpl<B> descriptor, Type validatedValueType) {
+		super( descriptor, validatedValueType );
+	}
+
+	@Override
+	protected <T> void validateConstraints(ValidationContext<T> validationContext,
+			ValueContext<?, ?> valueContext,
+			Set<ConstraintViolation<T>> constraintViolations) {
+
+		if ( LOG.isTraceEnabled() ) {
+			LOG.tracef(
+					"Validating value %s against constraint defined by %s.",
+					valueContext.getCurrentValidatedValue(),
+					descriptor
+			);
+		}
+
+		// find the right constraint validator
+		ConstraintValidator<B, ?> validator = getInitializedConstraintValidator( validationContext, valueContext );
+
+		// create a constraint validator context
+		ConstraintValidatorContextImpl constraintValidatorContext = new ConstraintValidatorContextImpl(
+				validationContext.getParameterNames(),
+				validationContext.getClockProvider(),
+				valueContext.getPropertyPath(),
+				descriptor
+		);
+
+		// validate
+		constraintViolations.addAll(
+				validateSingleConstraint(
+						validationContext,
+						valueContext,
+						constraintValidatorContext,
+						validator
+				)
+		);
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/MetaConstraint.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/MetaConstraint.java
@@ -63,7 +63,7 @@ public class MetaConstraint<A extends Annotation> {
 	 */
 	MetaConstraint(ConstraintDescriptorImpl<A> constraintDescriptor, ConstraintLocation location, List<ContainerClassTypeParameterAndExtractor> valueExtractionPath,
 			Type validatedValueType) {
-		this.constraintTree = new ConstraintTree<>( constraintDescriptor, validatedValueType );
+		this.constraintTree = ConstraintTree.of( constraintDescriptor, validatedValueType );
 		this.location = location;
 		this.valueExtractionPath = getValueExtractionPath( valueExtractionPath );
 		this.hashCode = buildHashCode( constraintDescriptor, location );


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1543

I've created two implementations for `ConstraintTree` nodes - one is a leaf kind a constraint node without any children hence non-composing constraint. In such case we can simplify the logic in validate method and jump directly to validating "main" constraint. Another kind of node is for a composing constraints. It has children and all the logic as was in the `ConstraintTree` prior to changes.

The changes themselves might not be very readable. But it's just because of moving methods around in the class :smile: 

@gsmet please let me know what you think of such approach.

Also some benchmark numbers for these changes:
Current:
```bash
Benchmark                                                                                  Mode  Cnt     Score    Error   Units
SimpleValidation.testSimpleBeanValidation                                                  thrpt   20  1901.092 ± 34.301  ops/ms
CascadedValidation.testCascadedValidation                                                  thrpt   20   457.333 ± 140.714  ops/ms
CascadedWithLotsOfItemsAndMoreConstraintsValidation.testCascadedValidationWithLotsOfItems  thrpt   20  1435.712 ±  47.790   ops/s
CascadedWithLotsOfItemsValidation.testCascadedValidationWithLotsOfItems                    thrpt   20  1844.000 ±  43.504   ops/s
```
6.0.7:
```bash
Benchmark                                                                                  Mode  Cnt     Score    Error   Units
SimpleValidation.testSimpleBeanValidation                                                  thrpt   20  1888.014 ± 36.861  ops/ms
CascadedValidation.testCascadedValidation                                                  thrpt   20   421.932 ± 111.066  ops/ms
CascadedWithLotsOfItemsAndMoreConstraintsValidation.testCascadedValidationWithLotsOfItems  thrpt   20  1234.872 ±  15.871   ops/s
CascadedWithLotsOfItemsValidation.testCascadedValidationWithLotsOfItems                    thrpt   20  1691.087 ±  27.512   ops/s
```
