### PR TITLE
HV-1682 Introduce BeanMetaDataClassNormalizer in predefined scope

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/PredefinedScopeHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/PredefinedScopeHibernateValidatorConfiguration.java
@@ -9,6 +9,8 @@ package org.hibernate.validator;
 import java.util.Locale;
 import java.util.Set;
 
+import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
+
 /**
  * Extension of {@link HibernateValidatorConfiguration} with additional methods dedicated to defining the predefined
  * scope of bean validation e.g. validated classes, constraint validators...
@@ -25,4 +27,7 @@ public interface PredefinedScopeHibernateValidatorConfiguration extends BaseHibe
 
 	@Incubating
 	PredefinedScopeHibernateValidatorConfiguration initializeLocales(Set<Locale> locales);
+
+	@Incubating
+	PredefinedScopeHibernateValidatorConfiguration beanMetaDataClassNormalizer(BeanMetaDataClassNormalizer beanMetaDataClassNormalizer);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeConfigurationImpl.java
@@ -15,6 +15,7 @@ import javax.validation.spi.ValidationProvider;
 
 import org.hibernate.validator.PredefinedScopeHibernateValidatorConfiguration;
 import org.hibernate.validator.internal.util.CollectionHelper;
+import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
 
 /**
  * @author Guillaume Smet
@@ -23,6 +24,8 @@ public class PredefinedScopeConfigurationImpl extends AbstractConfigurationImpl<
 		implements PredefinedScopeHibernateValidatorConfiguration, ConfigurationState {
 
 	private Set<Class<?>> beanClassesToInitialize;
+
+	private BeanMetaDataClassNormalizer beanMetaDataClassNormalizer;
 
 	public PredefinedScopeConfigurationImpl(BootstrapState state) {
 		super( state );
@@ -46,5 +49,15 @@ public class PredefinedScopeConfigurationImpl extends AbstractConfigurationImpl<
 	public PredefinedScopeHibernateValidatorConfiguration initializeLocales(Set<Locale> locales) {
 		setLocalesToInitialize( CollectionHelper.toImmutableSet( locales ) );
 		return thisAsT();
+	}
+
+	@Override
+	public PredefinedScopeHibernateValidatorConfiguration beanMetaDataClassNormalizer(BeanMetaDataClassNormalizer beanMetaDataClassNormalizer) {
+		this.beanMetaDataClassNormalizer = beanMetaDataClassNormalizer;
+		return thisAsT();
+	}
+
+	public BeanMetaDataClassNormalizer getBeanMetaDataClassNormalizer() {
+		return beanMetaDataClassNormalizer;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
@@ -18,6 +18,7 @@ import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurat
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineTraversableResolverResultCacheEnabled;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.logValidatorFactoryScopedConfiguration;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.registerCustomConstraintValidators;
+import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineBeanMetaDataClassNormalizer;
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 
 import java.lang.invoke.MethodHandles;
@@ -170,6 +171,7 @@ public class PredefinedScopeValidatorFactoryImpl implements PredefinedScopeHiber
 				validationOrderGenerator,
 				buildMetaDataProviders( constraintCreationContext, xmlMetaDataProvider, constraintMappings ),
 				methodValidationConfiguration,
+				determineBeanMetaDataClassNormalizer( hibernateSpecificConfig ),
 				hibernateSpecificConfig.getBeanClassesToInitialize()
 		);
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryConfigurationHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryConfigurationHelper.java
@@ -26,6 +26,7 @@ import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
 import org.hibernate.validator.internal.engine.constraintdefinition.ConstraintDefinitionContribution;
 import org.hibernate.validator.internal.engine.scripting.DefaultScriptEvaluatorFactory;
+import org.hibernate.validator.internal.metadata.DefaultBeanMetaDataClassNormalizer;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.properties.DefaultGetterPropertySelectionStrategy;
 import org.hibernate.validator.internal.properties.javabean.JavaBeanHelper;
@@ -36,6 +37,7 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetClassLoader;
 import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
 import org.hibernate.validator.internal.util.privilegedactions.NewInstance;
+import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
 import org.hibernate.validator.spi.cfg.ConstraintMappingContributor;
 import org.hibernate.validator.spi.properties.GetterPropertySelectionStrategy;
 import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
@@ -277,6 +279,15 @@ final class ValidatorFactoryConfigurationHelper {
 		}
 
 		return new DefaultGetterPropertySelectionStrategy();
+	}
+
+	static BeanMetaDataClassNormalizer determineBeanMetaDataClassNormalizer(PredefinedScopeConfigurationImpl hibernateSpecificConfig) {
+		if ( hibernateSpecificConfig.getBeanMetaDataClassNormalizer() != null ) {
+			LOG.usingBeanMetaDataClassNormalizer( hibernateSpecificConfig.getBeanMetaDataClassNormalizer().getClass() );
+			return hibernateSpecificConfig.getBeanMetaDataClassNormalizer();
+		}
+
+		return new DefaultBeanMetaDataClassNormalizer();
 	}
 
 	static void registerCustomConstraintValidators(Set<DefaultConstraintMapping> constraintMappings,

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/DefaultBeanMetaDataClassNormalizer.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/DefaultBeanMetaDataClassNormalizer.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.metadata;
+
+import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
+
+/**
+ * The default implementation of {@link BeanMetaDataClassNormalizer}.
+ * <p>
+ * Simply returns the provided class.
+ *
+ * @author Guillaume Smet
+ */
+public class DefaultBeanMetaDataClassNormalizer implements BeanMetaDataClassNormalizer {
+
+	@Override
+	public Class<?> normalize(Class<?> beanClass) {
+		return beanClass;
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -61,6 +61,7 @@ import org.hibernate.validator.internal.util.logging.formatter.ExecutableFormatt
 import org.hibernate.validator.internal.util.logging.formatter.ObjectArrayFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.TypeFormatter;
 import org.hibernate.validator.internal.xml.mapping.ContainerElementTypePath;
+import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
 import org.hibernate.validator.spi.properties.GetterPropertySelectionStrategy;
 import org.hibernate.validator.spi.scripting.ScriptEvaluationException;
 import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
@@ -881,4 +882,8 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 250, value = "Uninitialized locale: %s. Please register your locale as a locale to initialize when initializing your ValidatorFactory.")
 	ValidationException uninitializedLocale(Locale locale);
+
+	@LogMessage(level = INFO)
+	@Message(id = 251, value = "Using %s as bean metadata class normalizer.")
+	void usingBeanMetaDataClassNormalizer(@FormatWith(ClassObjectFormatter.class) Class<? extends BeanMetaDataClassNormalizer> beanMetaDataClassNormalizerClass);
 }

