### PR TITLE
HV-1534 <getter> property validation doesn't work when using <constraint-mappings> xml configuration

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/TypeConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/TypeConstraintMappingContextImpl.java
@@ -34,14 +34,13 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.ExecutableHelper;
-import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredConstructor;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredField;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredMethod;
-import org.hibernate.validator.internal.util.privilegedactions.GetMethod;
+import org.hibernate.validator.internal.util.privilegedactions.GetMethodFromPropertyName;
 import org.hibernate.validator.internal.util.privilegedactions.NewInstance;
 import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 
@@ -270,12 +269,7 @@ public final class TypeConstraintMappingContextImpl<C> extends ConstraintMapping
 		}
 		else {
 			String methodName = property.substring( 0, 1 ).toUpperCase() + property.substring( 1 );
-			for ( String prefix : ReflectionHelper.PROPERTY_ACCESSOR_PREFIXES ) {
-				member = run( GetMethod.action( clazz, prefix + methodName ) );
-				if ( member != null ) {
-					break;
-				}
-			}
+			member = run( GetMethodFromPropertyName.action( clazz, methodName ) );
 		}
 		return member;
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -388,7 +388,7 @@ public interface Log extends BasicLogger {
 	@Message(id = 105, value = "%1$s does not contain the fieldType %2$s.")
 	ValidationException getBeanDoesNotContainTheFieldException(@FormatWith(ClassObjectFormatter.class) Class<?> beanClass, String fieldName);
 
-	@Message(id = 106, value = "%1$s does not contain the property %2$s.")
+	@Message(id = 106, value = "%1$s does not define the property %2$s.")
 	ValidationException getBeanDoesNotContainThePropertyException(@FormatWith(ClassObjectFormatter.class) Class<?> beanClass, String getterName);
 
 	@Message(id = 107, value = "Annotation of type %1$s does not contain a parameter %2$s.")

--- a/engine/src/main/java/org/hibernate/validator/internal/util/privilegedactions/GetMethodFromPropertyName.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/privilegedactions/GetMethodFromPropertyName.java
@@ -10,8 +10,8 @@ import java.lang.reflect.Method;
 import java.security.PrivilegedAction;
 
 /**
- * Returns the method with the specified property name or {@code null} if it does not exist. This method will prepend
- * 'is' and 'get' to the property name and capitalize the first letter.
+ * Returns the method with the specified property name or {@code null} if it is not declared in the specified class.
+ * This method will prepend 'is' and 'get' to the property name and capitalize the first letter.
  *
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
@@ -36,10 +36,10 @@ public final class GetMethodFromPropertyName implements PrivilegedAction<Method>
 			string[0] = Character.toUpperCase( string[0] );
 			String fullMethodName = new String( string );
 			try {
-				return clazz.getMethod( "get" + fullMethodName );
+				return clazz.getDeclaredMethod( "get" + fullMethodName );
 			}
 			catch (NoSuchMethodException e) {
-				return clazz.getMethod( "is" + fullMethodName );
+				return clazz.getDeclaredMethod( "is" + fullMethodName );
 			}
 		}
 		catch (NoSuchMethodException e) {

--- a/engine/src/main/java/org/hibernate/validator/internal/util/privilegedactions/GetMethodFromPropertyName.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/privilegedactions/GetMethodFromPropertyName.java
@@ -9,6 +9,8 @@ package org.hibernate.validator.internal.util.privilegedactions;
 import java.lang.reflect.Method;
 import java.security.PrivilegedAction;
 
+import org.hibernate.validator.internal.util.ReflectionHelper;
+
 /**
  * Returns the method with the specified property name or {@code null} if it is not declared in the specified class.
  * This method will prepend 'is' and 'get' to the property name and capitalize the first letter.
@@ -31,19 +33,18 @@ public final class GetMethodFromPropertyName implements PrivilegedAction<Method>
 
 	@Override
 	public Method run() {
-		try {
-			char[] string = property.toCharArray();
-			string[0] = Character.toUpperCase( string[0] );
-			String fullMethodName = new String( string );
+		char[] string = property.toCharArray();
+		string[0] = Character.toUpperCase( string[0] );
+		String fullMethodName = new String( string );
+
+		for ( String prefix : ReflectionHelper.PROPERTY_ACCESSOR_PREFIXES ) {
 			try {
-				return clazz.getDeclaredMethod( "get" + fullMethodName );
+				return clazz.getDeclaredMethod( prefix + fullMethodName );
 			}
 			catch (NoSuchMethodException e) {
-				return clazz.getDeclaredMethod( "is" + fullMethodName );
+				// silenlty ignore the exception. Will return null in the end if nothing is found
 			}
 		}
-		catch (NoSuchMethodException e) {
-			return null;
-		}
+		return null;
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/exception/XmlConfigurationExceptionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/exception/XmlConfigurationExceptionTest.java
@@ -14,6 +14,7 @@ import org.testng.annotations.Test;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.hibernate.validator.testutils.ValidatorUtil;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -41,6 +42,40 @@ public class XmlConfigurationExceptionTest {
 					"HV000085: No value provided for attribute 'regexp' of annotation @javax.validation.constraints.Pattern.",
 					"Wrong error message"
 			);
+		}
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1534")
+	public void testConstraintOnPropertyDefinedInSuperClass() {
+		Configuration<?> configuration = ValidatorUtil.getConfiguration();
+		configuration.addMapping(
+				XmlConfigurationExceptionTest.class.getResourceAsStream(
+						"constraint-on-subclass-mapping.xml"
+				)
+		);
+		assertThatThrownBy( () -> configuration.buildValidatorFactory() )
+				.isExactlyInstanceOf( ValidationException.class )
+				.hasMessage( "HV000106: " + MyClass.class.getName() + " does not define the property id." );
+	}
+
+	public static class MyObject {
+
+		private final String id;
+
+		public MyObject(String id) {
+			this.id = id;
+		}
+
+		public String getId() {
+			return id;
+		}
+	}
+
+	public static class MyClass extends MyObject {
+
+		public MyClass(String id) {
+			super( id );
 		}
 	}
 }

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/exception/constraint-on-subclass-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/exception/constraint-on-subclass-mapping.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<constraint-mappings
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://jboss.org/xml/ns/javax/validation/mapping/validation-mapping-1.1.xsd"
+        xmlns="http://jboss.org/xml/ns/javax/validation/mapping" version="1.1">
+
+    <bean class="org.hibernate.validator.test.internal.xml.exception.XmlConfigurationExceptionTest$MyClass">
+        <getter name="id">
+            <constraint annotation="javax.validation.constraints.NotNull"/>
+        </getter>
+    </bean>
+</constraint-mappings>


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1534

This doesn't seem to be a regression and I think it make sense to throw an exception in such cases. Changing `clazz. getMethod()` to `clazz.getDeclaredMethod()` does the trick. We also use `GetDeclaredMethod` which lookups the declared methods in case of xml method constraints. Hence having the same behavior for getters looks consistent. 
I've changed the message a bit to reflect the fact that the property should actually be defined for that particular type, rather than just containing it, which could happen through inheritance. 

Probably would be nice to mention such change of behavior somewhere in the notes later.