### PR TITLE
HV-1683 Upgrade javadoc plugin

### DIFF
--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/internal/checks/GroupSequenceProviderCheck.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/internal/checks/GroupSequenceProviderCheck.java
@@ -182,7 +182,7 @@ public class GroupSequenceProviderCheck extends AbstractConstraintCheck {
 	 *
 	 * @param typeMirror The {@code TypeMirror} instance.
 	 *
-	 * @return The generic type or {@code null} if the given type doesn't implement the {@link org.hibernate.validator.group.DefaultGroupSequenceProvider} interface.
+	 * @return The generic type or {@code null} if the given type doesn't implement the {@link org.hibernate.validator.spi.group.DefaultGroupSequenceProvider} interface.
 	 */
 	private TypeMirror retrieveGenericProviderType(TypeMirror typeMirror) {
 		return typeMirror.accept(

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -102,7 +102,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 
 	/**
 	 * {@link TraversableResolver} as passed to the constructor of this instance.
-	 * Never use it directly, always use {@link #getCachingTraversableResolver()} to retrieved the single threaded caching wrapper.
+	 * Never use it directly, always use {@link TraversableResolvers#wrapWithCachingForSingleValidation(TraversableResolver, boolean)} to retrieved the single threaded caching wrapper.
 	 */
 	private final TraversableResolver traversableResolver;
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/MetaConstraint.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/MetaConstraint.java
@@ -66,7 +66,7 @@ public class MetaConstraint<A extends Annotation> {
 	/**
 	 * @param constraintDescriptor The constraint descriptor for this constraint
 	 * @param location meta data about constraint placement
-	 * @param valueExtractorDescriptors the potential {@link ValueExtractor}s used to extract the value to validate
+	 * @param valueExtractionPath the potential {@link ValueExtractor}s used to extract the value to validate
 	 * @param validatedValueType the type of the validated element
 	 */
 	MetaConstraint(ConstraintValidatorManager constraintValidatorManager, ConstraintDescriptorImpl<A> constraintDescriptor,

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
@@ -59,7 +59,7 @@ import org.hibernate.validator.internal.metadata.raw.ConstrainedParameter;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedType;
 import org.hibernate.validator.internal.properties.Callable;
 import org.hibernate.validator.internal.properties.Constrainable;
-import org.hibernate.validator.internal.properties.Property;
+import org.hibernate.validator.internal.properties.Getter;
 import org.hibernate.validator.internal.properties.javabean.JavaBeanAnnotatedConstrainable;
 import org.hibernate.validator.internal.properties.javabean.JavaBeanAnnotatedElement;
 import org.hibernate.validator.internal.properties.javabean.JavaBeanExecutable;
@@ -817,7 +817,8 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 	 * The location of a type argument before it is really considered a constraint location.
 	 * <p>
 	 * It avoids initializing a constraint location if we did not find any constraints. This is especially useful in
-	 * a Java 9 environment as {@link ConstraintLocation#forProperty(Property)} tries to make the {@code Member} accessible
+	 * a Java 9 environment as {@link ConstraintLocation#forField(org.hibernate.validator.internal.properties.Field)}
+	 * or {@link ConstraintLocation#forGetter(Getter)} tries to make the {@code Member} accessible
 	 * which might not be possible (for instance for {@code java.util} classes).
 	 */
 	private interface TypeArgumentLocation {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/ProgrammaticMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/ProgrammaticMetaDataProvider.java
@@ -84,7 +84,7 @@ public class ProgrammaticMetaDataProvider implements MetaDataProvider {
 	 * all the given contexts. So the "merge" pulls together the information for all configured elements, but it will never
 	 * merge several configurations for one given element.
 	 *
-	 * @param contexts set of mapping contexts providing annotation processing options to be merged
+	 * @param mappings set of mapping contexts providing annotation processing options to be merged
 	 *
 	 * @return a single annotation processing options object
 	 */

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ConfigurationFilePropertiesTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ConfigurationFilePropertiesTest.java
@@ -31,10 +31,12 @@ public class ConfigurationFilePropertiesTest {
 	/**
 	 * The following test assumes that the file META-INF/validation.xml is present and
 	 * contains:
+	 * <pre>{@code
 	 * <property name="hibernate.validator.allow_parameter_constraint_override">true</property>
 	 * <property name="hibernate.validator.allow_multiple_cascaded_validation_on_return_values">true</property>
 	 * <property name="hibernate.validator.allow_parallel_method_parameter_constraint">true</property>
 	 * <property name="hibernate.validator.fail_fast">true</property>
+	 * }</pre>
 	 *
 	 * The Maven build runs this test in a separate execution of surefire, which adds the
 	 * path to the required file onto its classpath.

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/serialization/CustomConstraintSerializableTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/serialization/CustomConstraintSerializableTest.java
@@ -22,10 +22,9 @@ import org.testng.annotations.Test;
  * simple custom Email validation constraint taken from <a href="http://blog.jteam.nl/2009/08/04/bean-validation-integrating-jsr-303-with-spring/"
  * >this blog</a> gives a validation result that is not Serializable with
  * Hibernate Validator 4.0.2.GA with underlying cause that
- * <p/>
+ * <p>
  * {@code org.hibernate.validator.internal.util.annotationfactory.AnnotationProxy}
- * <p/>
- * <p/>
+ * <p>
  * Note that Hibernate Validator does not guarantee at all that a
  * {@link ConstraintViolation} is Serializable because an entity need not be
  * Serializable, but otherwise there should not be much of a problem (right?).

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/OptionalTypeAnnotationConstraintUsingValidatePropertyTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/OptionalTypeAnnotationConstraintUsingValidatePropertyTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /**
- * Test combination of {@link Optional} and {@link UnwrapValidatedValue} on fields using validate property.
+ * Test combination of {@link Optional} and {@link Unwrapping.Unwrap} on fields using validate property.
  *
  * @author Davide D'Alto
  */

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/UnwrapValidatedValueTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/UnwrapValidatedValueTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
- * Test for unwrapping validated values via {@link org.hibernate.validator.valuehandling.UnwrapValidatedValue}.
+ * Test for unwrapping validated values via {@link Unwrapping.Unwrap}.
  *
  * @author Gunnar Morling
  */

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/privilegedactions/GetAnnotationsParameterTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/privilegedactions/GetAnnotationsParameterTest.java
@@ -21,7 +21,7 @@ import org.hibernate.validator.internal.util.privilegedactions.GetAnnotationAttr
 import org.testng.annotations.Test;
 
 /**
- * Unit test for {@link GetAnnotationsParameter}.
+ * Unit test for {@link GetAnnotationAttribute}.
  *
  * @author Gunnar Morling
  *

--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
         <version.japicmp.plugin>0.11.0</version.japicmp.plugin>
         <version.jar.plugin>3.0.2</version.jar.plugin>
         <version.jqassistant.plugin>1.3.0</version.jqassistant.plugin>
-        <version.javadoc.plugin>3.0.0</version.javadoc.plugin>
+        <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
         <version.license.plugin>3.0</version.license.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.resources.plugin>3.0.2</version.resources.plugin>


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1683

This one was caused by the ambiguity of the null exception that the 3.0.0 plugin could throw. And  this helped while I was trying to make the other pr to pass the distribution build. So I've changed the version and made a few updates to the javadoc here and there.