### PR TITLE
HV-1607 Make the build work with JDK 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,6 @@
         <module>annotation-processor</module>
         <module>integration</module>
         <module>performance</module>
-        <module>osgi</module>
     </modules>
 
     <properties>
@@ -573,7 +572,7 @@
                 <plugin>
                     <groupId>de.thetaphi</groupId>
                     <artifactId>forbiddenapis</artifactId>
-                    <version>2.4.1</version>
+                    <version>2.5</version>
                     <configuration>
                         <!-- if the Java version used is too new, don't fail, just do nothing -->
                         <failOnUnsupportedJava>false</failOnUnsupportedJava>
@@ -1130,7 +1129,16 @@
             </build>
         </profile>
         <profile>
-            <id>jdk9</id>
+            <id>jdk9-</id>
+            <activation>
+                <jdk>(,9]</jdk>
+            </activation>
+            <modules>
+                <module>osgi</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>jdk9+</id>
             <activation>
                 <jdk>[9,)</jdk>
             </activation>


### PR DESCRIPTION
We need prevent the OSGi integration tests from running on JDK 10 for
now as pax-exam does not support JDK 10.

It will be fixed in the not yet released pax-exam 4.12.

 * https://hibernate.atlassian.net/browse/HV-1607