### PR TITLE
HV-1614 Unable to specify constraints at more than 1 nested parameter of a typed container

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/CascadableConstraintMappingContextImplBase.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/CascadableConstraintMappingContextImplBase.java
@@ -130,11 +130,15 @@ abstract class CascadableConstraintMappingContextImplBase<C extends Cascadable<C
 			);
 		}
 
-		ContainerElementConstraintMappingContextImpl containerElementContext = new ContainerElementConstraintMappingContextImpl(
-			typeContext, parent, location, index
+		// As we already checked that the specific path was not yet configured we should not worry about returning the same context here,
+		// as it means that there are some nested indexes which make a difference, And at the end a new context will be returned by call
+		// to containerElementContext#nestedContainerElement().
+		ContainerElementConstraintMappingContextImpl containerElementContext = containerElementContexts.computeIfAbsent(
+				index,
+				indx -> new ContainerElementConstraintMappingContextImpl(
+						typeContext, parent, location, indx
+				)
 		);
-
-		containerElementContexts.put( index, containerElementContext );
 
 		if ( nestedIndexes.length > 0 ) {
 			return containerElementContext.nestedContainerElement( nestedIndexes );

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/CascadableConstraintMappingContextImplBase.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/CascadableConstraintMappingContextImplBase.java
@@ -133,12 +133,11 @@ abstract class CascadableConstraintMappingContextImplBase<C extends Cascadable<C
 		// As we already checked that the specific path was not yet configured we should not worry about returning the same context here,
 		// as it means that there are some nested indexes which make a difference, And at the end a new context will be returned by call
 		// to containerElementContext#nestedContainerElement().
-		ContainerElementConstraintMappingContextImpl containerElementContext = containerElementContexts.computeIfAbsent(
-				index,
-				indx -> new ContainerElementConstraintMappingContextImpl(
-						typeContext, parent, location, indx
-				)
-		);
+		ContainerElementConstraintMappingContextImpl containerElementContext = containerElementContexts.get( index );
+		if ( containerElementContext == null ) {
+			containerElementContext = new ContainerElementConstraintMappingContextImpl( typeContext, parent, location, index );
+			containerElementContexts.put( index, containerElementContext );
+		}
 
 		if ( nestedIndexes.length > 0 ) {
 			return containerElementContext.nestedContainerElement( nestedIndexes );

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ContainerElementConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ContainerElementConstraintMappingContextImpl.java
@@ -168,15 +168,16 @@ public class ContainerElementConstraintMappingContextImpl extends CascadableCons
 			throw LOG.getTypeIsNotAParameterizedNorArrayTypeException( configuredType );
 		}
 
-		ContainerElementConstraintMappingContextImpl nestedContext = nestedContainerElementContexts.computeIfAbsent(
-				nestedIndexes[0],
-				index -> new ContainerElementConstraintMappingContextImpl(
-						typeContext,
-						parentContainerElementTarget,
-						ConstraintLocation.forTypeArgument( parentLocation, typeParameter, getContainerElementType() ),
-						index
-				)
-		);
+		ContainerElementConstraintMappingContextImpl nestedContext = nestedContainerElementContexts.get( nestedIndexes[0] );
+		if ( nestedContext == null ) {
+			nestedContext = new ContainerElementConstraintMappingContextImpl(
+					typeContext,
+					parentContainerElementTarget,
+					ConstraintLocation.forTypeArgument( parentLocation, typeParameter, getContainerElementType() ),
+					nestedIndexes[0]
+			);
+			nestedContainerElementContexts.put( nestedIndexes[0], nestedContext );
+		}
 
 		if ( nestedIndexes.length > 1 ) {
 			return nestedContext.nestedContainerElement( Arrays.copyOfRange( nestedIndexes, 1, nestedIndexes.length ) );

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ContainerElementConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ContainerElementConstraintMappingContextImpl.java
@@ -168,14 +168,15 @@ public class ContainerElementConstraintMappingContextImpl extends CascadableCons
 			throw LOG.getTypeIsNotAParameterizedNorArrayTypeException( configuredType );
 		}
 
-		ContainerElementConstraintMappingContextImpl nestedContext = new ContainerElementConstraintMappingContextImpl(
-			typeContext,
-			parentContainerElementTarget,
-			ConstraintLocation.forTypeArgument( parentLocation, typeParameter, getContainerElementType() ),
-			nestedIndexes[0]
+		ContainerElementConstraintMappingContextImpl nestedContext = nestedContainerElementContexts.computeIfAbsent(
+				nestedIndexes[0],
+				index -> new ContainerElementConstraintMappingContextImpl(
+						typeContext,
+						parentContainerElementTarget,
+						ConstraintLocation.forTypeArgument( parentLocation, typeParameter, getContainerElementType() ),
+						index
+				)
 		);
-
-		nestedContainerElementContexts.put( nestedIndexes[0], nestedContext );
 
 		if ( nestedIndexes.length > 1 ) {
 			return nestedContext.nestedContainerElement( Arrays.copyOfRange( nestedIndexes, 1, nestedIndexes.length ) );


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1614

So it turned out that there actually was a bug. We need to check if the context was already created by previous calls prior to returning the new one. I've changed a couple of `Map#put()` calls to `Map#computeIfAbsent()` and it should be fine now.