### PR TITLE
HV-1644 Avoid having JavaFX as a transitive dependency [6.0 backport]

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -210,5 +210,19 @@
                 <javadoc.additional.options>-html5</javadoc.additional.options>
             </properties>
         </profile>
+        <profile>
+            <id>jdk11+</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-base</artifactId>
+                    <version>${version.org.openjfx}</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -339,5 +339,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>jdk11+</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.openjfx</groupId>
+                    <artifactId>javafx-base</artifactId>
+                    <version>${version.org.openjfx}</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -290,8 +290,9 @@
             <dependencies>
                 <dependency>
                     <groupId>org.openjfx</groupId>
-                    <artifactId>javafx.base</artifactId>
-                    <version>11.0.0-SNAPSHOT</version>
+                    <artifactId>javafx-base</artifactId>
+                    <version>${version.org.openjfx}</version>
+                    <scope>provided</scope>
                 </dependency>
             </dependencies>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,9 @@
         <wildfly-maven-plugin.version>1.2.1.Final</wildfly-maven-plugin.version>
         <wildfly-core.version>4.0.0.Final</wildfly-core.version>
 
+        <!-- JavaFX dependencies (from JDK 11) -->
+        <version.org.openjfx>11-ea+19</version.org.openjfx>
+
         <!-- Test dependencies -->
         <arquillian.version>1.1.11.Final</arquillian.version>
         <testng.version>6.8</testng.version>
@@ -1221,13 +1224,6 @@
                     </plugins>
                 </pluginManagement>
             </build>
-            <repositories>
-                <repository>
-                    <id>sonatype-oss-snapshots</id>
-                    <name>Sonatype OSS Snapshots</name>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-                </repository>
-            </repositories>
         </profile>
         <profile>
             <id>jqassistant</id>


### PR DESCRIPTION
Also remove the snapshot repository we temporarily added as the
artifacts have been published to Maven Central.

 * https://hibernate.atlassian.net/browse/HV-1644