### PR TITLE
Added new module with validation aspect

### DIFF
--- a/executable-validation/aspectj-validation/pom.xml
+++ b/executable-validation/aspectj-validation/pom.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.hibernate.validator</groupId>
+        <artifactId>hibernate-validator-executable-validation</artifactId>
+        <version>6.0.9-SNAPSHOT</version>
+    </parent>
+    <artifactId>hibernate-validator-aspectj-validation</artifactId>
+
+    <name>Hibernate Validator AspectJ Validation</name>
+
+    <properties>
+        <hibernate-validator-parent.path>../..</hibernate-validator-parent.path>
+        <automatic.module.name>org.hibernate.validator.aspectj.validation</automatic.module.name>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>de.thetaphi</groupId>
+                <artifactId>forbiddenapis</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <archive>
+                                <manifestEntries>
+                                    <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                                </manifestEntries>
+                            </archive>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.11</version>
+                <configuration>
+                    <complianceLevel>1.8</complianceLevel>
+                    <source>${maven.compiler.source}</source>
+                    <target>${maven.compiler.target}</target>
+                    <showWeaveInfo>true</showWeaveInfo>
+                    <verbose>true</verbose>
+                    <Xlint>ignore</Xlint>
+                    <encoding>UTF-8</encoding>
+                    <excludes>
+                        <exclude>**/logging/*.*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- Compile time dependencies -->
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+        </dependency>
+
+        <!-- Provided dependencies -->
+        <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-processor</artifactId>
+            <!--
+            HV-963
+            This is actually not a dependency which is needed at runtime, however,
+            Maven does not have a compile time only scope. The dependency is needed to
+            run the JBoss Logging annotation processor as part of the main compilation.
+            Trying different setups via compiler plugin local dependencies or extensions
+            all fail. See also http://stackoverflow.com/questions/14322904/maven-3-how-to-add-annotation-processor-dependency
+            -->
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-validator-test-utils</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/Validate.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/Validate.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.groups.Default;
+
+/**
+ * Marker annotation to filter the methods/constructors validation of
+ * which should be performed.
+ *
+ * @author Marko Bekhta
+ */
+@Target({ METHOD, /*TYPE,*/ CONSTRUCTOR })
+@Retention(RUNTIME)
+public @interface Validate {
+
+	/**
+	 * @return an array of validation groups for which validation should be applied.
+	 * 		Is empty by default, hence validation will run for {@link Default} group.
+	 */
+	Class<?>[] groups() default { };
+}

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/ServiceLoaderBasedValidatorFactoryProducer.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/ServiceLoaderBasedValidatorFactoryProducer.java
@@ -1,0 +1,68 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation.internal;
+
+import java.lang.invoke.MethodHandles;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+
+import org.hibernate.validator.aspectj.validation.internal.util.logging.Log;
+import org.hibernate.validator.aspectj.validation.internal.util.logging.LoggerFactory;
+import org.hibernate.validator.aspectj.validation.internal.util.privilegedactions.GetValidatorProviderFactoryFromServiceLoader;
+import org.hibernate.validator.aspectj.validation.spi.ValidatorFactoryProducer;
+
+/**
+ * Uses {@link ServiceLoader} mechanism to look up user provided {@link ValidatorFactoryProducer}.
+ * If none are found will provide a default {@link ValidatorFactory}.
+ *
+ * @author Marko Bekhta
+ */
+class ServiceLoaderBasedValidatorFactoryProducer {
+
+	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
+
+	private final ValidatorFactory validatorFactory;
+
+	ServiceLoaderBasedValidatorFactoryProducer() {
+		List<ValidatorFactoryProducer> validatorFactoryProducers = run( GetValidatorProviderFactoryFromServiceLoader.action() );
+		if ( validatorFactoryProducers.isEmpty() ) {
+			validatorFactory = Validation.buildDefaultValidatorFactory();
+			LOG.defaultValidatorUsage();
+		}
+		else {
+			ValidatorFactoryProducer producer = validatorFactoryProducers.get( 0 );
+			try {
+				validatorFactory = producer.getConfiguredValidatorFactory();
+				if ( validatorFactoryProducers.size() > 1 ) {
+					LOG.multipleValidatorFactoryProducers( producer.getClass() );
+				}
+			}
+			catch (Exception e) {
+				throw LOG.errorCreatingValidatorFactoryFromProducer( producer.getClass(), e );
+			}
+		}
+	}
+
+	public ValidatorFactory getValidatorFactory() {
+		return validatorFactory;
+	}
+
+	/**
+	 * Runs the given privileged action, using a privileged block if required.
+	 * <p>
+	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
+	 * privileged actions within HV's protection domain.
+	 */
+	private static <T> T run(PrivilegedAction<T> action) {
+		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
+	}
+}

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/ValidationAspect.aj
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/ValidationAspect.aj
@@ -1,0 +1,125 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation.internal;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validator;
+import javax.validation.executable.ExecutableValidator;
+
+import org.hibernate.validator.aspectj.validation.Validate;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.ConstructorSignature;
+import org.aspectj.lang.reflect.MethodSignature;
+
+/**
+ * An aspect that contains all the pointcuts and validation advices for method/constructor
+ * validation. Uses {@link ServiceLoaderBasedValidatorFactoryProducer} to get an instance
+ * of {@link Validator}.
+ *
+ * @author Marko Bekhta
+ */
+@Aspect
+public aspect ValidationAspect {
+
+	private final ExecutableValidator executableValidator;
+
+	{
+		// initialize an executable validator from a loaded validator factory:
+		ServiceLoaderBasedValidatorFactoryProducer producer = new ServiceLoaderBasedValidatorFactoryProducer();
+		executableValidator = producer.getValidatorFactory().getValidator().forExecutables();
+	}
+
+	/**
+	 * Defines a pointcut that looks for {@code @Validate} annotated elements. Used to build up advices.
+	 *
+	 * @param validate a reference to the annotation
+	 */
+	pointcut annotationPointCutDefinition(Validate validate): @annotation(validate);
+
+	/**
+	 * Defines a pointcut that looks for any method executions. Used to build up advices.
+	 */
+	pointcut atMethodExecution(): execution(* *(..));
+
+	/**
+	 * Defines a pointcut that looks for any constructor executions. Used to build up advices.
+	 * @param jp a joint point of constructor execution
+	 */
+	pointcut atConstructorExecution(): execution(*.new(..));
+
+	/**
+	 * Defines an advice for validation of method parameters
+	 */
+	before(Validate validate): annotationPointCutDefinition(validate) && atMethodExecution() {
+		Set<ConstraintViolation<Object>> violations = executableValidator.validateParameters(
+				thisJoinPoint.getTarget(),
+				( (MethodSignature) thisJoinPoint.getSignature() ).getMethod(),
+				thisJoinPoint.getArgs(),
+				validate.groups()
+		);
+
+		// if there are any violations - throw a ConstraintViolationException
+		if ( !violations.isEmpty() ) {
+			throw new ConstraintViolationException( violations );
+		}
+	}
+
+	/**
+	 * Defines an advice for validation of method return value
+	 */
+	after(Validate validate) returning(Object returnValue): annotationPointCutDefinition(validate) && atMethodExecution() {
+		Set<ConstraintViolation<Object>> violations = executableValidator.validateReturnValue(
+				thisJoinPoint.getTarget(),
+				( (MethodSignature) thisJoinPoint.getSignature() ).getMethod(),
+				returnValue,
+				validate.groups()
+		);
+
+		// if there are any violations - throw a ConstraintViolationException
+		if ( !violations.isEmpty() ) {
+			throw new ConstraintViolationException( violations );
+		}
+	}
+
+	/**
+	 * Defines an advice for validation of constructor parameters
+	 */
+	before(Validate validate): annotationPointCutDefinition(validate) && atConstructorExecution() {
+		Set<ConstraintViolation<Object>> violations = executableValidator.validateConstructorParameters(
+				( (ConstructorSignature) thisJoinPoint.getSignature() ).getConstructor(),
+				thisJoinPoint.getArgs(),
+				validate.groups()
+		);
+
+		// if there are any violations - throw a ConstraintViolationException
+		if ( !violations.isEmpty() ) {
+			throw new ConstraintViolationException( violations );
+		}
+	}
+
+
+	/**
+	 * Defines an advice for validation of method return value
+	 */
+	after(Validate validate): annotationPointCutDefinition(validate) && atConstructorExecution() {
+		Set<ConstraintViolation<Object>> violations = executableValidator.validateConstructorReturnValue(
+				( (ConstructorSignature) thisJoinPoint.getSignature() ).getConstructor(),
+				thisJoinPoint.getTarget(),
+				validate.groups()
+		);
+
+		// if there are any violations - throw a ConstraintViolationException
+		if ( !violations.isEmpty() ) {
+			throw new ConstraintViolationException( violations );
+		}
+	}
+
+}

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/package-info.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+/**
+ * This package is part of the private Hibernate Validator API.
+ */
+package org.hibernate.validator.aspectj.validation.internal;

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/logging/Log.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/logging/Log.java
@@ -1,0 +1,42 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation.internal.util.logging;
+
+import static org.jboss.logging.Logger.Level.INFO;
+
+import org.hibernate.validator.aspectj.validation.internal.util.logging.formatter.ClassObjectFormatter;
+import org.hibernate.validator.aspectj.validation.spi.ValidatorFactoryProducer;
+
+import org.jboss.logging.BasicLogger;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.FormatWith;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
+
+/**
+ * The Hibernate Validator AspectJ Validation logger interface for JBoss Logging.
+ * <p>
+ * New log messages must always use an incremented message id.
+ *
+ * @author Marko Bekhta
+ */
+@MessageLogger(projectCode = "HVAJV")
+public interface Log extends BasicLogger {
+
+	@LogMessage(level = INFO)
+	@Message(id = 1, value = "No ValidatorFactoryProducers were found. Using a default ValidatorFactory.")
+	void defaultValidatorUsage();
+
+	@LogMessage(level = INFO)
+	@Message(id = 2, value = "Multiple ValidatorFactoryProducers were found. Check your configuration. Using one of the found producers (%s).")
+	void multipleValidatorFactoryProducers(Class<? extends ValidatorFactoryProducer> aClass);
+
+	@Message(id = 3, value = "Unable to create ValidatorFactory using %1$s producer.")
+	IllegalStateException errorCreatingValidatorFactoryFromProducer(@FormatWith(ClassObjectFormatter.class) Class<? extends ValidatorFactoryProducer> aClass, @Cause Exception cause);
+
+}

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/logging/LoggerFactory.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/logging/LoggerFactory.java
@@ -1,0 +1,29 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation.internal.util.logging;
+
+import java.lang.invoke.MethodHandles.Lookup;
+
+import org.jboss.logging.Logger;
+
+/**
+ * @author Hardy Ferentschik
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2012 SERLI
+ * @author Sanne Grinovero
+ */
+public final class LoggerFactory {
+
+	public static Log make(final Lookup creationContext) {
+		final String className = creationContext.lookupClass().getName();
+		return Logger.getMessageLogger( Log.class, className );
+	}
+
+	// private constructor to avoid instantiation
+	private LoggerFactory() {
+	}
+}
+

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/logging/formatter/ClassObjectFormatter.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/logging/formatter/ClassObjectFormatter.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation.internal.util.logging.formatter;
+
+/**
+ * Used with JBoss Logging to display class names in log messages.
+ *
+ * @author Gunnar Morling
+ */
+public class ClassObjectFormatter {
+
+	private final String stringRepresentation;
+
+	public ClassObjectFormatter(Class<?> clazz) {
+		this.stringRepresentation = clazz.getName();
+	}
+
+	@Override
+	public String toString() {
+		return stringRepresentation;
+	}
+}

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/logging/formatter/package-info.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/logging/formatter/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+/**
+ * Contains formatters used by the {@link org.hibernate.validator.aspectj.validation.internal.util.logging.Log}.
+ * <p>
+ * This package is part of the private Hibernate Validator API.
+ */
+package org.hibernate.validator.aspectj.validation.internal.util.logging.formatter;

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/logging/package-info.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/logging/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+/**
+ * <p>
+ * This package is part of the private Hibernate Validator API.
+ */
+package org.hibernate.validator.aspectj.validation.internal.util.logging;

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/package-info.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+/**
+ * This package is part of the private Hibernate Validator API.
+ */
+package org.hibernate.validator.aspectj.validation.internal.util;

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/privilegedactions/GetValidatorProviderFactoryFromServiceLoader.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/privilegedactions/GetValidatorProviderFactoryFromServiceLoader.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation.internal.util.privilegedactions;
+
+import java.security.PrivilegedAction;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.hibernate.validator.aspectj.validation.spi.ValidatorFactoryProducer;
+
+/**
+ * A privileged action that accesses {@link ServiceLoader} mechanism to lookup
+ * a list of {@link ValidatorFactoryProducer}.
+ *
+ * @author Marko Bekhta
+ */
+public class GetValidatorProviderFactoryFromServiceLoader implements PrivilegedAction<List<ValidatorFactoryProducer>> {
+
+	private GetValidatorProviderFactoryFromServiceLoader() {
+	}
+
+	public static GetValidatorProviderFactoryFromServiceLoader action() {
+		return new GetValidatorProviderFactoryFromServiceLoader();
+	}
+
+	@Override
+	public List<ValidatorFactoryProducer> run() {
+		return loadInstances( GetValidatorProviderFactoryFromServiceLoader.class.getClassLoader() );
+
+	}
+
+	private List<ValidatorFactoryProducer> loadInstances(ClassLoader classloader) {
+		ServiceLoader<ValidatorFactoryProducer> loader = ServiceLoader.load( ValidatorFactoryProducer.class, classloader );
+
+		Iterable<ValidatorFactoryProducer> iterable = () -> loader.iterator();
+		return StreamSupport.stream( iterable.spliterator(), false )
+				.collect( Collectors.toList() );
+	}
+}

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/privilegedactions/package-info.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/internal/util/privilegedactions/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+/**
+ * Contains privileged actions that should run within security manager.
+ * <p>
+ * This package is part of the private Hibernate Validator API.
+ */
+package org.hibernate.validator.aspectj.validation.internal.util.privilegedactions;

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/package-info.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+/**
+ * Contains {@link org.hibernate.validator.aspectj.validation.Validate} marker annotation to mark methods for validation.
+ * <p>
+ * This package is part of the public Hibernate Validator API.
+ */
+package org.hibernate.validator.aspectj.validation;

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/spi/ValidatorFactoryProducer.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/spi/ValidatorFactoryProducer.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation.spi;
+
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+
+/**
+ * Interface that should be implemented by end users to provide configured
+ * {@link ValidatorFactory}.
+ *
+ * @author Marko Bekhta
+ */
+public interface ValidatorFactoryProducer {
+
+	/**
+	 * @return configured {@link ValidatorFactory} that will be used to create
+	 * 		{@link Validator} to perform executable validation.
+	 */
+	ValidatorFactory getConfiguredValidatorFactory();
+}

