### PR TITLE
HV-1699 Hibernate-validator 6: Weird behavior of the @Max annotation with a BigDecimal set on a Number field

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MaxValidatorForNumber.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MaxValidatorForNumber.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.number.bound;
 
+import org.hibernate.validator.internal.constraintvalidators.bv.number.InfinityNumberComparatorHelper;
+
 /**
  * Check that the number being validated is less than or equal to the maximum
  * value specified.
@@ -16,6 +18,6 @@ public class MaxValidatorForNumber extends AbstractMaxValidator<Number> {
 
 	@Override
 	protected int compare(Number number) {
-		return NumberComparatorHelper.compare( number, maxValue );
+		return NumberComparatorHelper.compare( number, maxValue, InfinityNumberComparatorHelper.GREATER_THAN );
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MinValidatorForNumber.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MinValidatorForNumber.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.number.bound;
 
+import org.hibernate.validator.internal.constraintvalidators.bv.number.InfinityNumberComparatorHelper;
+
 /**
  * Check that the number being validated is greater than or equal to the minimum
  * value specified.
@@ -16,6 +18,6 @@ public class MinValidatorForNumber extends AbstractMinValidator<Number> {
 
 	@Override
 	protected int compare(Number number) {
-		return NumberComparatorHelper.compare( number, minValue );
+		return NumberComparatorHelper.compare( number, minValue, InfinityNumberComparatorHelper.LESS_THAN );
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/NumberComparatorHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/NumberComparatorHelper.java
@@ -32,7 +32,24 @@ final class NumberComparatorHelper {
 		return number.compareTo( value );
 	}
 
-	public static int compare(Number number, long value) {
+	public static int compare(Number number, long value, OptionalInt treatNanAs) {
+		// In case of comparing numbers before we compare them as two longs:
+		// 1. We need to check for floating point number as it should be treated differently in such case:
+		if ( number instanceof Double ) {
+			return compare( (Double) number, value, treatNanAs );
+		}
+		if ( number instanceof Float ) {
+			return compare( (Float) number, value, treatNanAs );
+		}
+
+		// 2. We need to check for big numbers so that we don't lose data when converting them to long:
+		if ( number instanceof BigDecimal ) {
+			return compare( (BigDecimal) number, value );
+		}
+		if ( number instanceof BigInteger ) {
+			return compare( (BigInteger) number, value );
+		}
+
 		return Long.compare( number.longValue(), value );
 	}
 
@@ -41,7 +58,7 @@ final class NumberComparatorHelper {
 		if ( infinity.isPresent() ) {
 			return infinity.getAsInt();
 		}
-		return Long.compare( number.longValue(), value );
+		return Double.compare( number, value );
 	}
 
 	public static int compare(Float number, long value, OptionalInt treatNanAs) {
@@ -49,6 +66,6 @@ final class NumberComparatorHelper {
 		if ( infinity.isPresent() ) {
 			return infinity.getAsInt();
 		}
-		return Long.compare( number.longValue(), value );
+		return Float.compare( number, value );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/BaseMinMaxValidatorForNumberTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/BaseMinMaxValidatorForNumberTest.java
@@ -98,6 +98,7 @@ public class BaseMinMaxValidatorForNumberTest {
 
 		assertTrue( constraint.isValid( null, null ) );
 		assertEquals( constraint.isValid( 14.99, null ), isMax );
+		assertEquals( constraint.isValid( 15.001, null ), !isMax );
 		assertEquals( constraint.isValid( -14.99, null ), isMax );
 		assertEquals( constraint.isValid( -1560000000D, null ), isMax );
 		assertEquals( constraint.isValid( Double.NEGATIVE_INFINITY, null ), isMax );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MaxValidatorForNumberTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MaxValidatorForNumberTest.java
@@ -6,6 +6,11 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv;
 
+import static org.testng.Assert.assertFalse;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.Max;
 
@@ -77,6 +82,23 @@ public class MaxValidatorForNumberTest extends BaseMinMaxValidatorForNumberTest 
 		DecimalMax m = descriptorBuilder.build().getAnnotation();
 		testDecimalMax( m, false );
 
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1699")
+	public void testIsValidNumberForFloatingPointOrBigNumbersStoredAsNumber() {
+		ConstraintAnnotationDescriptor.Builder<Max> descriptorBuilder = new ConstraintAnnotationDescriptor.Builder<>( Max.class );
+		descriptorBuilder.setAttribute( "value", 1L );
+		Max m = descriptorBuilder.build().getAnnotation();
+		MaxValidatorForNumber validator = new MaxValidatorForNumber();
+		validator.initialize( m );
+
+		assertFalse( validator.isValid( 1.01, null ) );
+		assertFalse( validator.isValid( 1.01F, null ) );
+		assertFalse( validator.isValid( new BigDecimal( "1.01" ), null ) );
+		assertFalse( validator.isValid( new BigInteger( "2" ), null ) );
+		assertFalse( validator.isValid( Double.POSITIVE_INFINITY, null ) );
+		assertFalse( validator.isValid( Float.POSITIVE_INFINITY, null ) );
 	}
 
 	private void testDecimalMax(DecimalMax m, boolean inclusive) {


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1699

If a `*Number*` validator was used it would convert any number to long hence some data might be lost. 

Change how numbers are compared in Max/Min validators
- for Min/Max `Number` validators check if actual numbers are not with floating point (float,double) and if they are direct them to correct number comparator helper method
- for big numbers (BigDecimal, BigInteger) check in number comparator helper before converting to long. If actual numbers are from the 'Big*' classes direct the call to corresponding overloaded versions of the method so that no data will be lost
- Compare floating point numbers using `Double#compare()`