### PR TITLE
HV-1698 Try to make ConstraintValidator constructors accessible if not public

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorFactoryImpl.java
@@ -20,12 +20,11 @@ import org.hibernate.validator.internal.util.privilegedactions.NewInstance;
  * @author Emmanuel Bernard
  * @author Hardy Ferentschik
  */
-//TODO Can we make the constructor non-public?
 public class ConstraintValidatorFactoryImpl implements ConstraintValidatorFactory {
 
 	@Override
 	public final <T extends ConstraintValidator<?, ?>> T getInstance(Class<T> key) {
-		return run( NewInstance.action( key, "ConstraintValidator" ) );
+		return run( NewInstance.action( key, "ConstraintValidator", true ) );
 	}
 
 	@Override

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintValidatorManagerTest.java
@@ -12,6 +12,7 @@ import static org.hibernate.validator.testutils.ConstraintValidatorInitializatio
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -458,6 +459,14 @@ public class ConstraintValidatorManagerTest {
 		}
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HV-1698")
+	public void testConstraintValidatorWithPrivateConstructor() {
+		try ( ValidatorFactory factory = getConfiguration().buildValidatorFactory() ) {
+			assertFalse( factory.getValidator().validate( new Bar() ).isEmpty() );
+		}
+	}
+
 	private ConstraintDescriptorImpl<?> getConstraintDescriptorForProperty(String propertyName) {
 		return getSingleConstraintDescriptorForProperty( validator, Foo.class, propertyName );
 	}
@@ -482,6 +491,11 @@ public class ConstraintValidatorManagerTest {
 
 		@Size
 		String s2;
+	}
+
+	private static class Bar {
+		@ConstraintWithPrivateValidator
+		private Object object;
 	}
 
 	public class MyCustomValidatorFactory implements ConstraintValidatorFactory {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintWithPrivateValidator.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/constraintvalidation/ConstraintWithPrivateValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.constraintvalidation;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.Payload;
+
+@Target({ FIELD, METHOD, PARAMETER, ANNOTATION_TYPE })
+@Retention(RUNTIME)
+@Documented
+@Constraint(validatedBy = { ConstraintWithPrivateValidator.ConstraintWithPrivateValidatorValidator.class })
+public @interface ConstraintWithPrivateValidator {
+	String message() default "Invalid";
+
+	Class<?>[] groups() default { };
+
+	Class<? extends Payload>[] payload() default { };
+
+	class ConstraintWithPrivateValidatorValidator implements ConstraintValidator<ConstraintWithPrivateValidator, Object> {
+		private ConstraintWithPrivateValidatorValidator() {
+		}
+
+		@Override
+		public boolean isValid(Object value, ConstraintValidatorContext context) {
+			return false;
+		}
+	}
+
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1698

Make constraint validator constructors accessible:
- update `NewInstance` action with makeAccessible switch
- use new action switch when instantiating constraint validators