--- a/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/spi/package-info.java
+++ b/executable-validation/aspectj-validation/src/main/java/org/hibernate/validator/aspectj/validation/spi/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+/**
+ * Contains an interface {@link org.hibernate.validator.aspectj.validation.spi.ValidatorFactoryProducer}
+ * that can be implemented by users to configure and build a {@link javax.validation.ValidatorFactory}.
+ * <p>
+ * This package is part of the public Hibernate Validator API.
+ */
+package org.hibernate.validator.aspectj.validation.spi;

--- a/executable-validation/aspectj-validation/src/test/java/org/hibernate/validator/aspectj/validation/internal/AspectValidationTest.java
+++ b/executable-validation/aspectj-validation/src/test/java/org/hibernate/validator/aspectj/validation/internal/AspectValidationTest.java
@@ -1,0 +1,95 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation.internal;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.hibernate.validator.aspectj.validation.Validate;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class AspectValidationTest {
+
+	@Test
+	public void testValidationOfMethodParameters() throws Exception {
+		Foo foo = new Foo( "", 1 );
+		assertThatThrownBy( () -> foo.doNoting( null ) )
+				.isInstanceOf( ConstraintViolationException.class )
+				.hasMessageContaining( "must not be null" );
+	}
+
+	@Test
+	public void testValidationOnMethodReturnValue() throws Exception {
+		Foo foo = new Foo( null, 1 );
+		assertThatThrownBy( () -> foo.getString() )
+				.isInstanceOf( ConstraintViolationException.class )
+				.hasMessageContaining( "must not be null" );
+	}
+
+	@Test
+	public void testValidationOnConstructorParameters() throws Exception {
+		assertThatThrownBy( () -> new Foo( 1 ) )
+				.isInstanceOf( ConstraintViolationException.class )
+				.hasMessageContaining( "must be greater than or equal to 10" );
+	}
+
+	@Test
+	public void testValidationOnConstructorReturnValue() throws Exception {
+		assertThatThrownBy( () -> new Foo( "" ) )
+				.isInstanceOf( ConstraintViolationException.class )
+				.hasMessageContaining( "size must be between 100 and 1000" );
+	}
+
+	public static class Foo {
+
+		@Size(min = 100, max = 1000)
+		private final String string;
+		private final int number;
+
+		public Foo(String string, int number) {
+			this.string = string;
+			this.number = number;
+		}
+
+		@Validate
+		public Foo(@Min(10) int number) {
+			this.number = number;
+			this.string = Integer.toString( number );
+		}
+
+		@Validate
+		@Valid
+		public Foo(String string) {
+			this.number = 10;
+			this.string = string;
+		}
+
+		@NotNull
+		@Validate
+		public String getString() {
+			return string;
+		}
+
+		@Validate
+		public void doNoting(@NotNull String justString) {
+
+		}
+
+		public int getNumber() {
+			return number;
+		}
+	}
+}

