### PR TITLE
HV-1634 Deal with synthetic and implicit parameters properly when getting the generic type of a parameter

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/util/ReflectionHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/ReflectionHelper.java
@@ -204,30 +204,6 @@ public final class ReflectionHelper {
 		return type;
 	}
 
-	/**
-	 * Returns the type of the parameter of the given method with the given parameter index.
-	 *
-	 * @param executable The executable of interest.
-	 * @param parameterIndex The index of the parameter for which the type should be returned.
-	 *
-	 * @return The erased type.
-	 */
-	public static Type typeOf(Executable executable, int parameterIndex) {
-		Type[] genericParameterTypes = executable.getGenericParameterTypes();
-
-		// getGenericParameterTypes() doesn't return synthetic parameters; in this case fall back to getParameterTypes()
-		if ( parameterIndex >= genericParameterTypes.length ) {
-			genericParameterTypes = executable.getParameterTypes();
-		}
-
-		Type type = genericParameterTypes[parameterIndex];
-
-		if ( type instanceof TypeVariable ) {
-			type = TypeHelper.getErasedType( type );
-		}
-		return type;
-	}
-
 	public static Object getValue(Field field, Object object) {
 		try {
 			return field.get( object );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/TypeVariableMethodParameterResolutionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/TypeVariableMethodParameterResolutionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.methodvalidation;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.constraints.Size;
+import javax.validation.executable.ExecutableValidator;
+
+import org.testng.annotations.Test;
+
+public class TypeVariableMethodParameterResolutionTest {
+
+	@Test
+	public void testTypeVariableMethodParameterResolution() throws NoSuchMethodException, SecurityException {
+		ExecutableValidator validator = Validation.buildDefaultValidatorFactory()
+				.getValidator().forExecutables();
+
+		Set<ConstraintViolation<Bean>> violations = validator.validateParameters( new Bean(), Bean.class.getMethod( "method", List.class ),
+				new Object[]{ new ArrayList<>() } );
+		assertThat( violations ).containsOnlyViolations( violationOf( Size.class ) );
+	}
+
+	@SuppressWarnings("unused")
+	private class Bean {
+
+		public <T extends List<?>> void method(@Size(min = 1) T myList) {
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/properties/javabean/JavaBeanExecutableTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/properties/javabean/JavaBeanExecutableTest.java
@@ -1,0 +1,60 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.properties.javabean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+import java.util.Map;
+
+import org.hibernate.validator.internal.properties.javabean.JavaBeanConstructor;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.testng.annotations.Test;
+
+public class JavaBeanExecutableTest {
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1634")
+	public void testGenericTypeParametersWithImplicitParameters() throws NoSuchMethodException, SecurityException {
+		JavaBeanConstructor constructor = new JavaBeanConstructor( Bean.class.getDeclaredConstructors()[0] );
+
+		assertThat( constructor.getParameters() ).hasSize( 3 );
+
+		ParameterizedType parameterizedType1 = (ParameterizedType) constructor.getParameterGenericType( 1 );
+		assertThat( parameterizedType1.getRawType() ).isEqualTo( Map.class );
+
+		ParameterizedType parameterizedType2 = (ParameterizedType) constructor.getParameterGenericType( 2 );
+		assertThat( parameterizedType2.getRawType() ).isEqualTo( List.class );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1634")
+	public void testGenericTypeParametersWithoutImplicitParameters() throws NoSuchMethodException, SecurityException {
+		JavaBeanConstructor constructor = new JavaBeanConstructor( StaticBean.class.getDeclaredConstructors()[0] );
+
+		assertThat( constructor.getParameters() ).hasSize( 2 );
+
+		ParameterizedType parameterizedType0 = (ParameterizedType) constructor.getParameterGenericType( 0 );
+		assertThat( parameterizedType0.getRawType() ).isEqualTo( Map.class );
+
+		ParameterizedType parameterizedType1 = (ParameterizedType) constructor.getParameterGenericType( 1 );
+		assertThat( parameterizedType1.getRawType() ).isEqualTo( List.class );
+	}
+
+	private class Bean {
+
+		private Bean(Map<String, String> map, List<Integer> list) {
+		}
+	}
+
+	private static class StaticBean {
+
+		private StaticBean(Map<String, String> map, List<Integer> list) {
+		}
+	}
+}


### PR DESCRIPTION
* https://hibernate.atlassian.net/browse/HV-1634

This one is a funny one: I discovered it while working on the reflection abstraction stuff and it has been there forever (the code of `ReflectionHelper#typeOf(Executable, int)` was not working correctly at all).

I thought about it again when playing with the Kotlin issue with enum constructors.

I removed this now unused and broken method and implemented things properly in the new code (the old logic came directly from the old method).

Apparently, we don't have a lot of users playing with non-static nested classes and generic parameters in their constructors :).