### PR TITLE
HV-1585 Omit the cache lookup in AbstractMessageInterpolator for the simple text messages

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/AbstractMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/AbstractMessageInterpolator.java
@@ -251,6 +251,12 @@ public abstract class AbstractMessageInterpolator implements MessageInterpolator
 	 * @return the interpolated message.
 	 */
 	private String interpolateMessage(String message, Context context, Locale locale) throws MessageDescriptorFormatException {
+		// if message does not contain something like "{message.key}" we can ignore next steps and just return
+		// the unescaped message. We don't want to store it in the map if cache is enabled to prevent map lookups.
+		if ( message.indexOf( '{' ) < 0 ) {
+			return replaceEscapedLiterals( message );
+		}
+
 		String resolvedMessage = null;
 
 		// either retrieve message from cache, or if message is not yet there or caching is disabled,
@@ -298,11 +304,6 @@ public abstract class AbstractMessageInterpolator implements MessageInterpolator
 	}
 
 	private String resolveMessage(String message, Locale locale) {
-		//if message does not contain something like "{message.key}" we can ignore next steps and just return the message
-		if ( message.indexOf( '{' ) < 0 ) {
-			return message;
-		}
-
 		String resolvedMessage = message;
 
 		ResourceBundle userResourceBundle = userResourceBundleLocator


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1585

Added a check to prevent map lookups in case of simple user defined message that does not require any message resolution and should not be stored in cache (if it is enabled).