--- a/executable-validation/aspectj-validation/src/test/java/org/hibernate/validator/aspectj/validation/internal/ServiceLoaderBasedValidatorFactoryProducerTest.java
+++ b/executable-validation/aspectj-validation/src/test/java/org/hibernate/validator/aspectj/validation/internal/ServiceLoaderBasedValidatorFactoryProducerTest.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ServiceLoader;
+
+import javax.validation.ValidatorFactory;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class ServiceLoaderBasedValidatorFactoryProducerTest {
+
+	/**
+	 * Test that producer is correctly loaded by {@link ServiceLoader} by checking the type of configured clock provider.
+	 */
+	@Test
+	public void testGetValidatorFactory() throws Exception {
+		ServiceLoaderBasedValidatorFactoryProducer producer = new ServiceLoaderBasedValidatorFactoryProducer();
+		ValidatorFactory validatorFactory = producer.getValidatorFactory();
+		assertThat( validatorFactory.getClockProvider() ).isInstanceOf( ValidatorFactoryProducerTestImpl.FixedClockProvider.class );
+	}
+}

--- a/executable-validation/aspectj-validation/src/test/java/org/hibernate/validator/aspectj/validation/internal/ValidatorFactoryProducerTestImpl.java
+++ b/executable-validation/aspectj-validation/src/test/java/org/hibernate/validator/aspectj/validation/internal/ValidatorFactoryProducerTestImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.aspectj.validation.internal;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import javax.validation.ClockProvider;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+
+import org.hibernate.validator.aspectj.validation.spi.ValidatorFactoryProducer;
+
+/**
+ * @author Marko Bekhta
+ */
+public class ValidatorFactoryProducerTestImpl implements ValidatorFactoryProducer {
+
+	@Override
+	public ValidatorFactory getConfiguredValidatorFactory() {
+		return Validation.byDefaultProvider().configure()
+				.clockProvider( new FixedClockProvider() )
+				.buildValidatorFactory();
+	}
+
+	public static class FixedClockProvider implements ClockProvider {
+
+		@Override
+		public Clock getClock() {
+			ZonedDateTime dateTime = ZonedDateTime.of( LocalDateTime.of( 2018, 3, 13, 0, 0 ), ZoneOffset.ofHours( 0 ) );
+			return Clock.fixed( dateTime.toInstant(), dateTime.getZone() );
+		}
+	}
+}

