### PR TITLE
HV-1088 Making sure constraint validators are always properly released when using multiple custom constraint validator factories (backport to 5.4.X)

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorManager.java
@@ -63,7 +63,13 @@ public class ConstraintValidatorManager {
 	/**
 	 * The most recently used non default constraint validator factory.
 	 */
-	private ConstraintValidatorFactory mostRecentlyUsedNonDefaultConstraintValidatorFactory;
+	private volatile ConstraintValidatorFactory mostRecentlyUsedNonDefaultConstraintValidatorFactory;
+
+	/**
+	 * Used for synchronizing access to {@link #mostRecentlyUsedNonDefaultConstraintValidatorFactory} (which can be
+	 * null itself).
+	 */
+	private final Object mostRecentlyUsedNonDefaultConstraintValidatorFactoryMutex = new Object();
 
 	/**
 	 * Cache of initialized {@code ConstraintValidator} instances keyed against validates type, annotation and
@@ -119,8 +125,12 @@ public class ConstraintValidatorManager {
 	private <V, A extends Annotation> ConstraintValidator<A, V> cacheValidator(CacheKey key, ConstraintValidator<A, V> constraintValidator) {
 		// we only cache constraint validator instances for the default and most recently used factory
 		if ( key.constraintFactory != defaultConstraintValidatorFactory && key.constraintFactory != mostRecentlyUsedNonDefaultConstraintValidatorFactory ) {
-			clearEntriesForFactory( mostRecentlyUsedNonDefaultConstraintValidatorFactory );
-			mostRecentlyUsedNonDefaultConstraintValidatorFactory = key.constraintFactory;
+			synchronized ( mostRecentlyUsedNonDefaultConstraintValidatorFactoryMutex ) {
+				if ( key.constraintFactory != mostRecentlyUsedNonDefaultConstraintValidatorFactory ) {
+					clearEntriesForFactory( mostRecentlyUsedNonDefaultConstraintValidatorFactory );
+					mostRecentlyUsedNonDefaultConstraintValidatorFactory = key.constraintFactory;
+				}
+			}
 		}
 
 		@SuppressWarnings("unchecked")


### PR DESCRIPTION
As the title suggests, this PR back ports [same change ](https://github.com/hibernate/hibernate-validator/commit/9e2c0d99e9ed856b8b57cbac3aac8a3bbb1d47a6)as it was done for v6.

For more details, see #658 

@gunnarmorling FYI