### PR TITLE
HV-1588 Bail out faster during cascading validation when in fail fast mode

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -569,6 +569,10 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 					// validate cascading on the annotated object
 					if ( effectiveCascadingMetaData.isCascading() ) {
 						validateCascadedAnnotatedObjectForCurrentGroup( value, validationContext, valueContext, effectiveCascadingMetaData );
+
+						if ( shouldFailFast( validationContext ) ) {
+							break;
+						}
 					}
 
 					if ( effectiveCascadingMetaData.isContainer() ) {
@@ -578,6 +582,10 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 							// validate cascading on the container elements
 							validateCascadedContainerElementsForCurrentGroup( value, validationContext, valueContext,
 									containerCascadingMetaData.getContainerElementTypesCascadingMetaData() );
+
+							if ( shouldFailFast( validationContext ) ) {
+								break;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1588

If we don't do that, we do quite a lot of useless work.

Note that the tests was added to ensure this case also worked correctly.