### PR TITLE
HV-1450 BeanMetaDataImpl.BeanMetaDataBuilder#build() can choose ConstraintMetaData w/o constraints

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
@@ -321,15 +321,15 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 
 			//are the locations equal (created by different builders) or
 			//does one of the executables override the other one?
-			return resolveToSameMethodInHierarchy( executable, candidate );
+			return isResolvedToSameMethodInHierarchy( executable, candidate );
 		}
 
-		private boolean resolveToSameMethodInHierarchy(Executable first, Executable other) {
+		private boolean isResolvedToSameMethodInHierarchy(Executable first, Executable other) {
 			if ( first instanceof Constructor || other instanceof Constructor ) {
 				return first.equals( other );
 			}
 
-			return executableHelper.resolveToSameMethodInHierarchy( getBeanClass(), (Method) first, (Method) other );
+			return executableHelper.isResolvedToSameMethodInHierarchy( getBeanClass(), (Method) first, (Method) other );
 		}
 
 		private boolean overrides(Executable first, Executable other) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
@@ -321,9 +321,15 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 
 			//are the locations equal (created by different builders) or
 			//does one of the executables override the other one?
-			return executable.equals( candidate ) ||
-					overrides( executable, candidate ) ||
-					overrides( candidate, executable );
+			return resolveToSameMethodInHierarchy( executable, candidate );
+		}
+
+		private boolean resolveToSameMethodInHierarchy(Executable first, Executable other) {
+			if ( first instanceof Constructor || other instanceof Constructor ) {
+				return first.equals( other );
+			}
+
+			return executableHelper.resolveToSameMethodInHierarchy( getBeanClass(), (Method) first, (Method) other );
 		}
 
 		private boolean overrides(Executable first, Executable other) {

--- a/engine/src/main/java/org/hibernate/validator/internal/util/ExecutableHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/ExecutableHelper.java
@@ -91,7 +91,7 @@ public final class ExecutableHelper {
 			return false;
 		}
 
-		if ( !isOneMethodVisibleToAnother( subTypeMethod, superTypeMethod ) ) {
+		if ( !isMethodVisibleTo( superTypeMethod, subTypeMethod ) ) {
 			return false;
 		}
 
@@ -110,7 +110,7 @@ public final class ExecutableHelper {
 	 * 		override another one in the class hierarchy with {@code mainSubType} at the bottom,
 	 * 		{@code false} otherwise.
 	 */
-	public boolean resolveToSameMethodInHierarchy(Class<?> mainSubType, Method left, Method right) {
+	public boolean isResolvedToSameMethodInHierarchy(Class<?> mainSubType, Method left, Method right) {
 		Contracts.assertValueNotNull( mainSubType, "mainSubType" );
 		Contracts.assertValueNotNull( left, "left" );
 		Contracts.assertValueNotNull( right, "right" );
@@ -148,7 +148,7 @@ public final class ExecutableHelper {
 			return false;
 		}
 
-		if ( !isOneMethodVisibleToAnother( left, right ) || !isOneMethodVisibleToAnother( right, left ) ) {
+		if ( !isMethodVisibleTo( right, left ) || !isMethodVisibleTo( left, right ) ) {
 			return false;
 		}
 
@@ -163,9 +163,9 @@ public final class ExecutableHelper {
 		);
 	}
 
-	private static boolean isOneMethodVisibleToAnother(Method left, Method right) {
-		return Modifier.isPublic( right.getModifiers() ) || Modifier.isProtected( right.getModifiers() )
-				|| right.getDeclaringClass().getPackage().equals( left.getDeclaringClass().getPackage() );
+	private static boolean isMethodVisibleTo(Method visibleMethod, Method otherMethod) {
+		return Modifier.isPublic( visibleMethod.getModifiers() ) || Modifier.isProtected( visibleMethod.getModifiers() )
+				|| visibleMethod.getDeclaringClass().getPackage().equals( otherMethod.getDeclaringClass().getPackage() );
 	}
 
 	public static String getSimpleName(Executable executable) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/MethodParameterConstraintsInParallelHierarchyTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/MethodParameterConstraintsInParallelHierarchyTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 public class MethodParameterConstraintsInParallelHierarchyTest {
 
 	/**
-	 * NOTE: prior to the changes where this test was added it would fail randomly.
+	 * NOTE: prior to the changes made for HV-1450, this test was failing randomly.
 	 */
 	@Test
 	@TestForIssue(jiraKey = "HV-1450")
@@ -37,13 +37,14 @@ public class MethodParameterConstraintsInParallelHierarchyTest {
 		Method method = WebServiceImpl.class.getMethod( "getEntityVersion", Long.class );
 		Object[] params = new Object[] { null };
 
-		Validator validator = Validation.byDefaultProvider().configure()
-				.buildValidatorFactory().getValidator();
+		for ( int i = 0; i < 100; i++ ) {
+			Validator validator = Validation.byDefaultProvider().configure()
+					.buildValidatorFactory().getValidator();
 
-		Set<ConstraintViolation<WebServiceImpl>> violations =
-				validator.forExecutables().validateParameters( service, method, params );
+			Set<ConstraintViolation<WebServiceImpl>> violations = validator.forExecutables().validateParameters( service, method, params );
 
-		assertThat( violations ).containsOnlyViolations( violationOf( NotNull.class ) );
+			assertThat( violations ).containsOnlyViolations( violationOf( NotNull.class ) );
+		}
 	}
 
 	private class WebServiceImpl extends AbstractWebService implements ExtendedWebService {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/MethodParameterConstraintsInParallelHierarchyTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/MethodParameterConstraintsInParallelHierarchyTest.java
@@ -1,0 +1,71 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.methodvalidation;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.testutil.TestForIssue;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class MethodParameterConstraintsInParallelHierarchyTest {
+
+	/**
+	 * NOTE: prior to the changes where this test was added it would fail randomly.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HV-1450")
+	public void testDeepParallelHierarchyIsProcessedCorrectly() throws Exception {
+
+		WebServiceImpl service = new WebServiceImpl();
+		Method method = WebServiceImpl.class.getMethod( "getEntityVersion", Long.class );
+		Object[] params = new Object[] { null };
+
+		Validator validator = Validation.byDefaultProvider().configure()
+				.buildValidatorFactory().getValidator();
+
+		Set<ConstraintViolation<WebServiceImpl>> violations =
+				validator.forExecutables().validateParameters( service, method, params );
+
+		assertThat( violations ).containsOnlyViolations( violationOf( NotNull.class ) );
+	}
+
+	private class WebServiceImpl extends AbstractWebService implements ExtendedWebService {
+
+	}
+
+	private abstract class AbstractWebService implements WebService {
+
+		@Override
+		public int getEntityVersion(Long id) {
+			return id.intValue();
+		}
+	}
+
+	private interface ExtendedWebService extends WebService {
+
+		@Override
+		int getEntityVersion(Long id);
+	}
+
+	private interface WebService {
+
+		int getEntityVersion(@NotNull Long id);
+	}
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1450

In the end it turned out that this could be fixed with not so much changes:
- changed the logic on how executable builder determines if it should accept a constrained element. Used a most specific sub type from the hierarchy under inspection to resolve executables and check if they override each other somewhere in the hierarchy.
- changed the order of metadata providers. Made annotation based as a first provider. This should build all possible builder delegates after the first iteration on metadata providers and data from other providers will be just merged in.