### PR TITLE
HV-1599 Avoid creating later discarded violations when reportAsSingleViolation is true

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidationContext.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.validation.ClockProvider;
 import javax.validation.ConstraintValidatorFactory;
@@ -33,7 +32,6 @@ import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.ValidatorFactoryImpl.ValidatorFactoryScopedContext;
-import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintViolationCreationContext;
 import org.hibernate.validator.internal.engine.path.PathImpl;
@@ -272,14 +270,6 @@ public class ValidationContext<T> {
 		return constraintValidatorInitializationContext;
 	}
 
-	public Set<ConstraintViolation<T>> createConstraintViolations(ValueContext<?, ?> localContext,
-			ConstraintValidatorContextImpl constraintValidatorContext) {
-
-		return constraintValidatorContext.getConstraintViolationCreationContexts().stream()
-			.map( c -> createConstraintViolation( localContext, c, constraintValidatorContext.getConstraintDescriptor() ) )
-			.collect( Collectors.toSet() );
-	}
-
 	public ConstraintValidatorFactory getConstraintValidatorFactory() {
 		return constraintValidatorFactory;
 	}
@@ -308,16 +298,19 @@ public class ValidationContext<T> {
 		markCurrentBeanAsProcessedForCurrentPath( valueContext.getCurrentBean(), valueContext.getPropertyPath() );
 	}
 
-	public void addConstraintFailures(Set<ConstraintViolation<T>> failingConstraintViolations) {
-		this.failingConstraintViolations.addAll( failingConstraintViolations );
+	public void addConstraintFailure(ConstraintViolation<T> failingConstraintViolation) {
+		this.failingConstraintViolations.add( failingConstraintViolation );
 	}
 
 	public Set<ConstraintViolation<T>> getFailingConstraints() {
 		return failingConstraintViolations;
 	}
 
-
-	public ConstraintViolation<T> createConstraintViolation(ValueContext<?, ?> localContext, ConstraintViolationCreationContext constraintViolationCreationContext, ConstraintDescriptor<?> descriptor) {
+	public ConstraintViolation<T> createConstraintViolation(
+			ValueContext<?, ?> localContext,
+			ConstraintViolationCreationContext constraintViolationCreationContext,
+			ConstraintDescriptor<?> descriptor
+	) {
 		String messageTemplate = constraintViolationCreationContext.getMessage();
 		String interpolatedMessage = interpolate(
 				messageTemplate,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/SimpleConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/SimpleConstraintTree.java
@@ -9,10 +9,9 @@ package org.hibernate.validator.internal.engine.constraintvalidation;
 import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Type;
-import java.util.Set;
+import java.util.Collection;
 
 import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintViolation;
 
 import org.hibernate.validator.internal.engine.ValidationContext;
 import org.hibernate.validator.internal.engine.ValueContext;
@@ -41,7 +40,7 @@ class SimpleConstraintTree<B extends Annotation> extends ConstraintTree<B> {
 	@Override
 	protected <T> void validateConstraints(ValidationContext<T> validationContext,
 			ValueContext<?, ?> valueContext,
-			Set<ConstraintViolation<T>> constraintViolations) {
+			Collection<ConstraintValidatorContextImpl> violatedConstraintValidatorContexts) {
 
 		if ( LOG.isTraceEnabled() ) {
 			LOG.tracef(
@@ -64,13 +63,8 @@ class SimpleConstraintTree<B extends Annotation> extends ConstraintTree<B> {
 		);
 
 		// validate
-		constraintViolations.addAll(
-				validateSingleConstraint(
-						validationContext,
-						valueContext,
-						constraintValidatorContext,
-						validator
-				)
-		);
+		if ( validateSingleConstraint( valueContext, constraintValidatorContext, validator ).isPresent() ) {
+			violatedConstraintValidatorContexts.add( constraintValidatorContext );
+		}
 	}
 }

--- a/performance/src/main/java/org/hibernate/validator/performance/simple/SimpleComposingConstraintValidation.java
+++ b/performance/src/main/java/org/hibernate/validator/performance/simple/SimpleComposingConstraintValidation.java
@@ -1,0 +1,104 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.performance.simple;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintViolation;
+import javax.validation.Payload;
+import javax.validation.ReportAsSingleViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * @author Marko Bekhta
+ */
+public class SimpleComposingConstraintValidation {
+
+	@State(Scope.Benchmark)
+	public static class ValidationState {
+
+		public volatile Validator validator;
+
+		{
+			ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+			validator = factory.getValidator();
+		}
+
+	}
+
+	@Benchmark
+	@BenchmarkMode(Mode.Throughput)
+	@OutputTimeUnit(TimeUnit.MILLISECONDS)
+	@Fork(value = 1)
+	@Threads(50)
+	@Warmup(iterations = 10)
+	@Measurement(iterations = 20)
+	public void testSimpleComposingConstraintValidation(ValidationState state, Blackhole bh) {
+		Foo foo = new Foo( "" );
+		Set<ConstraintViolation<Foo>> violations = state.validator.validate( foo );
+		bh.consume( violations );
+	}
+
+	public static class Foo {
+
+		@ComposingConstraint
+		private final String foo;
+
+		public Foo(String foo) {
+			this.foo = foo;
+		}
+	}
+
+	@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+	@Retention(RUNTIME)
+	@Documented
+	@Constraint(validatedBy = { })
+	@ReportAsSingleViolation
+	@NotNull
+	@Size(min = 1)
+	@NotBlank
+	@NotEmpty
+	@interface ComposingConstraint {
+
+		String message() default "message";
+
+		Class<?>[] groups() default { };
+
+		Class<? extends Payload>[] payload() default { };
+	}
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1599

Changed when the violation is created in ConstraintTree
- delayed creating of violation when validating constraint in ConstraintTree
- added a benchmark to SimpleValidation with composing constraint validation

And the benchmark results:
master:
```bash
# Run complete. Total time: 00:01:16

Benchmark                                                  Mode  Cnt     Score    Error   Units
SimpleValidation.testSimpleBeanValidation                 thrpt   20  2398.520 ± 39.749  ops/ms
SimpleValidation.testSimpleComposingConstraintValidation  thrpt   20  2824.607 ± 44.032  ops/ms
```

and with these changes:
```bash
# Run complete. Total time: 00:01:15

Benchmark                                                  Mode  Cnt     Score     Error   Units
SimpleValidation.testSimpleBeanValidation                 thrpt   20  2557.733 ± 327.732  ops/ms
SimpleValidation.testSimpleComposingConstraintValidation  thrpt   20  3580.094 ± 468.561  ops/ms
```