### PR TITLE
HV-1691 Rename PathImpl#getPathWithoutLeafNode to createCopyWithoutLeafNode

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -1277,7 +1277,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 			return true;
 		}
 
-		Path pathToObject = path.getPathWithoutLeafNode();
+		Path pathToObject = PathImpl.createCopyWithoutLeafNode( path );
 		try {
 			return validationContext.getTraversableResolver().isReachable(
 					traversableObject,
@@ -1314,7 +1314,7 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 			return false;
 		}
 
-		Path pathToObject = path.getPathWithoutLeafNode();
+		Path pathToObject = PathImpl.createCopyWithoutLeafNode( path );
 		try {
 			return validationContext.getTraversableResolver().isCascadable(
 					traversableObject,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
@@ -247,7 +247,7 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 		 */
 		private void dropLeafNodeIfRequired() {
 			if ( propertyPath.getLeafNode().getKind() == ElementKind.BEAN ) {
-				propertyPath = propertyPath.getPathWithoutLeafNode();
+				propertyPath = PathImpl.createCopyWithoutLeafNode( propertyPath );
 			}
 		}
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/CrossParameterConstraintValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/CrossParameterConstraintValidatorContextImpl.java
@@ -70,7 +70,7 @@ public class CrossParameterConstraintValidatorContextImpl extends ConstraintVali
 		}
 
 		private void dropLeafNode() {
-			propertyPath = propertyPath.getPathWithoutLeafNode();
+			propertyPath = PathImpl.createCopyWithoutLeafNode( propertyPath );
 		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -105,12 +105,13 @@ public final class PathImpl implements Path, Serializable {
 		return new PathImpl( path );
 	}
 
-	public boolean isRootPath() {
-		return nodeList.size() == 1 && nodeList.get( 0 ).getName() == null;
+	public static PathImpl createCopyWithoutLeafNode(PathImpl path) {
+		return new PathImpl( path.nodeList.subList( 0, path.nodeList.size() - 1 ) );
 	}
 
-	public PathImpl getPathWithoutLeafNode() {
-		return new PathImpl( nodeList.subList( 0, nodeList.size() - 1 ) );
+
+	public boolean isRootPath() {
+		return nodeList.size() == 1 && nodeList.get( 0 ).getName() == null;
 	}
 
 	public NodeImpl addPropertyNode(String nodeName) {


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1691

So this won't solve the whole issue of `PathImpl` and `NodeImpl` not being serializable by Jackson but it will solve the immediate issue by making the `getPathWithoutLeafNode()` method purpose more clear and not suitable for serialization.