### PR TITLE
HV-1701 Add Max/MinValidatorForInteger

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MaxValidatorForByte.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MaxValidatorForByte.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.bv.number.bound;
+
+/**
+ * Check that the number being validated is less than or equal to the maximum
+ * value specified.
+ *
+ * @author Marko Bekhta
+ */
+public class MaxValidatorForByte extends AbstractMaxValidator<Byte> {
+
+	@Override
+	protected int compare(Byte number) {
+		return NumberComparatorHelper.compare( number.longValue(), maxValue );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MaxValidatorForInteger.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MaxValidatorForInteger.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.bv.number.bound;
+
+/**
+ * Check that the number being validated is less than or equal to the maximum
+ * value specified.
+ *
+ * @author Marko Bekhta
+ */
+public class MaxValidatorForInteger extends AbstractMaxValidator<Integer> {
+
+	@Override
+	protected int compare(Integer number) {
+		return NumberComparatorHelper.compare( number.longValue(), maxValue );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MaxValidatorForShort.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MaxValidatorForShort.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.bv.number.bound;
+
+/**
+ * Check that the number being validated is less than or equal to the maximum
+ * value specified.
+ *
+ * @author Marko Bekhta
+ */
+public class MaxValidatorForShort extends AbstractMaxValidator<Short> {
+
+	@Override
+	protected int compare(Short number) {
+		return NumberComparatorHelper.compare( number.longValue(), maxValue );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MinValidatorForByte.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MinValidatorForByte.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.bv.number.bound;
+
+/**
+ * Check that the number being validated is greater than or equal to the minimum
+ * value specified.
+ *
+ * @author Marko Bekhta
+ */
+public class MinValidatorForByte extends AbstractMinValidator<Byte> {
+
+	@Override
+	protected int compare(Byte number) {
+		return NumberComparatorHelper.compare( number.longValue(), minValue );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MinValidatorForInteger.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MinValidatorForInteger.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.bv.number.bound;
+
+/**
+ * Check that the number being validated is greater than or equal to the minimum
+ * value specified.
+ *
+ * @author Marko Bekhta
+ */
+public class MinValidatorForInteger extends AbstractMinValidator<Integer> {
+
+	@Override
+	protected int compare(Integer number) {
+		return NumberComparatorHelper.compare( number.longValue(), minValue );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MinValidatorForShort.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/MinValidatorForShort.java
@@ -1,0 +1,21 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.bv.number.bound;
+
+/**
+ * Check that the number being validated is greater than or equal to the minimum
+ * value specified.
+ *
+ * @author Marko Bekhta
+ */
+public class MinValidatorForShort extends AbstractMinValidator<Short> {
+
+	@Override
+	protected int compare(Short number) {
+		return NumberComparatorHelper.compare( number.longValue(), minValue );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/NumberComparatorHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/NumberComparatorHelper.java
@@ -33,8 +33,9 @@ final class NumberComparatorHelper {
 	}
 
 	public static int compare(Number number, long value, OptionalInt treatNanAs) {
-		// In case of comparing numbers before we compare them as two longs:
-		// 1. We need to check for floating point number as it should be treated differently in such case:
+		// In case of comparing numbers we need to check for special cases:
+		// 1. Floating point numbers should consider nan/infinity as values hence they should
+		// be directed to corresponding overloaded methods:
 		if ( number instanceof Double ) {
 			return compare( (Double) number, value, treatNanAs );
 		}
@@ -42,7 +43,7 @@ final class NumberComparatorHelper {
 			return compare( (Float) number, value, treatNanAs );
 		}
 
-		// 2. We need to check for big numbers so that we don't lose data when converting them to long:
+		// 2. For big numbers we don't want to lose any data so we just cast them and call corresponding methods:
 		if ( number instanceof BigDecimal ) {
 			return compare( (BigDecimal) number, value );
 		}
@@ -50,7 +51,14 @@ final class NumberComparatorHelper {
 			return compare( (BigInteger) number, value );
 		}
 
-		return Long.compare( number.longValue(), value );
+		// 3. For any integer types we convert them to long as we would do that anyway
+		// when comparing with a long value. And use corresponding method for longs:
+		if ( number instanceof Byte || number instanceof Integer || number instanceof Long || number instanceof Short ) {
+			return compare( number.longValue(), value );
+		}
+
+		// 4. As a fallback we convert the number to double:
+		return compare( number.doubleValue(), value, treatNanAs );
 	}
 
 	public static int compare(Double number, long value, OptionalInt treatNanAs) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMaxValidatorForByte.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMaxValidatorForByte.java
@@ -6,18 +6,16 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal;
 
-import org.hibernate.validator.internal.constraintvalidators.bv.number.InfinityNumberComparatorHelper;
-
 /**
  * Check that the number being validated is less than or equal to the maximum
  * value specified.
  *
  * @author Marko Bekhta
  */
-public class DecimalMaxValidatorForNumber extends AbstractDecimalMaxValidator<Number> {
+public class DecimalMaxValidatorForByte extends AbstractDecimalMaxValidator<Byte> {
 
 	@Override
-	protected int compare(Number number) {
-		return DecimalNumberComparatorHelper.compare( number, maxValue, InfinityNumberComparatorHelper.GREATER_THAN );
+	protected int compare(Byte number) {
+		return DecimalNumberComparatorHelper.compare( number.longValue(), maxValue );
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMaxValidatorForInteger.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMaxValidatorForInteger.java
@@ -6,18 +6,16 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal;
 
-import org.hibernate.validator.internal.constraintvalidators.bv.number.InfinityNumberComparatorHelper;
-
 /**
  * Check that the number being validated is less than or equal to the maximum
  * value specified.
  *
  * @author Marko Bekhta
  */
-public class DecimalMaxValidatorForNumber extends AbstractDecimalMaxValidator<Number> {
+public class DecimalMaxValidatorForInteger extends AbstractDecimalMaxValidator<Integer> {
 
 	@Override
-	protected int compare(Number number) {
-		return DecimalNumberComparatorHelper.compare( number, maxValue, InfinityNumberComparatorHelper.GREATER_THAN );
+	protected int compare(Integer number) {
+		return DecimalNumberComparatorHelper.compare( number.longValue(), maxValue );
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMaxValidatorForShort.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMaxValidatorForShort.java
@@ -6,18 +6,16 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal;
 
-import org.hibernate.validator.internal.constraintvalidators.bv.number.InfinityNumberComparatorHelper;
-
 /**
  * Check that the number being validated is less than or equal to the maximum
  * value specified.
  *
  * @author Marko Bekhta
  */
-public class DecimalMaxValidatorForNumber extends AbstractDecimalMaxValidator<Number> {
+public class DecimalMaxValidatorForShort extends AbstractDecimalMaxValidator<Short> {
 
 	@Override
-	protected int compare(Number number) {
-		return DecimalNumberComparatorHelper.compare( number, maxValue, InfinityNumberComparatorHelper.GREATER_THAN );
+	protected int compare(Short number) {
+		return DecimalNumberComparatorHelper.compare( number.longValue(), maxValue );
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMinValidatorForByte.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMinValidatorForByte.java
@@ -6,18 +6,16 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal;
 
-import org.hibernate.validator.internal.constraintvalidators.bv.number.InfinityNumberComparatorHelper;
-
 /**
  * Check that the number being validated is greater than or equal to the minimum
  * value specified.
  *
  * @author Marko Bekhta
  */
-public class DecimalMinValidatorForNumber extends AbstractDecimalMinValidator<Number> {
+public class DecimalMinValidatorForByte extends AbstractDecimalMinValidator<Byte> {
 
 	@Override
-	protected int compare(Number number) {
-		return DecimalNumberComparatorHelper.compare( number, minValue, InfinityNumberComparatorHelper.LESS_THAN );
+	protected int compare(Byte number) {
+		return DecimalNumberComparatorHelper.compare( number.longValue(), minValue );
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMinValidatorForInteger.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMinValidatorForInteger.java
@@ -6,18 +6,16 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal;
 
-import org.hibernate.validator.internal.constraintvalidators.bv.number.InfinityNumberComparatorHelper;
-
 /**
  * Check that the number being validated is greater than or equal to the minimum
  * value specified.
  *
  * @author Marko Bekhta
  */
-public class DecimalMinValidatorForNumber extends AbstractDecimalMinValidator<Number> {
+public class DecimalMinValidatorForInteger extends AbstractDecimalMinValidator<Integer> {
 
 	@Override
-	protected int compare(Number number) {
-		return DecimalNumberComparatorHelper.compare( number, minValue, InfinityNumberComparatorHelper.LESS_THAN );
+	protected int compare(Integer number) {
+		return DecimalNumberComparatorHelper.compare( number.longValue(), minValue );
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMinValidatorForShort.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalMinValidatorForShort.java
@@ -6,18 +6,16 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal;
 
-import org.hibernate.validator.internal.constraintvalidators.bv.number.InfinityNumberComparatorHelper;
-
 /**
  * Check that the number being validated is greater than or equal to the minimum
  * value specified.
  *
  * @author Marko Bekhta
  */
-public class DecimalMinValidatorForNumber extends AbstractDecimalMinValidator<Number> {
+public class DecimalMinValidatorForShort extends AbstractDecimalMinValidator<Short> {
 
 	@Override
-	protected int compare(Number number) {
-		return DecimalNumberComparatorHelper.compare( number, minValue, InfinityNumberComparatorHelper.LESS_THAN );
+	protected int compare(Short number) {
+		return DecimalNumberComparatorHelper.compare( number.longValue(), minValue );
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalNumberComparatorHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/number/bound/decimal/DecimalNumberComparatorHelper.java
@@ -32,8 +32,33 @@ final class DecimalNumberComparatorHelper {
 		return BigDecimal.valueOf( number ).compareTo( value );
 	}
 
-	public static int compare(Number number, BigDecimal value) {
-		return BigDecimal.valueOf( number.doubleValue() ).compareTo( value );
+	public static int compare(Number number, BigDecimal value, OptionalInt treatNanAs) {
+		// In case of comparing numbers we need to check for special cases:
+		// 1. Floating point numbers should consider nan/infinity as values hence they should
+		// be directed to corresponding overloaded methods:
+		if ( number instanceof Double ) {
+			return compare( (Double) number, value, treatNanAs );
+		}
+		if ( number instanceof Float ) {
+			return compare( (Float) number, value, treatNanAs );
+		}
+
+		// 2. For big numbers we don't want to lose any data so we just cast them and call corresponding methods:
+		if ( number instanceof BigDecimal ) {
+			return compare( (BigDecimal) number, value );
+		}
+		if ( number instanceof BigInteger ) {
+			return compare( (BigInteger) number, value );
+		}
+
+		// 3. For any integer types we convert them to long as we would do that anyway
+		// to create a BigDecimal instance. And use corresponding method for longs:
+		if ( number instanceof Byte || number instanceof Integer || number instanceof Long || number instanceof Short ) {
+			return compare( number.longValue(), value );
+		}
+
+		// 4. As a fallback we convert the number to double:
+		return compare( number.doubleValue(), value, treatNanAs );
 	}
 
 	public static int compare(Double number, BigDecimal value, OptionalInt treatNanAs) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
@@ -133,16 +133,22 @@ import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.Min
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForShort;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForBigInteger;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForByte;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForDouble;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForFloat;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForLong;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForNumber;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForShort;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForBigInteger;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForByte;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForDouble;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForFloat;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForLong;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForNumber;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForShort;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForBigInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.sign.NegativeOrZeroValidatorForByte;
@@ -337,20 +343,26 @@ public class ConstraintHelper {
 			putConstraints( tmpConstraints, DecimalMax.class,  Arrays.asList(
 					DecimalMaxValidatorForBigDecimal.class,
 					DecimalMaxValidatorForBigInteger.class,
+					DecimalMaxValidatorForByte.class,
 					DecimalMaxValidatorForDouble.class,
 					DecimalMaxValidatorForFloat.class,
 					DecimalMaxValidatorForLong.class,
+					DecimalMaxValidatorForInteger.class,
 					DecimalMaxValidatorForNumber.class,
+					DecimalMaxValidatorForShort.class,
 					DecimalMaxValidatorForCharSequence.class,
 					DecimalMaxValidatorForMonetaryAmount.class
 			) );
 			putConstraints( tmpConstraints, DecimalMin.class, Arrays.asList(
 					DecimalMinValidatorForBigDecimal.class,
 					DecimalMinValidatorForBigInteger.class,
+					DecimalMinValidatorForByte.class,
 					DecimalMinValidatorForDouble.class,
 					DecimalMinValidatorForFloat.class,
 					DecimalMinValidatorForLong.class,
+					DecimalMinValidatorForInteger.class,
 					DecimalMinValidatorForNumber.class,
+					DecimalMinValidatorForShort.class,
 					DecimalMinValidatorForCharSequence.class,
 					DecimalMinValidatorForMonetaryAmount.class
 			) );
@@ -359,19 +371,25 @@ public class ConstraintHelper {
 			putConstraints( tmpConstraints, DecimalMax.class, Arrays.asList(
 					DecimalMaxValidatorForBigDecimal.class,
 					DecimalMaxValidatorForBigInteger.class,
+					DecimalMaxValidatorForByte.class,
 					DecimalMaxValidatorForDouble.class,
 					DecimalMaxValidatorForFloat.class,
 					DecimalMaxValidatorForLong.class,
+					DecimalMaxValidatorForInteger.class,
 					DecimalMaxValidatorForNumber.class,
+					DecimalMaxValidatorForShort.class,
 					DecimalMaxValidatorForCharSequence.class
 			) );
 			putConstraints( tmpConstraints, DecimalMin.class, Arrays.asList(
 					DecimalMinValidatorForBigDecimal.class,
 					DecimalMinValidatorForBigInteger.class,
+					DecimalMinValidatorForByte.class,
 					DecimalMinValidatorForDouble.class,
 					DecimalMinValidatorForFloat.class,
 					DecimalMinValidatorForLong.class,
+					DecimalMinValidatorForInteger.class,
 					DecimalMinValidatorForNumber.class,
+					DecimalMinValidatorForShort.class,
 					DecimalMinValidatorForCharSequence.class
 			) );
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
@@ -115,16 +115,22 @@ import org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmpt
 import org.hibernate.validator.internal.constraintvalidators.bv.notempty.NotEmptyValidatorForMap;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForBigInteger;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForByte;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForDouble;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForFloat;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForLong;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForNumber;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForShort;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForBigInteger;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForByte;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForDouble;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForFloat;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForLong;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForNumber;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForShort;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForBigInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForDouble;
@@ -427,20 +433,26 @@ public class ConstraintHelper {
 			putConstraints( tmpConstraints, Max.class, Arrays.asList(
 					MaxValidatorForBigDecimal.class,
 					MaxValidatorForBigInteger.class,
+					MaxValidatorForByte.class,
 					MaxValidatorForDouble.class,
 					MaxValidatorForFloat.class,
+					MaxValidatorForInteger.class,
 					MaxValidatorForLong.class,
 					MaxValidatorForNumber.class,
+					MaxValidatorForShort.class,
 					MaxValidatorForCharSequence.class,
 					MaxValidatorForMonetaryAmount.class
 			) );
 			putConstraints( tmpConstraints, Min.class, Arrays.asList(
 					MinValidatorForBigDecimal.class,
 					MinValidatorForBigInteger.class,
+					MinValidatorForByte.class,
 					MinValidatorForDouble.class,
 					MinValidatorForFloat.class,
+					MinValidatorForInteger.class,
 					MinValidatorForLong.class,
 					MinValidatorForNumber.class,
+					MinValidatorForShort.class,
 					MinValidatorForCharSequence.class,
 					MinValidatorForMonetaryAmount.class
 			) );
@@ -458,10 +470,13 @@ public class ConstraintHelper {
 			putConstraints( tmpConstraints, Min.class, Arrays.asList(
 					MinValidatorForBigDecimal.class,
 					MinValidatorForBigInteger.class,
+					MinValidatorForByte.class,
 					MinValidatorForDouble.class,
 					MinValidatorForFloat.class,
+					MinValidatorForInteger.class,
 					MinValidatorForLong.class,
 					MinValidatorForNumber.class,
+					MinValidatorForShort.class,
 					MinValidatorForCharSequence.class
 			) );
 		}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/BaseMinMaxValidatorForNumberTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/BaseMinMaxValidatorForNumberTest.java
@@ -75,6 +75,51 @@ public class BaseMinMaxValidatorForNumberTest {
 		assertEquals( constraint.isValid( BigInteger.valueOf( 1560000000 ), null ), !isMax );
 	}
 
+	protected void testValidatorByte(ConstraintValidator<?, Byte> constraint, boolean inclusive, boolean isMax) {
+		if ( inclusive ) {
+			assertTrue( constraint.isValid( (byte) 15, null ) );
+		}
+		else {
+			assertFalse( constraint.isValid( (byte) 15, null ) );
+		}
+
+		assertTrue( constraint.isValid( null, null ) );
+		assertEquals( constraint.isValid( (byte) 14, null ), isMax );
+		assertEquals( constraint.isValid( (byte) 16, null ), !isMax );
+		assertEquals( constraint.isValid( Byte.MIN_VALUE, null ), isMax );
+		assertEquals( constraint.isValid( Byte.MAX_VALUE, null ), !isMax );
+	}
+
+	protected void testValidatorShort(ConstraintValidator<?, Short> constraint, boolean inclusive, boolean isMax) {
+		if ( inclusive ) {
+			assertTrue( constraint.isValid( (short) 15, null ) );
+		}
+		else {
+			assertFalse( constraint.isValid( (short) 15, null ) );
+		}
+
+		assertTrue( constraint.isValid( null, null ) );
+		assertEquals( constraint.isValid( (short) 14, null ), isMax );
+		assertEquals( constraint.isValid( (short) 16, null ), !isMax );
+		assertEquals( constraint.isValid( Short.MIN_VALUE, null ), isMax );
+		assertEquals( constraint.isValid( Short.MAX_VALUE, null ), !isMax );
+	}
+
+	protected void testValidatorInteger(ConstraintValidator<?, Integer> constraint, boolean inclusive, boolean isMax) {
+		if ( inclusive ) {
+			assertTrue( constraint.isValid( 15, null ) );
+		}
+		else {
+			assertFalse( constraint.isValid( 15, null ) );
+		}
+
+		assertTrue( constraint.isValid( null, null ) );
+		assertEquals( constraint.isValid( 14, null ), isMax );
+		assertEquals( constraint.isValid( 16, null ), !isMax );
+		assertEquals( constraint.isValid( Integer.MIN_VALUE, null ), isMax );
+		assertEquals( constraint.isValid( Integer.MAX_VALUE, null ), !isMax );
+	}
+
 	protected void testValidatorLong(ConstraintValidator<?, Long> constraint, boolean inclusive, boolean isMax) {
 		if ( inclusive ) {
 			assertTrue( constraint.isValid( 15L, null ) );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/BaseMinMaxValidatorForNumberTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/BaseMinMaxValidatorForNumberTest.java
@@ -13,6 +13,7 @@ import static org.testng.Assert.assertTrue;
 import java.lang.annotation.Annotation;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+
 import javax.validation.ConstraintValidator;
 
 /**
@@ -39,6 +40,18 @@ public class BaseMinMaxValidatorForNumberTest {
 		assertEquals( constraint.isValid( b, null ), isMax );
 		assertEquals( constraint.isValid( 14.99, null ), isMax );
 		assertEquals( constraint.isValid( -14.99, null ), isMax );
+		assertEquals( constraint.isValid( 14.99F, null ), isMax );
+		assertEquals( constraint.isValid( -14.99F, null ), isMax );
+		assertEquals( constraint.isValid( 14, null ), isMax );
+		assertEquals( constraint.isValid( 16, null ), !isMax );
+		assertEquals( constraint.isValid( (short) 14, null ), isMax );
+		assertEquals( constraint.isValid( (short) 16, null ), !isMax );
+		assertEquals( constraint.isValid( BigInteger.valueOf( 14L ), null ), isMax );
+		assertEquals( constraint.isValid( BigInteger.valueOf( 16L ), null ), !isMax );
+		assertEquals( constraint.isValid( BigDecimal.valueOf( 14L ), null ), isMax );
+		assertEquals( constraint.isValid( BigDecimal.valueOf( 16L ), null ), !isMax );
+		assertEquals( constraint.isValid( new BigDecimal( "14.99" ), null ), isMax );
+		assertEquals( constraint.isValid( new BigDecimal( "15.001" ), null ), !isMax );
 		assertEquals( constraint.isValid( bWrapper, null ), !isMax );
 		assertEquals( constraint.isValid( 20, null ), !isMax );
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MaxValidatorForNumberTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MaxValidatorForNumberTest.java
@@ -17,10 +17,13 @@ import javax.validation.constraints.Max;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.AbstractMaxValidator;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForBigInteger;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForByte;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForDouble;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForFloat;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForLong;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForNumber;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MaxValidatorForShort;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.AbstractDecimalMaxValidator;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForBigInteger;
@@ -139,6 +142,18 @@ public class MaxValidatorForNumberTest extends BaseMinMaxValidatorForNumberTest 
 		constraint = new MaxValidatorForBigInteger();
 		constraint.initialize( m );
 		testValidatorBigInteger( constraint, inclusive, true );
+
+		constraint = new MaxValidatorForByte();
+		constraint.initialize( m );
+		testValidatorByte( constraint, inclusive, true );
+
+		constraint = new MaxValidatorForShort();
+		constraint.initialize( m );
+		testValidatorShort( constraint, inclusive, true );
+
+		constraint = new MaxValidatorForInteger();
+		constraint.initialize( m );
+		testValidatorInteger( constraint, inclusive, true );
 
 		constraint = new MaxValidatorForLong();
 		constraint.initialize( m );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MaxValidatorForNumberTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MaxValidatorForNumberTest.java
@@ -27,10 +27,13 @@ import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.Max
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.AbstractDecimalMaxValidator;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForBigInteger;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForByte;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForDouble;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForFloat;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForLong;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForNumber;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMaxValidatorForShort;
 import org.hibernate.validator.internal.util.annotation.ConstraintAnnotationDescriptor;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.testng.annotations.Test;
@@ -61,6 +64,17 @@ public class MaxValidatorForNumberTest extends BaseMinMaxValidatorForNumberTest 
 		DecimalMax m = descriptorBuilder.build().getAnnotation();
 
 		testDecimalMax( m, true );
+	}
+
+	@Test
+	public void testIsValidDecimalMax1() {
+		ConstraintAnnotationDescriptor.Builder<DecimalMax> descriptorBuilder = new ConstraintAnnotationDescriptor.Builder<>( DecimalMax.class );
+		descriptorBuilder.setAttribute( "value", Integer.toString( Integer.MAX_VALUE - 1 ) );
+		DecimalMax m = descriptorBuilder.build().getAnnotation();
+
+		DecimalMaxValidatorForNumber constraint = new DecimalMaxValidatorForNumber();
+		constraint.initialize( m );
+		assertFalse( constraint.isValid( Double.POSITIVE_INFINITY, null ) );
 	}
 
 	@Test(expectedExceptions = IllegalArgumentException.class)
@@ -116,6 +130,18 @@ public class MaxValidatorForNumberTest extends BaseMinMaxValidatorForNumberTest 
 		constraint = new DecimalMaxValidatorForBigInteger();
 		constraint.initialize( m );
 		testValidatorBigInteger( constraint, inclusive, true );
+
+		constraint = new DecimalMaxValidatorForByte();
+		constraint.initialize( m );
+		testValidatorByte( constraint, inclusive, true );
+
+		constraint = new DecimalMaxValidatorForShort();
+		constraint.initialize( m );
+		testValidatorShort( constraint, inclusive, true );
+
+		constraint = new DecimalMaxValidatorForInteger();
+		constraint.initialize( m );
+		testValidatorInteger( constraint, inclusive, true );
 
 		constraint = new DecimalMaxValidatorForLong();
 		constraint.initialize( m );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MinValidatorForNumberTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MinValidatorForNumberTest.java
@@ -12,10 +12,13 @@ import javax.validation.constraints.Min;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.AbstractMinValidator;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForBigInteger;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForByte;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForDouble;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForFloat;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForLong;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForNumber;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForShort;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.AbstractDecimalMinValidator;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForBigInteger;
@@ -117,6 +120,18 @@ public class MinValidatorForNumberTest extends BaseMinMaxValidatorForNumberTest 
 		constraint = new MinValidatorForBigInteger();
 		constraint.initialize( m );
 		testValidatorBigInteger( constraint, inclusive, false );
+
+		constraint = new MinValidatorForByte();
+		constraint.initialize( m );
+		testValidatorByte( constraint, inclusive, false );
+
+		constraint = new MinValidatorForShort();
+		constraint.initialize( m );
+		testValidatorShort( constraint, inclusive, false );
+
+		constraint = new MinValidatorForInteger();
+		constraint.initialize( m );
+		testValidatorInteger( constraint, inclusive, false );
 
 		constraint = new MinValidatorForLong();
 		constraint.initialize( m );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MinValidatorForNumberTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/MinValidatorForNumberTest.java
@@ -22,10 +22,13 @@ import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.Min
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.AbstractDecimalMinValidator;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForBigDecimal;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForBigInteger;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForByte;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForDouble;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForFloat;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForLong;
 import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForNumber;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.decimal.DecimalMinValidatorForShort;
 import org.hibernate.validator.internal.util.annotation.ConstraintAnnotationDescriptor;
 import org.hibernate.validator.testutil.TestForIssue;
 import org.testng.annotations.Test;
@@ -94,6 +97,18 @@ public class MinValidatorForNumberTest extends BaseMinMaxValidatorForNumberTest 
 		constraint = new DecimalMinValidatorForBigInteger();
 		constraint.initialize( m );
 		testValidatorBigInteger( constraint, inclusive, false );
+
+		constraint = new DecimalMinValidatorForByte();
+		constraint.initialize( m );
+		testValidatorByte( constraint, inclusive, false );
+
+		constraint = new DecimalMinValidatorForShort();
+		constraint.initialize( m );
+		testValidatorShort( constraint, inclusive, false );
+
+		constraint = new DecimalMinValidatorForInteger();
+		constraint.initialize( m );
+		testValidatorInteger( constraint, inclusive, false );
 
 		constraint = new DecimalMinValidatorForLong();
 		constraint.initialize( m );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/ConstraintValidatorCachingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/ConstraintValidatorCachingTest.java
@@ -41,7 +41,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import org.hibernate.validator.internal.constraintvalidators.bv.NotNullValidator;
-import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForNumber;
+import org.hibernate.validator.internal.constraintvalidators.bv.number.bound.MinValidatorForInteger;
 import org.hibernate.validator.internal.constraintvalidators.bv.size.SizeValidatorForCollection;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
 import org.hibernate.validator.testutil.TestForIssue;
@@ -78,7 +78,7 @@ public class ConstraintValidatorCachingTest {
 		constraintValidatorFactory.assertSize( 3 );
 
 		constraintValidatorFactory.assertKeyExists( SizeValidatorForCollection.class );
-		constraintValidatorFactory.assertKeyExists( MinValidatorForNumber.class );
+		constraintValidatorFactory.assertKeyExists( MinValidatorForInteger.class );
 		constraintValidatorFactory.assertKeyExists( NotNullValidator.class );
 
 		// getting a new validator from the same factory should have the same instances cached


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1701

- Add specific validators for min/max constraints and byte/short/integer types as the existing common number one makes additional actions that can be omitted in this case.
- Make checks in Number validator for DecimalMin/DecimalMax to check for double/float to capture infinity situation correctly. Also direct a check of Big* types to corresponding methods
- Add specific validators for DecimalMin/DecimalMax constraints and byte/short/integer types as the existing common number one makes additional actions that can be omitted in this case.


So it got me thinking about the DecimalMin/max as there's the same situation with Number validator. Hence I've made similar changes for that validator hierarchy as well.  