### PR TITLE
HV-667 Create the Bean Validation descriptor model lazily

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -364,7 +364,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		}
 
 		BeanMetaData<U> beanMetaData = valueContext.getCurrentBeanMetaData();
-		if ( beanMetaData.defaultGroupSequenceIsRedefined() ) {
+		if ( beanMetaData.isDefaultGroupSequenceRedefined() ) {
 			validationOrder.assertDefaultGroupSequenceIsExpandable( beanMetaData.getDefaultGroupSequence( valueContext.getCurrentBean() ) );
 		}
 
@@ -435,7 +435,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		// evaluating the constraints of a bean per class in hierarchy, this is necessary to detect potential default group re-definitions
 		for ( Class<? super U> clazz : beanMetaData.getClassHierarchy() ) {
 			BeanMetaData<? super U> hostingBeanMetaData = beanMetaDataManager.getBeanMetaData( clazz );
-			boolean defaultGroupSequenceIsRedefined = hostingBeanMetaData.defaultGroupSequenceIsRedefined();
+			boolean defaultGroupSequenceIsRedefined = hostingBeanMetaData.isDefaultGroupSequenceRedefined();
 
 			// if the current class redefined the default group sequence, this sequence has to be applied to all the class hierarchy.
 			if ( defaultGroupSequenceIsRedefined ) {
@@ -766,7 +766,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		valueContext.setCurrentValidatedValue( value );
 
 		BeanMetaData<?> beanMetaData = valueContext.getCurrentBeanMetaData();
-		if ( beanMetaData.defaultGroupSequenceIsRedefined() ) {
+		if ( beanMetaData.isDefaultGroupSequenceRedefined() ) {
 			validationOrder.assertDefaultGroupSequenceIsExpandable( beanMetaData.getDefaultGroupSequence( null ) );
 		}
 
@@ -828,7 +828,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 			);
 		}
 
-		if ( beanMetaData.defaultGroupSequenceIsRedefined() ) {
+		if ( beanMetaData.isDefaultGroupSequenceRedefined() ) {
 			validationOrder.assertDefaultGroupSequenceIsExpandable(
 					beanMetaData.getDefaultGroupSequence(
 							validationContext.getRootBean()
@@ -1014,7 +1014,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 
 		ExecutableMetaData executableMetaData = executableMetaDataOptional.get();
 
-		if ( beanMetaData.defaultGroupSequenceIsRedefined() ) {
+		if ( beanMetaData.isDefaultGroupSequenceRedefined() ) {
 			validationOrder.assertDefaultGroupSequenceIsExpandable( beanMetaData.getDefaultGroupSequence( bean ) );
 		}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaData.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaData.java
@@ -79,7 +79,7 @@ public interface BeanMetaData<T> extends Validatable {
 	/**
 	 * @return {@code true} if the entity redefines the default group sequence, {@code false} otherwise.
 	 */
-	boolean defaultGroupSequenceIsRedefined();
+	boolean isDefaultGroupSequenceRedefined();
 
 	/**
 	 * @return A set of {@code MetaConstraint} instances encapsulating the information of all the constraints

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -357,7 +357,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	}
 
 	@Override
-	public boolean defaultGroupSequenceIsRedefined() {
+	public boolean isDefaultGroupSequenceRedefined() {
 		return defaultGroupSequenceRedefined;
 	}
 


### PR DESCRIPTION
@gunnarmorling an oldie (January 2013...) but goodie.

An easy way to reduce bootstrapping work and memory usage. Best reviewed commit per commit (one is just a simple method renaming)

https://hibernate.atlassian.net/browse/HV-667