### PR TITLE
 HV-1681 PredefinedScopeValidatorFactory and @Valid on unregistered bean throws a NPE

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -1246,7 +1246,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 
 		propertyPath.removeLeafNode();
 
-		return ValueContext.getLocalExecutionContext( validatorScopedContext.getParameterNameProvider(), clazz, beanMetaData, propertyPath );
+		return ValueContext.getLocalExecutionContext( validatorScopedContext.getParameterNameProvider(), beanMetaData, propertyPath );
 	}
 
 	private boolean isValidationRequired(BaseBeanValidationContext<?> validationContext,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -1011,7 +1011,9 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 
 		ValueContext<V, Object> cascadingValueContext = null;
 
-		if ( value != null ) {
+		boolean isCascadingRequired = value != null && executableMetaData.isCascading();
+
+		if ( isCascadingRequired ) {
 			cascadingValueContext = ValueContexts.getLocalExecutionContextForExecutable(
 					validatorScopedContext.getParameterNameProvider(),
 					value,
@@ -1042,7 +1044,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 						return;
 					}
 
-					if ( value != null ) {
+					if ( isCascadingRequired ) {
 						cascadingValueContext.setCurrentGroup( group.getDefiningClass() );
 						validateCascadedConstraints( validationContext, cascadingValueContext );
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValueContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValueContext.java
@@ -40,11 +40,6 @@ public class ValueContext<T, V> {
 	private final T currentBean;
 
 	/**
-	 * The class of the current bean.
-	 */
-	private final Class<T> currentBeanType;
-
-	/**
 	 * The metadata of the current bean.
 	 */
 	private final BeanMetaData<T> currentBeanMetaData;
@@ -75,32 +70,31 @@ public class ValueContext<T, V> {
 			ExecutableParameterNameProvider parameterNameProvider, T value, Validatable validatable, PathImpl propertyPath) {
 		@SuppressWarnings("unchecked")
 		Class<T> rootBeanType = (Class<T>) value.getClass();
-		return new ValueContext<>( parameterNameProvider, value, rootBeanType, beanMetaDataManager.getBeanMetaData( rootBeanType ), validatable, propertyPath );
+		return new ValueContext<>( parameterNameProvider, value, beanMetaDataManager.getBeanMetaData( rootBeanType ), validatable, propertyPath );
 	}
 
 	@SuppressWarnings("unchecked")
 	public static <T, V> ValueContext<T, V> getLocalExecutionContext(ExecutableParameterNameProvider parameterNameProvider, T value,
 			BeanMetaData<?> currentBeanMetaData, PathImpl propertyPath) {
 		Class<T> rootBeanType = (Class<T>) value.getClass();
-		return new ValueContext<>( parameterNameProvider, value, rootBeanType, (BeanMetaData<T>) currentBeanMetaData, currentBeanMetaData, propertyPath );
+		return new ValueContext<>( parameterNameProvider, value, (BeanMetaData<T>) currentBeanMetaData, currentBeanMetaData, propertyPath );
 	}
 
 	public static <T, V> ValueContext<T, V> getLocalExecutionContext(BeanMetaDataManager beanMetaDataManager,
 			ExecutableParameterNameProvider parameterNameProvider, Class<T> rootBeanType, Validatable validatable, PathImpl propertyPath) {
 		BeanMetaData<T> rootBeanMetaData = rootBeanType != null ? beanMetaDataManager.getBeanMetaData( rootBeanType ) : null;
-		return new ValueContext<>( parameterNameProvider, null, rootBeanType, rootBeanMetaData, validatable, propertyPath );
+		return new ValueContext<>( parameterNameProvider, null, rootBeanMetaData, validatable, propertyPath );
 	}
 
 	@SuppressWarnings("unchecked")
-	public static <T, V> ValueContext<T, V> getLocalExecutionContext(ExecutableParameterNameProvider parameterNameProvider, Class<T> currentBeanType,
+	public static <T, V> ValueContext<T, V> getLocalExecutionContext(ExecutableParameterNameProvider parameterNameProvider,
 			BeanMetaData<?> currentBeanMetaData, PathImpl propertyPath) {
-		return new ValueContext<>( parameterNameProvider, null, currentBeanType, (BeanMetaData<T>) currentBeanMetaData, currentBeanMetaData, propertyPath );
+		return new ValueContext<>( parameterNameProvider, null, (BeanMetaData<T>) currentBeanMetaData, currentBeanMetaData, propertyPath );
 	}
 
-	private ValueContext(ExecutableParameterNameProvider parameterNameProvider, T currentBean, Class<T> currentBeanType, BeanMetaData<T> currentBeanMetaData, Validatable validatable, PathImpl propertyPath) {
+	private ValueContext(ExecutableParameterNameProvider parameterNameProvider, T currentBean, BeanMetaData<T> currentBeanMetaData, Validatable validatable, PathImpl propertyPath) {
 		this.parameterNameProvider = parameterNameProvider;
 		this.currentBean = currentBean;
-		this.currentBeanType = currentBeanType;
 		this.currentBeanMetaData = currentBeanMetaData;
 		this.currentValidatable = validatable;
 		this.propertyPath = propertyPath;
@@ -116,10 +110,6 @@ public class ValueContext<T, V> {
 
 	public final T getCurrentBean() {
 		return currentBean;
-	}
-
-	public final Class<T> getCurrentBeanType() {
-		return currentBeanType;
 	}
 
 	public final BeanMetaData<T> getCurrentBeanMetaData() {
@@ -221,7 +211,6 @@ public class ValueContext<T, V> {
 		final StringBuilder sb = new StringBuilder();
 		sb.append( "ValueContext" );
 		sb.append( "{currentBean=" ).append( currentBean );
-		sb.append( ", currentBeanType=" ).append( currentBeanType );
 		sb.append( ", propertyPath=" ).append( propertyPath );
 		sb.append( ", currentGroup=" ).append( currentGroup );
 		sb.append( ", currentValue=" ).append( currentValue );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ComposingConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ComposingConstraintTree.java
@@ -22,8 +22,8 @@ import java.util.stream.Collectors;
 import javax.validation.ConstraintValidator;
 
 import org.hibernate.validator.constraints.CompositionType;
-import org.hibernate.validator.internal.engine.ValueContext;
 import org.hibernate.validator.internal.engine.validationcontext.ValidationContext;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.logging.Log;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintTree.java
@@ -18,7 +18,7 @@ import javax.validation.ConstraintDeclarationException;
 import javax.validation.ConstraintValidator;
 import javax.validation.ValidationException;
 
-import org.hibernate.validator.internal.engine.ValueContext;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.engine.validationcontext.ValidationContext;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 import org.hibernate.validator.internal.util.logging.Log;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/SimpleConstraintTree.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/SimpleConstraintTree.java
@@ -13,8 +13,8 @@ import java.util.Collection;
 
 import javax.validation.ConstraintValidator;
 
-import org.hibernate.validator.internal.engine.ValueContext;
 import org.hibernate.validator.internal.engine.validationcontext.ValidationContext;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/AbstractValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/AbstractValidationContext.java
@@ -25,11 +25,11 @@ import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.MessageInterpolatorContext;
-import org.hibernate.validator.internal.engine.ValueContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintViolationCreationContext;
 import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/BaseBeanValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/BaseBeanValidationContext.java
@@ -11,8 +11,8 @@ import javax.validation.TraversableResolver;
 import javax.validation.Validator;
 
 import org.hibernate.validator.internal.engine.ValidatorImpl;
-import org.hibernate.validator.internal.engine.ValueContext;
 import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/BeanValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/BeanValidationContext.java
@@ -14,9 +14,9 @@ import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
-import org.hibernate.validator.internal.engine.ValueContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintViolationCreationContext;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 
 /**

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/ParameterExecutableValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/ParameterExecutableValidationContext.java
@@ -19,12 +19,12 @@ import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
-import org.hibernate.validator.internal.engine.ValueContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintViolationCreationContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.CrossParameterConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/PropertyValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/PropertyValidationContext.java
@@ -17,13 +17,13 @@ import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
-import org.hibernate.validator.internal.engine.ValueContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintViolationCreationContext;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
-import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.metadata.location.AbstractPropertyConstraintLocation;
+import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.metadata.location.TypeArgumentConstraintLocation;
 
 /**

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/ReturnValueExecutableValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/ReturnValueExecutableValidationContext.java
@@ -17,9 +17,9 @@ import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
 import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
-import org.hibernate.validator.internal.engine.ValueContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintViolationCreationContext;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData;
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/ValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/ValidationContext.java
@@ -15,7 +15,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
-import org.hibernate.validator.internal.engine.ValueContext;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintTree;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorContextImpl;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/ValidationContextBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/ValidationContextBuilder.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.validator.internal.engine.validationcontext;
 
-import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Executable;
 
 import javax.validation.ConstraintValidatorFactory;
@@ -17,8 +16,6 @@ import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintVa
 import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
-import org.hibernate.validator.internal.util.logging.Log;
-import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
 /**
  * Builder for creating {@link AbstractValidationContext}s suited for the different kinds of validation.
@@ -27,8 +24,6 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
  * @author Marko Bekhta
  */
 public class ValidationContextBuilder {
-
-	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
 
 	private final BeanMetaDataManager beanMetaDataManager;
 	private final ConstraintValidatorManager constraintValidatorManager;
@@ -57,8 +52,6 @@ public class ValidationContextBuilder {
 		Class<T> rootBeanClass = (Class<T>) rootBean.getClass();
 		BeanMetaData<T> rootBeanMetaData = beanMetaDataManager.getBeanMetaData( rootBeanClass );
 
-		checkRootBeanMetaData( rootBeanClass, rootBeanMetaData );
-
 		return new BeanValidationContext<>(
 				constraintValidatorManager,
 				constraintValidatorFactory,
@@ -76,8 +69,6 @@ public class ValidationContextBuilder {
 		Class<T> rootBeanClass = (Class<T>) rootBean.getClass();
 		BeanMetaData<T> rootBeanMetaData = beanMetaDataManager.getBeanMetaData( rootBeanClass );
 
-		checkRootBeanMetaData( rootBeanClass, rootBeanMetaData );
-
 		return new PropertyValidationContext<>(
 				constraintValidatorManager,
 				constraintValidatorFactory,
@@ -93,8 +84,6 @@ public class ValidationContextBuilder {
 
 	public <T> BaseBeanValidationContext<T> forValidateValue(Class<T> rootBeanClass, PathImpl propertyPath) {
 		BeanMetaData<T> rootBeanMetaData = beanMetaDataManager.getBeanMetaData( rootBeanClass );
-
-		checkRootBeanMetaData( rootBeanClass, rootBeanMetaData );
 
 		return new PropertyValidationContext<>(
 				constraintValidatorManager,
@@ -116,8 +105,6 @@ public class ValidationContextBuilder {
 		@SuppressWarnings("unchecked")
 		Class<T> rootBeanClass = rootBean != null ? (Class<T>) rootBean.getClass() : (Class<T>) executable.getDeclaringClass();
 		BeanMetaData<T> rootBeanMetaData = beanMetaDataManager.getBeanMetaData( rootBeanClass );
-
-		checkRootBeanMetaData( rootBeanClass, rootBeanMetaData );
 
 		return new ParameterExecutableValidationContext<>(
 				constraintValidatorManager,
@@ -142,8 +129,6 @@ public class ValidationContextBuilder {
 		Class<T> rootBeanClass = rootBean != null ? (Class<T>) rootBean.getClass() : (Class<T>) executable.getDeclaringClass();
 		BeanMetaData<T> rootBeanMetaData = beanMetaDataManager.getBeanMetaData( rootBeanClass );
 
-		checkRootBeanMetaData( rootBeanClass, rootBeanMetaData );
-
 		return new ReturnValueExecutableValidationContext<>(
 				constraintValidatorManager,
 				constraintValidatorFactory,
@@ -157,11 +142,5 @@ public class ValidationContextBuilder {
 				rootBeanMetaData.getMetaDataFor( executable ),
 				executableReturnValue
 		);
-	}
-
-	private <T> void checkRootBeanMetaData(Class<T> rootBeanClass, BeanMetaData<T> rootBeanMetaData) {
-		if ( rootBeanMetaData == null ) {
-			throw LOG.uninitializedBeanMetaData( rootBeanClass );
-		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valuecontext/BeanValueContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valuecontext/BeanValueContext.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.valuecontext;
+
+import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
+import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
+
+/**
+ * @author Marko Bekhta
+ */
+public class BeanValueContext<T, V> extends ValueContext<T, V> {
+
+	/**
+	 * The metadata of the current bean.
+	 */
+	private final BeanMetaData<T> currentBeanMetaData;
+
+	BeanValueContext(ExecutableParameterNameProvider parameterNameProvider, T currentBean, BeanMetaData<T> currentBeanMetaData, PathImpl propertyPath) {
+		super( parameterNameProvider, currentBean, currentBeanMetaData, propertyPath );
+		this.currentBeanMetaData = currentBeanMetaData;
+	}
+
+	public final BeanMetaData<T> getCurrentBeanMetaData() {
+		return currentBeanMetaData;
+	}
+
+	public static class ValueState<V> {
+
+		private final PathImpl propertyPath;
+
+		private final V currentValue;
+
+		ValueState(PathImpl propertyPath, V currentValue) {
+			this.propertyPath = propertyPath;
+			this.currentValue = currentValue;
+		}
+
+		public PathImpl getPropertyPath() {
+			return propertyPath;
+		}
+
+		public V getCurrentValue() {
+			return currentValue;
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valuecontext/ValueContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valuecontext/ValueContext.java
@@ -4,17 +4,16 @@
  * License: Apache License, Version 2.0
  * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
  */
-package org.hibernate.validator.internal.engine;
+package org.hibernate.validator.internal.engine.valuecontext;
 
 import java.lang.reflect.TypeVariable;
 
 import javax.validation.groups.Default;
 
 import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.hibernate.validator.internal.engine.valuecontext.BeanValueContext.ValueState;
 import org.hibernate.validator.internal.engine.valueextraction.AnnotatedObject;
 import org.hibernate.validator.internal.engine.valueextraction.ArrayElement;
-import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
-import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.facets.Cascadable;
 import org.hibernate.validator.internal.metadata.facets.Validatable;
 import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
@@ -40,11 +39,6 @@ public class ValueContext<T, V> {
 	private final T currentBean;
 
 	/**
-	 * The metadata of the current bean.
-	 */
-	private final BeanMetaData<T> currentBeanMetaData;
-
-	/**
 	 * The current property path we are validating.
 	 */
 	private PathImpl propertyPath;
@@ -66,36 +60,9 @@ public class ValueContext<T, V> {
 	 */
 	private ConstraintLocationKind constraintLocationKind;
 
-	public static <T, V> ValueContext<T, V> getLocalExecutionContext(BeanMetaDataManager beanMetaDataManager,
-			ExecutableParameterNameProvider parameterNameProvider, T value, Validatable validatable, PathImpl propertyPath) {
-		@SuppressWarnings("unchecked")
-		Class<T> rootBeanType = (Class<T>) value.getClass();
-		return new ValueContext<>( parameterNameProvider, value, beanMetaDataManager.getBeanMetaData( rootBeanType ), validatable, propertyPath );
-	}
-
-	@SuppressWarnings("unchecked")
-	public static <T, V> ValueContext<T, V> getLocalExecutionContext(ExecutableParameterNameProvider parameterNameProvider, T value,
-			BeanMetaData<?> currentBeanMetaData, PathImpl propertyPath) {
-		Class<T> rootBeanType = (Class<T>) value.getClass();
-		return new ValueContext<>( parameterNameProvider, value, (BeanMetaData<T>) currentBeanMetaData, currentBeanMetaData, propertyPath );
-	}
-
-	public static <T, V> ValueContext<T, V> getLocalExecutionContext(BeanMetaDataManager beanMetaDataManager,
-			ExecutableParameterNameProvider parameterNameProvider, Class<T> rootBeanType, Validatable validatable, PathImpl propertyPath) {
-		BeanMetaData<T> rootBeanMetaData = rootBeanType != null ? beanMetaDataManager.getBeanMetaData( rootBeanType ) : null;
-		return new ValueContext<>( parameterNameProvider, null, rootBeanMetaData, validatable, propertyPath );
-	}
-
-	@SuppressWarnings("unchecked")
-	public static <T, V> ValueContext<T, V> getLocalExecutionContext(ExecutableParameterNameProvider parameterNameProvider,
-			BeanMetaData<?> currentBeanMetaData, PathImpl propertyPath) {
-		return new ValueContext<>( parameterNameProvider, null, (BeanMetaData<T>) currentBeanMetaData, currentBeanMetaData, propertyPath );
-	}
-
-	private ValueContext(ExecutableParameterNameProvider parameterNameProvider, T currentBean, BeanMetaData<T> currentBeanMetaData, Validatable validatable, PathImpl propertyPath) {
+	ValueContext(ExecutableParameterNameProvider parameterNameProvider, T currentBean, Validatable validatable, PathImpl propertyPath) {
 		this.parameterNameProvider = parameterNameProvider;
 		this.currentBean = currentBean;
-		this.currentBeanMetaData = currentBeanMetaData;
 		this.currentValidatable = validatable;
 		this.propertyPath = propertyPath;
 	}
@@ -110,10 +77,6 @@ public class ValueContext<T, V> {
 
 	public final T getCurrentBean() {
 		return currentBean;
-	}
-
-	public final BeanMetaData<T> getCurrentBeanMetaData() {
-		return currentBeanMetaData;
 	}
 
 	public Validatable getCurrentValidatable() {
@@ -202,8 +165,8 @@ public class ValueContext<T, V> {
 	}
 
 	public final void resetValueState(ValueState<V> valueState) {
-		this.propertyPath = valueState.propertyPath;
-		this.currentValue = valueState.currentValue;
+		this.propertyPath = valueState.getPropertyPath();
+		this.currentValue = valueState.getCurrentValue();
 	}
 
 	@Override
@@ -222,17 +185,5 @@ public class ValueContext<T, V> {
 	public Object getValue(Object parent, ConstraintLocation location) {
 		// TODO: For BVAL-214 we'd get the value from a map or another alternative structure instead
 		return location.getValue( parent );
-	}
-
-	public static class ValueState<V> {
-
-		private final PathImpl propertyPath;
-
-		private final V currentValue;
-
-		private ValueState(PathImpl propertyPath, V currentValue) {
-			this.propertyPath = propertyPath;
-			this.currentValue = currentValue;
-		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valuecontext/ValueContexts.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valuecontext/ValueContexts.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.valuecontext;
+
+import org.hibernate.validator.internal.engine.path.PathImpl;
+import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
+import org.hibernate.validator.internal.metadata.facets.Validatable;
+import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
+
+/**
+ * @author Marko Bekhta
+ */
+public final class ValueContexts {
+
+	private ValueContexts() {
+	}
+
+	/**
+	 * Creates a value context for validating an executable. Can be applied to both parameter and
+	 * return value validation. Does not require a bean metadata information.
+	 */
+	public static <T, V> ValueContext<T, V> getLocalExecutionContextForExecutable(
+			ExecutableParameterNameProvider parameterNameProvider,
+			T value,
+			Validatable validatable,
+			PathImpl propertyPath) {
+		return new ValueContext<>( parameterNameProvider, value, validatable, propertyPath );
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T, V> BeanValueContext<T, V> getLocalExecutionContextForBean(
+			ExecutableParameterNameProvider parameterNameProvider,
+			T value,
+			BeanMetaData<?> currentBeanMetaData,
+			PathImpl propertyPath) {
+		return new BeanValueContext<>( parameterNameProvider, value, (BeanMetaData<T>) currentBeanMetaData, propertyPath );
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T, V> BeanValueContext<T, V> getLocalExecutionContextForValueValidation(
+			ExecutableParameterNameProvider parameterNameProvider,
+			BeanMetaData<?> currentBeanMetaData,
+			PathImpl propertyPath) {
+		return new BeanValueContext<>( parameterNameProvider, null, (BeanMetaData<T>) currentBeanMetaData, propertyPath );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/PredefinedScopeBeanMetaDataManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/PredefinedScopeBeanMetaDataManager.java
@@ -8,6 +8,7 @@ package org.hibernate.validator.internal.metadata;
 
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -30,8 +31,12 @@ import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.ExecutableHelper;
 import org.hibernate.validator.internal.util.ExecutableParameterNameProvider;
 import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
+import org.hibernate.validator.internal.util.logging.Log;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
 public class PredefinedScopeBeanMetaDataManager implements BeanMetaDataManager {
+
+	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
 
 	/**
 	 * Used to cache the constraint meta data for validated entities
@@ -84,7 +89,11 @@ public class PredefinedScopeBeanMetaDataManager implements BeanMetaDataManager {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <T> BeanMetaData<T> getBeanMetaData(Class<T> beanClass) {
-		return (BeanMetaData<T>) beanMetaDataMap.get( beanClass.getName() );
+		BeanMetaData<T> beanMetaData = (BeanMetaData<T>) beanMetaDataMap.get( beanClass.getName() );
+		if ( beanMetaData == null ) {
+			throw LOG.uninitializedBeanMetaData( beanClass );
+		}
+		return beanMetaData;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/MetaConstraint.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/MetaConstraint.java
@@ -15,10 +15,11 @@ import java.util.Set;
 
 import javax.validation.valueextraction.ValueExtractor;
 
-import org.hibernate.validator.internal.engine.ValueContext;
+import org.hibernate.validator.internal.engine.valuecontext.ValueContext;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintTree;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.engine.validationcontext.ValidationContext;
+import org.hibernate.validator.internal.engine.valuecontext.BeanValueContext;
 import org.hibernate.validator.internal.engine.valueextraction.ValueExtractorDescriptor;
 import org.hibernate.validator.internal.engine.valueextraction.ValueExtractorHelper;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
@@ -218,7 +219,7 @@ public class MetaConstraint<A extends Annotation> {
 		}
 
 		private void doValidate(Object value, String nodeName) {
-			ValueContext.ValueState<Object> originalValueState = valueContext.getCurrentValueState();
+			BeanValueContext.ValueState<Object> originalValueState = valueContext.getCurrentValueState();
 
 			Class<?> containerClass = currentValueExtractionPathNode.getContainerClass();
 			if ( containerClass != null ) {

--- a/engine/src/test/java/org/hibernate/validator/test/predefinedscope/PredefinedScopeValidatorFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/predefinedscope/PredefinedScopeValidatorFactoryTest.java
@@ -165,6 +165,12 @@ public class PredefinedScopeValidatorFactoryTest {
 		}
 	}
 
+	@TestForIssue(jiraKey = "HV-1681")
+	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000249:.*")
+	public void testValidOnUnknownBean() {
+		getValidator().validate( new AnotherBean() );
+	}
+
 	@Test(expectedExceptions = ValidationException.class, expectedExceptionsMessageRegExp = "HV000250:.*")
 	public void testUninitializedLocale() {
 		Locale defaultLocale = Locale.getDefault();
@@ -186,6 +192,7 @@ public class PredefinedScopeValidatorFactoryTest {
 	private static Validator getValidator() {
 		Set<Class<?>> beanMetaDataToInitialize = new HashSet<>();
 		beanMetaDataToInitialize.add( Bean.class );
+		beanMetaDataToInitialize.add( AnotherBean.class );
 
 		ValidatorFactory validatorFactory = Validation.byProvider( PredefinedScopeHibernateValidator.class )
 				.configure()
@@ -237,6 +244,17 @@ public class PredefinedScopeValidatorFactoryTest {
 		@SuppressWarnings("unused")
 		public void setEmail(@Email String email) {
 			this.email = email;
+		}
+	}
+
+	private static class AnotherBean {
+
+		@Valid
+		private final UnknownBean bean;
+
+
+		private AnotherBean() {
+			bean = new UnknownBean();
 		}
 	}
 


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1681

First 2 commits comes actually from the other PR. They remove some of the "unused" metadata from contexts and hence reduce the amount of unnecessary calls to bean metadata manager. 

And I changed the predefined manager to throw exception in case there's no metadata for some bean. Which resulted in the changes in 3d commit. It should also reduce the amount of operations as we don't need to run cascading validation all the time. 

Suggestion on interface naming are welcome :smiley: 