### PR TITLE
HV-1657 “propertyPath” available via the HibernateMessageInterpolatorContext

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/MessageInterpolatorContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/MessageInterpolatorContext.java
@@ -11,6 +11,7 @@ import static org.hibernate.validator.internal.util.CollectionHelper.toImmutable
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
+import javax.validation.Path;
 import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.internal.util.logging.Log;
@@ -33,19 +34,22 @@ public class MessageInterpolatorContext implements HibernateMessageInterpolatorC
 	private final ConstraintDescriptor<?> constraintDescriptor;
 	private final Object validatedValue;
 	private final Class<?> rootBeanType;
+	private final Path propertyPath;
 	@Immutable
 	private final Map<String, Object> messageParameters;
 	@Immutable
 	private final Map<String, Object> expressionVariables;
 
 	public MessageInterpolatorContext(ConstraintDescriptor<?> constraintDescriptor,
-			Object validatedValue,
-			Class<?> rootBeanType,
-			Map<String, Object> messageParameters,
-			Map<String, Object> expressionVariables) {
+					Object validatedValue,
+					Class<?> rootBeanType,
+					Path propertyPath,
+					Map<String, Object> messageParameters,
+					Map<String, Object> expressionVariables) {
 		this.constraintDescriptor = constraintDescriptor;
 		this.validatedValue = validatedValue;
 		this.rootBeanType = rootBeanType;
+		this.propertyPath = propertyPath;
 		this.messageParameters = toImmutableMap( messageParameters );
 		this.expressionVariables = toImmutableMap( expressionVariables );
 	}
@@ -73,6 +77,11 @@ public class MessageInterpolatorContext implements HibernateMessageInterpolatorC
 	@Override
 	public Map<String, Object> getExpressionVariables() {
 		return expressionVariables;
+	}
+
+	@Override
+	public Path getPropertyPath() {
+		return propertyPath;
 	}
 
 	@Override
@@ -122,6 +131,8 @@ public class MessageInterpolatorContext implements HibernateMessageInterpolatorC
 		sb.append( "MessageInterpolatorContext" );
 		sb.append( "{constraintDescriptor=" ).append( constraintDescriptor );
 		sb.append( ", validatedValue=" ).append( validatedValue );
+		sb.append( ", rootBeanType=" ).append( rootBeanType.getName() );
+		sb.append( ", propertyPath=" ).append( propertyPath );
 		sb.append( ", messageParameters=" ).append( messageParameters );
 		sb.append( ", expressionVariables=" ).append( expressionVariables );
 		sb.append( '}' );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/AbstractValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/AbstractValidationContext.java
@@ -228,6 +228,7 @@ abstract class AbstractValidationContext<T> implements BaseBeanValidationContext
 				messageTemplate,
 				valueContext.getCurrentValidatedValue(),
 				descriptor,
+				constraintViolationCreationContext.getPath(),
 				constraintViolationCreationContext.getMessageParameters(),
 				constraintViolationCreationContext.getExpressionVariables()
 		);
@@ -293,12 +294,14 @@ abstract class AbstractValidationContext<T> implements BaseBeanValidationContext
 			String messageTemplate,
 			Object validatedValue,
 			ConstraintDescriptor<?> descriptor,
+			Path path,
 			Map<String, Object> messageParameters,
 			Map<String, Object> expressionVariables) {
 		MessageInterpolatorContext context = new MessageInterpolatorContext(
 				descriptor,
 				validatedValue,
 				getRootBeanClass(),
+				path,
 				messageParameters,
 				expressionVariables
 		);

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/HibernateMessageInterpolatorContext.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/HibernateMessageInterpolatorContext.java
@@ -9,6 +9,7 @@ package org.hibernate.validator.messageinterpolation;
 import java.util.Map;
 
 import javax.validation.MessageInterpolator;
+import javax.validation.Path;
 
 /**
  * Extension to {@code MessageInterpolator.Context} which provides functionality
@@ -40,4 +41,11 @@ public interface HibernateMessageInterpolatorContext extends MessageInterpolator
 	 * @since 5.4.1
 	 */
 	Map<String, Object> getExpressionVariables();
+
+	/**
+	 * @return the path to the validated constraint starting from the root bean
+	 *
+	 * @since 6.1
+	 */
+	Path getPropertyPath();
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
@@ -67,9 +67,9 @@ public class ExpressionLanguageMessageInterpolationTest {
 				notNullDescriptor,
 				user,
 				null,
+				null,
 				Collections.<String, Object>emptyMap(),
-				Collections.<String, Object>emptyMap()
-		);
+				Collections.<String, Object>emptyMap() );
 
 		String expected = "18";
 		String actual = interpolatorUnderTest.interpolate( "${validatedValue.age}", context );