--- a/executable-validation/aspectj-validation/src/test/resources/META-INF/services/org.hibernate.validator.aspectj.validation.spi.ValidatorFactoryProducer
+++ b/executable-validation/aspectj-validation/src/test/resources/META-INF/services/org.hibernate.validator.aspectj.validation.spi.ValidatorFactoryProducer
@@ -1,0 +1,1 @@
+org.hibernate.validator.aspectj.validation.internal.ValidatorFactoryProducerTestImpl

--- a/executable-validation/pom.xml
+++ b/executable-validation/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.hibernate.validator</groupId>
+        <artifactId>hibernate-validator-parent</artifactId>
+        <version>6.0.9-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>hibernate-validator-executable-validation</artifactId>
+    <packaging>pom</packaging>
+
+    <name>Hibernate Validator Executable Validation</name>
+    <description>Hibernate Validator Executable Validation modules aggregator</description>
+
+    <properties>
+        <hibernate-validator-parent.path>..</hibernate-validator-parent.path>
+
+        <aspectj.version>1.8.13</aspectj.version>
+    </properties>
+
+    <modules>
+        <module>aspectj-validation</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjrt</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.aspectj</groupId>
+                <artifactId>aspectjtools</artifactId>
+                <version>${aspectj.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <module>modules</module>
         <module>tck-runner</module>
         <module>annotation-processor</module>
+        <module>executable-validation</module>
         <module>integration</module>
         <module>performance</module>
         <module>osgi</module>


### PR DESCRIPTION
Hi @gsmet ! Here's a separate module with an AspectJ validation that we talked earlier.  I've:

- added new module. It is under a new parent module as I would also like to investigate the ByteBuddy approach as well and see if we could give users different options to choose from. 
- created an aspect to validate methods and constructors. It is using a different syntax from the aspect that I've showed previously as it turned out that the initial approach caused issues with return value validation.
- added validator factory producer to get initialized validation factor. This uses the `ServiceLoader` to get initialized `ValidationFactory`. I haven't figured a different way to pass it to the aspect yet.
- there are 4 simple tests to show how the validation would work with such aspect.

If we would want to proceed in this direction I would probably work on some documentation to explain how this can be used by the users and also I would really like to add an option to HV to read metadata from static methods and use it in combination with aspects to validate calls of static methods.