### PR TITLE
HV-1610 make OSGI tests work on JDK 10

### DIFF
--- a/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/JavaVersionUtil.java
+++ b/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/JavaVersionUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.osgi.integrationtest;
+
+import java.util.Locale;
+
+final class JavaVersionUtil {
+
+	private JavaVersionUtil() {
+	}
+
+	static int getMajorVersion() {
+		String javaSpecVersion = System.getProperty( "java.specification.version" );
+		try {
+			if ( javaSpecVersion.contains( "." ) ) { //before jdk 9
+				return Integer.parseInt( javaSpecVersion.split( "\\." )[1] );
+			}
+			else {
+				return Integer.parseInt( javaSpecVersion );
+			}
+		}
+		catch (NumberFormatException e) {
+			throw getUnableToParseVersionException( javaSpecVersion );
+		}
+	}
+
+	private static IllegalArgumentException getUnableToParseVersionException(String version) {
+		return new IllegalArgumentException( String.format( Locale.ROOT, "We are unable to parse Java version '%1$s'.", version ) );
+	}
+}

--- a/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/KarafFeaturesAreInstallableTest.java
+++ b/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/KarafFeaturesAreInstallableTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.osgi.integrationtest;
 
+import static org.hibernate.validator.osgi.integrationtest.PaxExamOptions.JAVA_9;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.ops4j.pax.exam.CoreOptions.maven;
@@ -68,6 +69,7 @@ public class KarafFeaturesAreInstallableTest {
 
 		return options(
 				when( DEBUG ).useOptions( debugConfiguration( "5005", true ) ),
+				when( JavaVersionUtil.getMajorVersion() >= 9 ).useOptions( JAVA_9.option() ),
 				karafDistributionConfiguration()
 						.frameworkUrl(
 								maven()

--- a/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/OsgiIntegrationTest.java
+++ b/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/OsgiIntegrationTest.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.osgi.integrationtest;
 
+import static org.hibernate.validator.osgi.integrationtest.PaxExamOptions.JAVA_9;
 import static org.junit.Assert.assertEquals;
 import static org.ops4j.pax.exam.CoreOptions.maven;
 import static org.ops4j.pax.exam.CoreOptions.options;
@@ -91,6 +92,7 @@ public class OsgiIntegrationTest {
 
 		return options(
 				when( DEBUG ).useOptions( debugConfiguration( "5005", true ) ),
+				when( JavaVersionUtil.getMajorVersion() >= 9 ).useOptions( JAVA_9.option() ),
 				karafDistributionConfiguration()
 						.frameworkUrl(
 								maven()

--- a/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/PaxExamOptions.java
+++ b/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/PaxExamOptions.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.osgi.integrationtest;
+
+import org.ops4j.pax.exam.CoreOptions;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.options.DefaultCompositeOption;
+
+public enum PaxExamOptions {
+	JAVA_9(
+		CoreOptions.vmOptions(
+			"--add-opens",
+			"java.base/java.security=ALL-UNNAMED",
+			"--add-opens",
+			"java.base/java.net=ALL-UNNAMED",
+			"--add-opens",
+			"java.base/java.lang=ALL-UNNAMED",
+			"--add-opens",
+			"java.base/java.util=ALL-UNNAMED",
+			"--add-exports=java.base/sun.net.www.protocol.http=ALL-UNNAMED",
+			"--add-exports=java.base/sun.net.www.protocol.https=ALL-UNNAMED",
+			"--add-exports=java.xml.bind/com.sun.xml.internal.bind.v2.runtime=ALL-UNNAMED",
+			"--add-exports=jdk.xml.dom/org.w3c.dom.html=ALL-UNNAMED",
+			"--add-exports=jdk.naming.rmi/com.sun.jndi.url.rmi=ALL-UNNAMED",
+			"--add-exports=java.xml.ws/com.sun.xml.internal.messaging.saaj.soap.impl=ALL-UNNAMED",
+			"--add-modules",
+			"java.xml.ws.annotation,java.corba,java.transaction,java.xml.bind,java.xml.ws,jdk.xml.bind" )
+	);
+
+	private final Option[] options;
+
+	PaxExamOptions(Option... options) {
+		this.options = options;
+	}
+
+	public Option option() {
+		return new DefaultCompositeOption( options );
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -171,8 +171,8 @@
         <version.org.jboss.arquillian.container.arquillian-weld-se-embedded-1.1>1.0.0.Final</version.org.jboss.arquillian.container.arquillian-weld-se-embedded-1.1>
 
         <!-- OSGi dependencies -->
-        <version.org.apache.karaf>4.1.2</version.org.apache.karaf>
-        <version.org.ops4j.pax.exam>4.11.0</version.org.ops4j.pax.exam>
+        <version.org.apache.karaf>4.2.0</version.org.apache.karaf>
+        <version.org.ops4j.pax.exam>4.12.0</version.org.ops4j.pax.exam>
         <version.org.ops4j.pax.url>2.5.2</version.org.ops4j.pax.url>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
         <version.fish.payara>5.181</version.fish.payara>
@@ -1163,15 +1163,6 @@
             </build>
         </profile>
         <profile>
-            <id>jdk9-</id>
-            <activation>
-                <jdk>(,10)</jdk>
-            </activation>
-            <modules>
-                <module>osgi</module>
-            </modules>
-        </profile>
-        <profile>
             <id>jdk9+</id>
             <activation>
                 <jdk>[9,)</jdk>
@@ -1229,6 +1220,7 @@
             </activation>
             <modules>
                 <module>integration</module>
+                <module>osgi</module>
             </modules>
         </profile>
         <profile>


### PR DESCRIPTION
!!! DO NOT MERGE YET !!!

Needs https://github.com/ops4j/org.ops4j.pax.exam2/pull/76 to be merged and released.

Once a new version of Pax Exam is released, the pom.xml needs to be updated reflect the newer version. I also updated Karaf to latest release.

Tested on JDK 8,9 and 10. Thanks!

