### PR TITLE
HV-1692 Custom group sequence might cause StackOverflowError on objects with cycles

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -452,6 +452,9 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 							validationSuccessful = validateConstraintsForSingleDefaultGroupElement( validationContext, valueContext, validatedInterfaces, clazz,
 									metaConstraints, defaultSequenceMember );
 						}
+
+						validationContext.markCurrentBeanAsProcessed( valueContext );
+
 						if ( !validationSuccessful ) {
 							break;
 						}
@@ -463,9 +466,8 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 				Set<MetaConstraint<?>> metaConstraints = hostingBeanMetaData.getDirectMetaConstraints();
 				validateConstraintsForSingleDefaultGroupElement( validationContext, valueContext, validatedInterfaces, clazz, metaConstraints,
 						Group.DEFAULT_GROUP );
+				validationContext.markCurrentBeanAsProcessed( valueContext );
 			}
-
-			validationContext.markCurrentBeanAsProcessed( valueContext );
 
 			// all constraints in the hierarchy has been validated, stop validation.
 			if ( defaultGroupSequenceIsRedefined ) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/sequence/SequenceOnObjectsWithCycles.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/sequence/SequenceOnObjectsWithCycles.java
@@ -1,0 +1,64 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.groups.sequence;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.GroupSequence;
+import javax.validation.Valid;
+import javax.validation.Validator;
+
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ValidatorUtil;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+@TestForIssue(jiraKey = "HV-1692")
+public class SequenceOnObjectsWithCycles {
+
+	@Test
+	public void groupSequenceOfGroupSequences() {
+		Validator validator = ValidatorUtil.getValidator();
+
+		YourAnnotatedBean yourEntity1 = new YourAnnotatedBean();
+		AnotherBean anotherBean = new AnotherBean();
+		anotherBean.setYourAnnotatedBean( yourEntity1 );
+		yourEntity1.setBean( anotherBean );
+
+		Set<ConstraintViolation<YourAnnotatedBean>> constraintViolations = validator.validate( yourEntity1 );
+		Assert.assertEquals( 0, constraintViolations.size() );
+
+	}
+
+	@GroupSequence({ AnotherBean.class, Magic.class })
+	public class AnotherBean {
+
+		@Valid
+		private YourAnnotatedBean yourAnnotatedBean;
+
+
+		public void setYourAnnotatedBean(YourAnnotatedBean yourAnnotatedBean) {
+			this.yourAnnotatedBean = yourAnnotatedBean;
+		}
+	}
+
+	@GroupSequence({ YourAnnotatedBean.class, Magic.class })
+	public class YourAnnotatedBean {
+
+		@Valid
+		private AnotherBean bean;
+
+		public void setBean(AnotherBean bean) {
+			this.bean = bean;
+		}
+	}
+
+	public interface Magic {
+	}
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1692

Change when beans are marked as processed
- in case of redefined group sequences only the last group was marked as processed while all other groups were ignored. Marking bean as processed in the loop allows to catch all the groups in the sequence

As it turned out we were missing some of the processed units when dealing with group sequences. I've added a test from the ticket as a separate one, as I didn't find a better place for it. 