### PR TITLE
HV-1653 Improve the wrong doc of ParameterScriptAssert.

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/constraints/ParameterScriptAssert.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/ParameterScriptAssert.java
@@ -33,7 +33,10 @@ import org.hibernate.validator.constraints.ParameterScriptAssert.List;
  * ("Scripting for the Java<sup>TM</sup> Platform") compatible engine can be
  * found on the classpath. To refer to a parameter within the scripting
  * expression, use its name as obtained by the active
- * {@link javax.validation.ParameterNameProvider}. 
+ * {@link javax.validation.ParameterNameProvider}. The default provider will
+ * return the actual parameter names, if the -parameters compiler option
+ * has been enabled, and {@code arg0}, {@code arg1} etc. otherwise
+ * will be used as parameter names.
  * </p>
  * <p>
  * The following listing shows an example using the JavaScript engine which

--- a/engine/src/main/java/org/hibernate/validator/constraints/ParameterScriptAssert.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/ParameterScriptAssert.java
@@ -33,15 +33,14 @@ import org.hibernate.validator.constraints.ParameterScriptAssert.List;
  * ("Scripting for the Java<sup>TM</sup> Platform") compatible engine can be
  * found on the classpath. To refer to a parameter within the scripting
  * expression, use its name as obtained by the active
- * {@link javax.validation.ParameterNameProvider}. By default, {@code arg0}, {@code arg1} etc.
- * will be used as parameter names.
+ * {@link javax.validation.ParameterNameProvider}. 
  * </p>
  * <p>
  * The following listing shows an example using the JavaScript engine which
  * comes with the JDK:
  * </p>
  * <pre>
- * {@code @ParameterScriptAssert(script = "arg0.before(arg1)", lang = "javascript")
+ * {@code @ParameterScriptAssert(script = "start.before(end)", lang = "javascript")
  * public void createEvent(Date start, Date end) { ... }
  * }
  * </pre>


### PR DESCRIPTION
The ParameterScriptAssert doc example is not working.
arg0, arg1 ,arg2, etc are not passed to the script evaluations, at least in current implementation.  

See https://github.com/hibernate/hibernate-validator/blob/60e5c17bfbe709f32018e97a483f6011093587fe/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/ParameterScriptAssertValidator.java#L61-L68