### PR TITLE
HV-1587 Reduce significantly the tracking of already validated beans and constraints

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -814,7 +814,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 			ValidationOrder validationOrder) {
 		BeanMetaData<T> beanMetaData = validationContext.getRootBeanMetaData();
 
-		Optional<ExecutableMetaData> executableMetaDataOptional = beanMetaData.getMetaDataFor( validationContext.getExecutable() );
+		Optional<ExecutableMetaData> executableMetaDataOptional = validationContext.getExecutableMetaData();
 
 		if ( !executableMetaDataOptional.isPresent() ) {
 			// the method is unconstrained
@@ -1011,7 +1011,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 	private <V, T> void validateReturnValueInContext(ValidationContext<T> validationContext, T bean, V value, ValidationOrder validationOrder) {
 		BeanMetaData<T> beanMetaData = validationContext.getRootBeanMetaData();
 
-		Optional<ExecutableMetaData> executableMetaDataOptional = beanMetaData.getMetaDataFor( validationContext.getExecutable() );
+		Optional<ExecutableMetaData> executableMetaDataOptional = validationContext.getExecutableMetaData();
 
 		if ( !executableMetaDataOptional.isPresent() ) {
 			// the method is unconstrained

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaData.java
@@ -113,4 +113,9 @@ public interface BeanMetaData<T> extends Validatable {
 	 *         element itself and goes up the hierarchy chain. Interfaces are not included.
 	 */
 	List<Class<? super T>> getClassHierarchy();
+
+	/**
+	 * @return {@code true} if there is at least one cascading property in the bean metadata, {@code false} otherwise.
+	 */
+	boolean hasCascadingProperties();
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -135,6 +135,11 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	private final Set<Cascadable> cascadedProperties;
 
 	/**
+	 * Indicates if the bean has at least one cascading property.
+	 */
+	private final boolean hasCascadingProperties;
+
+	/**
 	 * The bean descriptor for this bean.
 	 */
 	private final BeanDescriptor beanDescriptor;
@@ -216,6 +221,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 
 		this.hasConstraints = hasConstraints;
 		this.cascadedProperties = CollectionHelper.toImmutableSet( cascadedProperties );
+		this.hasCascadingProperties = cascadedProperties.size() > 0;
 		this.allMetaConstraints = CollectionHelper.toImmutableSet( allMetaConstraints );
 
 		this.classHierarchyWithoutInterfaces = CollectionHelper.toImmutableList( ClassHierarchyHelper.getHierarchy(
@@ -283,6 +289,11 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	@Override
 	public Set<Cascadable> getCascadables() {
 		return cascadedProperties;
+	}
+
+	@Override
+	public boolean hasCascadingProperties() {
+		return hasCascadingProperties;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/ExecutableMetaData.java
@@ -76,6 +76,8 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 	private final ReturnValueMetaData returnValueMetaData;
 	private final ElementKind kind;
 
+	private final boolean hasCascadingParameters;
+
 	private ExecutableMetaData(
 			String name,
 			Type returnType,
@@ -84,7 +86,7 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 			Set<String> signatures,
 			Set<MetaConstraint<?>> returnValueConstraints,
 			Set<MetaConstraint<?>> returnValueContainerElementConstraints,
-			List<ParameterMetaData> parameterMetaData,
+			List<ParameterMetaData> parameterMetaDataList,
 			Set<MetaConstraint<?>> crossParameterConstraints,
 			CascadingMetaData cascadingMetaData,
 			boolean isConstrained,
@@ -99,7 +101,7 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 		);
 
 		this.parameterTypes = parameterTypes;
-		this.parameterMetaDataList = CollectionHelper.toImmutableList( parameterMetaData );
+		this.parameterMetaDataList = CollectionHelper.toImmutableList( parameterMetaDataList );
 		this.crossParameterConstraints = CollectionHelper.toImmutableSet( crossParameterConstraints );
 		this.signatures = signatures;
 		this.returnValueMetaData = new ReturnValueMetaData(
@@ -110,6 +112,8 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 		);
 		this.isGetter = isGetter;
 		this.kind = kind;
+
+		this.hasCascadingParameters = buildHasCascadingParameters( parameterMetaDataList );
 	}
 
 	/**
@@ -238,6 +242,19 @@ public class ExecutableMetaData extends AbstractConstraintMetaData {
 			return false;
 		}
 		return true;
+	}
+
+	public boolean hasCascadingParameters() {
+		return hasCascadingParameters;
+	}
+
+	private boolean buildHasCascadingParameters(List<ParameterMetaData> parameterMetaDataList) {
+		for ( ParameterMetaData parameterMetaData : parameterMetaDataList ) {
+			if ( parameterMetaData.isCascading() ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/MetaConstraint.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/MetaConstraint.java
@@ -56,6 +56,12 @@ public class MetaConstraint<A extends Annotation> {
 	private final int hashCode;
 
 	/**
+	 * Indicates if the constraint is defined for one group only: used to optimize already validated constraints
+	 * tracking.
+	 */
+	private final boolean isDefinedForOneGroupOnly;
+
+	/**
 	 * @param constraintDescriptor The constraint descriptor for this constraint
 	 * @param location meta data about constraint placement
 	 * @param valueExtractorDescriptors the potential {@link ValueExtractor}s used to extract the value to validate
@@ -67,6 +73,7 @@ public class MetaConstraint<A extends Annotation> {
 		this.location = location;
 		this.valueExtractionPath = getValueExtractionPath( valueExtractionPath );
 		this.hashCode = buildHashCode( constraintDescriptor, location );
+		this.isDefinedForOneGroupOnly = constraintDescriptor.getGroups().size() <= 1;
 	}
 
 	private static ValueExtractionPathNode getValueExtractionPath(List<ContainerClassTypeParameterAndExtractor> valueExtractionPath) {
@@ -83,6 +90,10 @@ public class MetaConstraint<A extends Annotation> {
 	 */
 	public final Set<Class<?>> getGroupList() {
 		return constraintTree.getDescriptor().getGroups();
+	}
+
+	public final boolean isDefinedForOneGroupOnly() {
+		return isDefinedForOneGroupOnly;
 	}
 
 	public final ConstraintDescriptorImpl<A> getDescriptor() {

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -172,6 +172,7 @@
                 <dependency>
                     <groupId>${project.groupId}</groupId>
                     <artifactId>hibernate-validator</artifactId>
+                    <version>${beanvalidation-impl.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish</groupId>
@@ -202,7 +203,7 @@
             </activation>
             <properties>
                 <beanvalidation-impl.name>Hibernate Validator</beanvalidation-impl.name>
-                <beanvalidation-impl.version>6.0.7.Final</beanvalidation-impl.version>
+                <beanvalidation-impl.version>6.0.8.Final</beanvalidation-impl.version>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1587

@gunnarmorling @marko-bekhta I think these changes are safe but I'm really interested in your feedback on this one as it's a rather bold change.

Before commit:
```
Result "org.hibernate.validator.performance.simple.SimpleValidation.testSimpleBeanValidation":
  1624.415 ±(99.9%) 21.333 ops/ms [Average]
  (min, avg, max) = (1555.542, 1624.415, 1668.294), stdev = 24.567
  CI (99.9%): [1603.082, 1645.748] (assumes normal distribution)
```

After commit:
```
Result "org.hibernate.validator.performance.simple.SimpleValidation.testSimpleBeanValidation":
  2023.440 ±(99.9%) 26.463 ops/ms [Average]
  (min, avg, max) = (1972.431, 2023.440, 2080.609), stdev = 30.475
  CI (99.9%): [1996.977, 2049.903] (assumes normal distribution)
```