### PR TITLE
HV-1665 Support incremental annotation processing in Gradle

### DIFF
--- a/annotation-processor/src/main/resources/META-INF/services/gradle/incremental.annotation.processors
+++ b/annotation-processor/src/main/resources/META-INF/services/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+org.hibernate.validator.ap.ConstraintValidationProcessor,isolating

--- a/documentation/src/main/asciidoc/ch13.asciidoc
+++ b/documentation/src/main/asciidoc/ch13.asciidoc
@@ -116,6 +116,24 @@ For using the Hibernate Validator annotation processor with Maven, set it up via
 ----
 ====
 
+[[validator-annotationprocessor-gradle]]
+===== Gradle
+
+When using https://gradle.org[Gradle] it is enough to reference the annotation processor as an `annotationProcessor` dependency.
+
+.Using the annotation processor with Gradle
+====
+[source, groovy]
+[subs="verbatim,attributes"]
+----
+dependencies {
+	annotationProcessor group: 'org.hibernate.validator', name: 'hibernate-validator-annotation-processor', version: '{hvVersion}'
+
+	// any other dependencies ...
+}
+----
+====
+
 [[validator-annotationprocessor-ant]]
 ===== Apache Ant
 


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1665

As per Gradle [doc on incremental APs](https://docs.gradle.org/nightly/userguide/java_plugin.html#making_an_annotation_processor_incremental) it looks like it should be enough to register AP in META-INF/gradle/incremental.annotation.processors
with corresponding category separated by a comma.

Also added a small section to documentation on AP and Gradle. (that's how I "configured" the AP for testing the gradle builds and messages from AP). We have the doc sections for various build tools but nothing for gradle. 