### PR TITLE
HV-1700 Remove reference of absent valueextractor from test resources

### DIFF
--- a/engine/src/test/resources/META-INF/services/javax.validation.valueextraction.ValueExtractor
+++ b/engine/src/test/resources/META-INF/services/javax.validation.valueextraction.ValueExtractor
@@ -1,1 +1,0 @@
-org.hibernate.validator.test.internal.engine.cascaded.GuavaOptionalValueExtractor


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1700

Remove ValueExtractor service file as not needed
- as the value extractors and tests for it from this file was moved to BVTCK the file became redundant and can be removed to prevent tests from logging messages about troubles with missing VE