@@ -82,9 +82,9 @@ public class ExpressionLanguageMessageInterpolationTest {
 				notNullDescriptor,
 				new User(),
 				null,
+				null,
 				Collections.<String, Object>emptyMap(),
-				Collections.<String, Object>emptyMap()
-		);
+				Collections.<String, Object>emptyMap() );
 
 		String expected = "${validatedValue.foo}";
 		String actual = interpolatorUnderTest.interpolate( "${validatedValue.foo}", context );
@@ -172,9 +172,9 @@ public class ExpressionLanguageMessageInterpolationTest {
 				notNullDescriptor,
 				42.00000d,
 				null,
+				null,
 				Collections.<String, Object>emptyMap(),
-				Collections.<String, Object>emptyMap()
-		);
+				Collections.<String, Object>emptyMap() );
 
 		// german locale
 		String expected = "42,00";
@@ -232,9 +232,9 @@ public class ExpressionLanguageMessageInterpolationTest {
 				notNullDescriptor,
 				42.00000d,
 				null,
+				null,
 				Collections.<String, Object>emptyMap(),
-				Collections.<String, Object>emptyMap()
-		);
+				Collections.<String, Object>emptyMap() );
 
 		String expected = "${formatter.foo('%1$.2f', validatedValue)}";
 		String actual = interpolatorUnderTest.interpolate(
@@ -308,8 +308,8 @@ public class ExpressionLanguageMessageInterpolationTest {
 				descriptor,
 				null,
 				null,
+				null,
 				Collections.<String, Object>emptyMap(),
-				Collections.<String, Object>emptyMap()
-		);
+				Collections.<String, Object>emptyMap() );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/MessageInterpolatorContextTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/MessageInterpolatorContextTest.java
@@ -7,35 +7,46 @@
 
 package org.hibernate.validator.test.internal.engine.messageinterpolation;
 
-import static org.easymock.EasyMock.createMock;
-import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.replay;
-import static org.easymock.EasyMock.verify;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
-import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
-import static org.testng.Assert.assertSame;
-import static org.testng.Assert.assertTrue;
-
-import java.util.Collections;
-import java.util.Set;
+import org.hibernate.validator.internal.engine.MessageInterpolatorContext;
+import org.hibernate.validator.messageinterpolation.HibernateMessageInterpolatorContext;
+import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
+import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ValidatorUtil;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
 
 import javax.validation.Configuration;
 import javax.validation.ConstraintViolation;
 import javax.validation.MessageInterpolator;
 import javax.validation.MessageInterpolator.Context;
+import javax.validation.Path;
+import javax.validation.Valid;
 import javax.validation.ValidationException;
 import javax.validation.Validator;
 import javax.validation.constraints.Size;
 import javax.validation.metadata.BeanDescriptor;
 import javax.validation.metadata.ConstraintDescriptor;
 import javax.validation.metadata.PropertyDescriptor;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.ResourceBundle;
+import java.util.Set;
 
-import org.hibernate.validator.internal.engine.MessageInterpolatorContext;
-import org.hibernate.validator.messageinterpolation.HibernateMessageInterpolatorContext;
-import org.hibernate.validator.testutil.TestForIssue;
-import org.hibernate.validator.testutils.ValidatorUtil;
-
-import org.testng.annotations.Test;
+import static org.easymock.EasyMock.createMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Hardy Ferentschik
@@ -43,6 +54,16 @@ import org.testng.annotations.Test;
 public class MessageInterpolatorContextTest {
 
 	private static final String MESSAGE = "{foo}";
+
+	Validator validator;
+
+	@BeforeTest
+	public void setUp() {
+		validator = getConfiguration()
+				.messageInterpolator( new PathResourceBundleMessageInterpolator( new TestResourceBundleLocator() ) )
+				.buildValidatorFactory()
+				.getValidator();
+	}
 
 	@Test
 	@TestForIssue(jiraKey = "HV-333")
@@ -69,9 +90,9 @@ public class MessageInterpolatorContextTest {
 								constraintDescriptors.iterator().next(),
 								validatedValue,
 								TestBean.class,
+								null,
 								Collections.<String, Object>emptyMap(),
-								Collections.<String, Object>emptyMap()
-						)
+								Collections.<String, Object>emptyMap() )
 				)
 		)
 				.andReturn( "invalid" );
