### PR TITLE
HV-1609 Change the way of filtering which beans to process in CDI extension

### DIFF
--- a/cdi/src/main/java/org/hibernate/validator/cdi/internal/ValidateableBeanFilter.java
+++ b/cdi/src/main/java/org/hibernate/validator/cdi/internal/ValidateableBeanFilter.java
@@ -1,0 +1,131 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.cdi.internal;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.enterprise.inject.spi.WithAnnotations;
+import javax.validation.Constraint;
+import javax.validation.Valid;
+import javax.validation.executable.ValidateOnExecution;
+
+import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
+
+/**
+ * A filter that checks if the passed class has any of these annotations:
+ * <ul>
+ * <li>{@link Valid}</li>
+ * <li>{@link Constraint}</li>
+ * <li>{@link ValidateOnExecution}</li>
+ * </ul>
+ * <p>
+ * on a type level, or on any member, or any parameter of any member. Super classes
+ * and all implemetned interfaces are considered while looking for these annotations.
+ * <p>
+ * The annotation may be applied as a meta-annotation on any annotation considered.
+ * <p>
+ * This filter is needed as {@link WithAnnotations} does not look into class hierarchy
+ * to look for annotations.
+ *
+ * @author Marko Bekhta
+ */
+public class ValidateableBeanFilter implements Predicate<Class<?>> {
+
+	private static final Set<Class<? extends Annotation>> ALLOWED_ANNOTATIONS = Collections.unmodifiableSet(
+			CollectionHelper.asSet( Valid.class, Constraint.class, ValidateOnExecution.class )
+	);
+
+	@Override
+	public boolean test(Class<?> type) {
+		for ( Class<?> clazz : ClassHierarchyHelper.getHierarchy( type ) ) {
+			if ( isAnnotationPresentAnywhere( clazz ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean isAnnotationPresentAnywhere(Class<?> clazz) {
+		Set<Annotation> processedAnnotations = new HashSet<>();
+		// 1. Is present on a type level:
+		if ( isAnnotationPresentIn( clazz.getDeclaredAnnotations(), processedAnnotations ) ) {
+			return true;
+		}
+
+		// 2. Or on a field level
+		for ( Field field : clazz.getDeclaredFields() ) {
+			if ( isAnnotationPresentIn( field.getDeclaredAnnotations(), processedAnnotations ) ) {
+				return true;
+			}
+		}
+		// 3. Or on any executable.
+		// 3.1 Constructors:
+		for ( Constructor<?> constructor : clazz.getDeclaredConstructors() ) {
+			if ( isAnnotationPresentOn( constructor, processedAnnotations ) ) {
+				return true;
+			}
+		}
+
+		// 3.2 Constructors:
+		for ( Method method : clazz.getDeclaredMethods() ) {
+			if ( isAnnotationPresentOn( method, processedAnnotations ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isAnnotationPresentIn(Annotation[] annotations, Set<Annotation> processedAnnotations) {
+		for ( Annotation annotation : annotations ) {
+			if ( isAnnotationAllowed( annotation, processedAnnotations ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isAnnotationPresentOn(Executable executable, Set<Annotation> processedAnnotations) {
+		// Check the executable itself first:
+		if ( isAnnotationPresentIn( executable.getDeclaredAnnotations(), processedAnnotations ) ) {
+			return true;
+		}
+		// Then check its parameters:
+		for ( Annotation[] annotations : executable.getParameterAnnotations() ) {
+			if ( isAnnotationPresentIn( annotations, processedAnnotations ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean isAnnotationAllowed(Annotation annotationToCheck, Set<Annotation> processedAnnotations) {
+		// Need to have this to prevent infinite loops, for example on annotations like @Target
+		if ( !processedAnnotations.add( annotationToCheck ) ) {
+			return false;
+		}
+		Class<? extends Annotation> annotationType = annotationToCheck.annotationType();
+		if ( ALLOWED_ANNOTATIONS.contains( annotationType ) ) {
+			return true;
+		}
+		for ( Annotation annotation : annotationType.getDeclaredAnnotations() ) {
+			if ( isAnnotationAllowed( annotation, processedAnnotations ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/ValidateableBeanFilterTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/ValidateableBeanFilterTest.java
@@ -1,0 +1,162 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.cdi.internal;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.function.Predicate;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Min;
+import javax.validation.executable.ExecutableType;
+import javax.validation.executable.ValidateOnExecution;
+
+import org.hibernate.validator.cdi.internal.ValidateableBeanFilter;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class ValidateableBeanFilterTest {
+
+	private Predicate<Class<?>> predicate;
+
+	@BeforeMethod
+	public void setUp() {
+		this.predicate = new ValidateableBeanFilter();
+	}
+
+	@Test
+	public void test() {
+		// Cases where no needed annotation is present:
+		// 1. Object doesn't have any needed annotations
+		assertFalse( predicate.test( Object.class ) );
+		// 2. Simple class with no annotations
+		assertFalse( predicate.test( SimpleClassWithNoAnnotations.class ) );
+		// 3. Class that implements a lot of interfaces but there's no need annotations on it
+		assertFalse( predicate.test( ImplementsALotOfInterfacesButNonAreAnnotated.class ) );
+
+		// Cases where annotation could be found somewhere:
+		// 1. A constraint annotation on an interface
+		assertTrue( predicate.test( InterfaceWithConstraintAnnotation.class ) );
+		// 2. Class that doesn't have any own annotations but implements an interface with one
+		assertTrue( predicate.test( NoAnnotationsOfItsOwnButImplementsAnnotatedInterface.class ) );
+		// 3. Class with deeper hierarchy and it's own annotation
+		assertTrue( predicate.test( ExtendsCleanClassButHasOwnAnnotation.class ) );
+
+		// 4. Interface with @Valid and class that implements it
+		assertTrue( predicate.test( ImplementsInterfaceWithValidAnnotation.class ) );
+		assertTrue( predicate.test( InterfaceWithValidAnnotation.class ) );
+
+		// 5. Interface with constraint and class that implements it
+		assertTrue( predicate.test( InterfaceWithConstraintAnnotation.class ) );
+		assertTrue( predicate.test( ImplementsInterfaceWithConstraintAnnotation.class ) );
+
+		// 6. Interface @ValidateOnExecution with and class that implements it
+		assertTrue( predicate.test( ImplementsInterfaceWithValidateOnExecutionAnnotation.class ) );
+		assertTrue( predicate.test( InterfaceWithValidateOnExecutionAnnotation.class ) );
+
+		// 7. Class with annotated field:
+		assertTrue( predicate.test( AnnotatedField.class ) );
+
+		// 8. Class with annotated constructor
+		assertTrue( predicate.test( AnnotatedConstructor.class ) );
+	}
+
+	private static class AnnotatedConstructor {
+		@Valid
+		public AnnotatedConstructor() {
+		}
+	}
+
+	private static class AnnotatedField {
+		@Min(10)
+		private int num;
+	}
+
+	private static class SimpleClassWithNoAnnotations {
+
+		public void doNothing() {
+		}
+	}
+
+	private static class NoAnnotationsOfItsOwnButImplementsAnnotatedInterface extends SimpleClassWithNoAnnotations implements InterfaceWithConstraintAnnotation {
+
+		@Override
+		public int bar() {
+			return 0;
+		}
+
+		public void doSomething(int foo) {
+		}
+	}
+
+	interface InterfaceWithConstraintAnnotation {
+
+		@Min(10)
+		int bar();
+	}
+
+	private static class ImplementsInterfaceWithConstraintAnnotation implements InterfaceWithConstraintAnnotation {
+
+		@Override
+		public int bar() {
+			return 0;
+		}
+	}
+
+	interface InterfaceWithValidAnnotation {
+
+		@Valid
+		SimpleClassWithNoAnnotations bar();
+	}
+
+	private static class ImplementsInterfaceWithValidAnnotation implements InterfaceWithValidAnnotation {
+
+		@Override
+		public SimpleClassWithNoAnnotations bar() {
+			return null;
+		}
+	}
+
+	@ValidateOnExecution(type = ExecutableType.NON_GETTER_METHODS)
+	interface InterfaceWithValidateOnExecutionAnnotation {
+
+		int bar();
+	}
+
+	private static class ImplementsInterfaceWithValidateOnExecutionAnnotation implements InterfaceWithValidateOnExecutionAnnotation {
+		public int bar() {
+			return 0;
+		}
+	}
+
+	private static class ImplementsALotOfInterfacesButNonAreAnnotated implements Serializable, Predicate<Integer>, Comparable<ImplementsALotOfInterfacesButNonAreAnnotated> {
+
+		@Override
+		public int compareTo(ImplementsALotOfInterfacesButNonAreAnnotated o) {
+			return 0;
+		}
+
+		@Override
+		public boolean test(Integer integer) {
+			return false;
+		}
+	}
+
+	private static class ExtendsCleanClassButHasOwnAnnotation extends ImplementsALotOfInterfacesButNonAreAnnotated {
+
+		@ValidateOnExecution
+		public int bar() {
+			return 0;
+		}
+	}
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1609

I've got the answer on our question about `@WithAnnotations` and it turns out that such behavior is dictated by the [CDI spec](http://docs.jboss.org/cdi/spec/2.0/cdi-spec.html#process_annotated_type):

> The annotation @WithAnnotations may be applied to the event parameter. If the annotation is applied, the container must only deliver ProcessAnnotatedType events for types which contain at least one of the annotations specified.

Hence there's not much can be done in this direction. So I've removed the annotation and added a custom filter to determine if we should try to wrap a bean with validation proxy.

I tried to run the same tests for tck 2.0.3 that were failing and with these changes all seems good.

If such approach is OK I'll create a JIRA ticket and update the commit message with it.

Link to mailing list - http://lists.jboss.org/pipermail/weld-dev/2018-May/003670.html