--- a/engine/src/main/java/org/hibernate/validator/metadata/BeanMetaDataClassNormalizer.java
+++ b/engine/src/main/java/org/hibernate/validator/metadata/BeanMetaDataClassNormalizer.java
@@ -1,0 +1,39 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.metadata;
+
+import org.hibernate.validator.Incubating;
+
+/**
+ * Define how the validated class is normalized before being used as the key to get the bean metadata.
+ * <p>
+ * In the case of the predefined scope validator factory, we have to register all the classes that will ever be
+ * validated. To validate method calls, frameworks usually generate proxies to intercept the calls. Such proxies might
+ * be hard to register in the predefined scope validator factory as they are generated code.
+ * <p>
+ * This contract allows to normalize the class before obtaining the metadata from the
+ * {@code PredefinedScopeBeanMetaDataManager} so that we only have to register the original bean class and not the proxy
+ * class.
+ * <p>
+ * Apart from avoiding the need to register the class, it also avoids generating unnecessary metadata for the proxy
+ * classes.
+ *
+ * @author Guillaume Smet
+ * @since 6.1
+ */
+@Incubating
+public interface BeanMetaDataClassNormalizer {
+
+	/**
+	 * Normalizes the provided class as the key used to get the bean metadata from the
+	 * {@code PredefinedScopeBeanMetaDataManager}.
+	 *
+	 * @param beanClass the original bean class
+	 * @return the normalized class
+	 */
+	Class<?> normalize(Class<?> beanClass);
+}


### PR DESCRIPTION
The idea is to be able to normalize the class and get the parent in the
case of a generated proxy.

@gunnarmorling very much interested if you have other name suggestions. Couldn't figure out something better but not totally satisfied.