@@ -88,13 +109,13 @@ public class MessageInterpolatorContextTest {
 
 	@Test(expectedExceptions = ValidationException.class)
 	public void testUnwrapToImplementationCausesValidationException() {
-		Context context = new MessageInterpolatorContext( null, null, null, Collections.<String, Object>emptyMap(), Collections.<String, Object>emptyMap() );
+		Context context = new MessageInterpolatorContext( null, null, null, null, Collections.<String, Object>emptyMap(), Collections.<String, Object>emptyMap() );
 		context.unwrap( MessageInterpolatorContext.class );
 	}
 
 	@Test
 	public void testUnwrapToInterfaceTypesSucceeds() {
-		Context context = new MessageInterpolatorContext( null, null, null, Collections.<String, Object>emptyMap(), Collections.<String, Object>emptyMap() );
+		Context context = new MessageInterpolatorContext( null, null, null, null, Collections.<String, Object>emptyMap(), Collections.<String, Object>emptyMap() );
 
 		MessageInterpolator.Context asMessageInterpolatorContext = context.unwrap( MessageInterpolator.Context.class );
 		assertSame( asMessageInterpolatorContext, context );
@@ -115,11 +136,44 @@ public class MessageInterpolatorContextTest {
 				null,
 				null,
 				rootBeanType,
+				null,
 				Collections.<String, Object>emptyMap(),
-				Collections.<String, Object>emptyMap()
-		);
+				Collections.<String, Object>emptyMap() );
 
 		assertSame( context.unwrap( HibernateMessageInterpolatorContext.class ).getRootBeanType(), rootBeanType );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1657")
+	public void testGetPropertyPath() {
+		Path pathMock = createMock( Path.class );
+		MessageInterpolator.Context context = new MessageInterpolatorContext(
+				null,
+				null,
+				null,
+				pathMock,
+				Collections.<String, Object>emptyMap(),
+				Collections.<String, Object>emptyMap() );
+
+		assertSame( context.unwrap( HibernateMessageInterpolatorContext.class ).getPropertyPath(), pathMock );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1657")
+	public void testUsageOfPathInInterpolation() {
+		Employee employee = createEmployee( "farTooLongStreet", "workPlaza" );
+		Set<ConstraintViolation<Employee>> constraintViolations = validator.validate( employee );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withMessage( "Employee Street should be smaller than 15" )
+		);
+
+		employee = createEmployee( "mySquare", "farTooLongStreet" );
+		constraintViolations = validator.validate( employee );
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Size.class )
+						.withMessage( "Company Street should be smaller than 15" )
+		);
 	}
 
 	private static class TestBean {
@@ -128,6 +182,146 @@ public class MessageInterpolatorContextTest {
 
 		public TestBean(String test) {
 			this.test = test;
+		}
+	}
+
+	/**
+	 * Interpolator demonstrator for {@link MessageInterpolatorContextTest#testUsageOfPathInInterpolation}
+	 */
+	public class PathResourceBundleMessageInterpolator extends ResourceBundleMessageInterpolator {
+
+		public PathResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator) {
+			super( userResourceBundleLocator );
+		}
+
+		@Override
+		public String interpolate(String message, Context context) {
+			String newMessage = super.interpolate( message, context );
+			newMessage = newMessage.replace( "#path#", "{" + pathToString( context ) + "}" );
+			return super.interpolate( newMessage, context );
+		}
+
+		private String pathToString(Context context) {
+			HibernateMessageInterpolatorContext hContext = context.unwrap( HibernateMessageInterpolatorContext.class );
+			StringBuilder baseNodeBuilder = new StringBuilder( hContext.getRootBeanType().getSimpleName() );
+			for ( Path.Node node : hContext.getPropertyPath() ) {
+				if ( node.getName() != null ) {
+					baseNodeBuilder.append( "." ).append( node.getName() );
+				}
+			}
+			return baseNodeBuilder.toString();
+		}
+
+	}
+
+	/**
+	 * creating a test employee with 2 properties of the same type (same annotation).
+	 *
+	 * @param employeeStreet
+	 * @param employerStreet
+	 * @return
+	 */
+	public static Employee createEmployee(String employeeStreet, String employerStreet) {
+		Employee employee = new Employee();
+		employee.address = new Address();
+		employee.address.street = employeeStreet;
+		employee.employer = new Employer();
+		employee.employer.address = new Address();
+		employee.employer.address.street = employerStreet;
+		return employee;
+	}
+
+	/**
+	 * Test bean for {@link MessageInterpolatorContextTest#testUsageOfPathInInterpolation}
+	 */
+	public static class Address {
+
+		@Size(max = 15)
+		private String street;
+
+	}
+
+	/**
+	 * Test bean for {@link MessageInterpolatorContextTest#testUsageOfPathInInterpolation}
+	 */
+	public static class Employee {
+
+		@Valid
+		private Address address;
+
+		@Valid
+		private Employer employer;
+	}
+
+	/**
+	 * Test bean for {@link MessageInterpolatorContextTest#testUsageOfPathInInterpolation}
+	 */
+	public static class Employer {
+
+		@Valid
+		private Address address;
+	}
+
+	/**
+	 * A dummy locator for {@link MessageInterpolatorContextTest#testUsageOfPathInInterpolation}
+	 */
+	private static class TestResourceBundleLocator implements ResourceBundleLocator {
+
+		private final ResourceBundle resourceBundle;
+
+		public TestResourceBundleLocator() {
+			this( new TestResourceBundle() );
+		}
+
+		public TestResourceBundleLocator(ResourceBundle bundle) {
+			resourceBundle = bundle;
+		}
+
+		@Override
+		public ResourceBundle getResourceBundle(Locale locale) {
+			return resourceBundle;
+		}
+	}
+
+	/**
+	 * A dummy resource bundle for {@link MessageInterpolatorContextTest#testUsageOfPathInInterpolation}
+	 */
+	private static class TestResourceBundle extends ResourceBundle implements Enumeration<String> {
+		private final Map<String, String> testResources;
+		Iterator<String> iter;
+
+		public TestResourceBundle() {
+			testResources = new HashMap<String, String>();
+			// add some test messages
+			testResources.put( "Employee.address.street", "Employee Street" );
+			testResources.put( "Employee.employer.address.street", "Company Street" );
+			testResources.put( "javax.validation.constraints.Size.message", "#path# should be smaller than {max}" );
+			iter = testResources.keySet().iterator();
+		}
+
+		@Override
+		public Object handleGetObject(String key) {
+			return testResources.get( key );
+		}
+
+		@Override
+		public Enumeration<String> getKeys() {
+			return this;
+		}
+
+		@Override
+		public boolean hasMoreElements() {
+			return iter.hasNext();
+		}
+
+		@Override
+		public String nextElement() {
+			if ( hasMoreElements() ) {
+				return iter.next();
+			}
+			else {
+				throw new NoSuchElementException();
+			}
 		}
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/ResourceBundleMessageInterpolatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/ResourceBundleMessageInterpolatorTest.java
@@ -279,9 +279,9 @@ public class ResourceBundleMessageInterpolatorTest {
 				descriptor,
 				null,
 				null,
+				null,
 				Collections.<String, Object>emptyMap(),
-				Collections.<String, Object>emptyMap()
-		);
+				Collections.<String, Object>emptyMap() );
 	}
 
 	private void runInterpolation(boolean cachingEnabled) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1657

See HV-1657 for more details. I did not add the `@Since` tag to the new method (which I probably should) since I don't know which version to indicate. I'm using Hibernate Validation in JBOSS EAP 7.1 (5.3.5Final) so I hope to get this available in some maintenance release.