### PR TITLE
HV-1680 Avoid reflection by using instrumentation - build the enhancer

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -157,6 +157,11 @@
             <artifactId>jackson-annotations</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/engine/src/main/java/org/hibernate/validator/engine/HibernateValidatorEnhancedBean.java
+++ b/engine/src/main/java/org/hibernate/validator/engine/HibernateValidatorEnhancedBean.java
@@ -8,8 +8,8 @@ package org.hibernate.validator.engine;
 
 /**
  * Hibernate Validator specific marker interface. Beans implementing this interface
- * would use corresponding {@link HibernateValidatorEnhancedBean#getFieldValue(String)}
- * and {@link HibernateValidatorEnhancedBean#getGetterValue(String)} methods to retrieve
+ * would use corresponding {@link HibernateValidatorEnhancedBean#$$_hibernateValidator_getFieldValue(String)}
+ * and {@link HibernateValidatorEnhancedBean#$$_hibernateValidator_getGetterValue(String)} methods to retrieve
  * bean property values instead of using reflection or any other means.
  * <p>
  * It is important to keep in mind that in case of explicit implementation of this interface
@@ -21,6 +21,11 @@ package org.hibernate.validator.engine;
  * @since 6.1
  */
 public interface HibernateValidatorEnhancedBean {
+
+	String GET_FIELD_VALUE_METHOD_NAME = "$$_hibernateValidator_getFieldValue";
+
+	String GET_GETTER_VALUE_METHOD_NAME = "$$_hibernateValidator_getGetterValue";
+
 	/**
 	 * @param name the name of a field property of interest.
 	 *
@@ -28,7 +33,7 @@ public interface HibernateValidatorEnhancedBean {
 	 *
 	 * @throws IllegalArgumentException in case no field could be found for the given name.
 	 */
-	Object getFieldValue(String name);
+	Object $$_hibernateValidator_getFieldValue(String name);
 
 	/**
 	 * @param name the name of a getter of interest.
@@ -37,5 +42,5 @@ public interface HibernateValidatorEnhancedBean {
 	 *
 	 * @throws IllegalArgumentException in case when no getter property could be found for the given name.
 	 */
-	Object getGetterValue(String name);
+	Object $$_hibernateValidator_getGetterValue(String name);
 }

--- a/engine/src/main/java/org/hibernate/validator/engine/HibernateValidatorEnhancedBean.java
+++ b/engine/src/main/java/org/hibernate/validator/engine/HibernateValidatorEnhancedBean.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.engine;
 
+import org.hibernate.validator.Incubating;
+
 /**
  * Hibernate Validator specific marker interface. Beans implementing this interface
  * would use corresponding {@link HibernateValidatorEnhancedBean#$$_hibernateValidator_getFieldValue(String)}
@@ -20,6 +22,7 @@ package org.hibernate.validator.engine;
  * @author Marko Bekhta
  * @since 6.1
  */
+@Incubating
 public interface HibernateValidatorEnhancedBean {
 
 	String GET_FIELD_VALUE_METHOD_NAME = "$$_hibernateValidator_getFieldValue";

--- a/engine/src/main/java/org/hibernate/validator/engine/HibernateValidatorEnhancedBean.java
+++ b/engine/src/main/java/org/hibernate/validator/engine/HibernateValidatorEnhancedBean.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.engine;
+
+/**
+ * Hibernate Validator specific marker interface. Beans implementing this interface
+ * would use corresponding {@link HibernateValidatorEnhancedBean#getFieldValue(String)}
+ * and {@link HibernateValidatorEnhancedBean#getGetterValue(String)} methods to retrieve
+ * bean property values instead of using reflection or any other means.
+ * <p>
+ * It is important to keep in mind that in case of explicit implementation of this interface
+ * access to all possible constrained getters and fields should be provided, for a class implementing
+ * the interface and all its super classes as well. Otherwise unexpected {@link IllegalArgumentException}
+ * could be thrown by the Hibernate Validator engine.
+ *
+ * @author Marko Bekhta
+ * @since 6.1
+ */
+public interface HibernateValidatorEnhancedBean {
+	/**
+	 * @param name the name of a field property of interest.
+	 *
+	 * @return the value of the field named {@code name} of the current bean.
+	 *
+	 * @throws IllegalArgumentException in case no field could be found for the given name.
+	 */
+	Object getFieldValue(String name);
+
+	/**
+	 * @param name the name of a getter of interest.
+	 *
+	 * @return the value returned by the getter named {@code name} of the current bean.
+	 *
+	 * @throws IllegalArgumentException in case when no getter property could be found for the given name.
+	 */
+	Object getGetterValue(String name);
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanField.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanField.java
@@ -148,7 +148,7 @@ public class JavaBeanField implements org.hibernate.validator.internal.propertie
 		@Override
 		public Object getValueFrom(Object bean) {
 			// we don't do an instanceof check here as it should already be applied when the accessor was created.
-			return ( (HibernateValidatorEnhancedBean) bean ).getFieldValue( name );
+			return ( (HibernateValidatorEnhancedBean) bean ).$$_hibernateValidator_getFieldValue( name );
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanGetter.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanGetter.java
@@ -129,7 +129,7 @@ public class JavaBeanGetter extends JavaBeanMethod implements Getter {
 		@Override
 		public Object getValueFrom(Object bean) {
 			// we don't do an instanceof check here as it should already be applied when the accessor was created.
-			return ( (HibernateValidatorEnhancedBean) bean ).getGetterValue( getterFullName );
+			return ( (HibernateValidatorEnhancedBean) bean ).$$_hibernateValidator_getGetterValue( getterFullName );
 		}
 	}
 	private static class GetterAccessor implements PropertyAccessor {

--- a/engine/src/main/java/org/hibernate/validator/internal/util/TypeHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/TypeHelper.java
@@ -40,6 +40,7 @@ import java.util.Set;
 
 import javax.validation.ConstraintValidator;
 
+import org.hibernate.validator.engine.HibernateValidatorEnhancedBean;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -75,6 +76,10 @@ public final class TypeHelper {
 
 	private TypeHelper() {
 		throw new AssertionError();
+	}
+
+	public static boolean isHibernateValidatorEnhancedBean(Class<?> clazz) {
+		return HibernateValidatorEnhancedBean.class.isAssignableFrom( clazz );
 	}
 
 	public static boolean isAssignable(Type supertype, Type type) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/EnhancedBeanAccessorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/EnhancedBeanAccessorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validator;
+import javax.validation.constraints.AssertTrue;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
+
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.engine.HibernateValidatorEnhancedBean;
+import org.hibernate.validator.testutil.TestForIssue;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+@TestForIssue(jiraKey = "HV-1680")
+public class EnhancedBeanAccessorTest {
+	@Test
+	public void testValidatePropertyWithRedefinedDefaultGroupOnMainEntity() {
+		Validator validator = getValidator();
+		Foo foo = new Foo();
+
+		Set<ConstraintViolation<Foo>> constraintViolations = validator.validate( foo );
+
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( Pattern.class ).withProperty( "string" ),
+				violationOf( Positive.class ).withProperty( "num" ),
+				violationOf( Min.class ).withProperty( "looooong" ),
+				violationOf( Length.class ).withProperty( "message" ),
+				violationOf( AssertTrue.class ).withProperty( "key" )
+		);
+	}
+
+	private static class Foo implements HibernateValidatorEnhancedBean {
+		@Pattern(regexp = "[A-Z]")
+		private String string;
+		@Positive
+		private Integer num;
+		@Min(100_000L)
+		private long looooong;
+
+		public Foo() {
+			this( "test", -1, 100L );
+		}
+
+		public Foo(final String string, final Integer num, final long looooong) {
+			this.string = string;
+			this.num = num;
+			this.looooong = looooong;
+		}
+
+		@Length(min = 100)
+		public String getMessage() {
+			return "messssssage";
+		}
+
+		@AssertTrue
+		public boolean getKey() {
+			return false;
+		}
+
+		@Override
+		public Object getFieldValue(String name) {
+			if ( "string".equals( name ) ) {
+				return string;
+			}
+			if ( "num".equals( name ) ) {
+				return num;
+			}
+			if ( "looooong".equals( name ) ) {
+				return looooong;
+			}
+			throw new IllegalArgumentException( "No such property as '" + name + "'" );
+		}
+
+		@Override
+		public Object getGetterValue(String name) {
+			if ( "getKey".equals( name ) ) {
+				return getKey();
+			}
+			if ( "getMessage".equals( name ) ) {
+				return getMessage();
+			}
+			throw new IllegalArgumentException( "No such property as '" + name + "'" );
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/EnhancedBeanAccessorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/EnhancedBeanAccessorTest.java
@@ -10,12 +10,15 @@ import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertT
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validator;
 import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Positive;
 
@@ -33,7 +36,7 @@ public class EnhancedBeanAccessorTest {
 	@Test
 	public void testValidatePropertyWithRedefinedDefaultGroupOnMainEntity() {
 		Validator validator = getValidator();
-		Foo foo = new Foo();
+		Foo foo = new Bar();
 
 		Set<ConstraintViolation<Foo>> constraintViolations = validator.validate( foo );
 
@@ -42,8 +45,26 @@ public class EnhancedBeanAccessorTest {
 				violationOf( Positive.class ).withProperty( "num" ),
 				violationOf( Min.class ).withProperty( "looooong" ),
 				violationOf( Length.class ).withProperty( "message" ),
-				violationOf( AssertTrue.class ).withProperty( "key" )
+				violationOf( AssertTrue.class ).withProperty( "key" ),
+				violationOf( NotEmpty.class ).withProperty( "strings" )
 		);
+	}
+
+	private static class Bar extends Foo implements HibernateValidatorEnhancedBean {
+		@NotEmpty
+		private final List<String> strings;
+
+		private Bar() {
+			this.strings = Collections.emptyList();
+		}
+
+		@Override
+		public Object getFieldValue(String name) {
+			if ( "strings".equals( name ) ) {
+				return strings;
+			}
+			return super.getFieldValue( name );
+		}
 	}
 
 	private static class Foo implements HibernateValidatorEnhancedBean {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/EnhancedBeanAccessorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/EnhancedBeanAccessorTest.java
@@ -59,11 +59,11 @@ public class EnhancedBeanAccessorTest {
 		}
 
 		@Override
-		public Object getFieldValue(String name) {
+		public Object $$_hibernateValidator_getFieldValue(String name) {
 			if ( "strings".equals( name ) ) {
 				return strings;
 			}
-			return super.getFieldValue( name );
+			return super.$$_hibernateValidator_getFieldValue( name );
 		}
 	}
 
@@ -96,7 +96,7 @@ public class EnhancedBeanAccessorTest {
 		}
 
 		@Override
-		public Object getFieldValue(String name) {
+		public Object $$_hibernateValidator_getFieldValue(String name) {
 			if ( "string".equals( name ) ) {
 				return string;
 			}
@@ -110,7 +110,7 @@ public class EnhancedBeanAccessorTest {
 		}
 
 		@Override
-		public Object getGetterValue(String name) {
+		public Object $$_hibernateValidator_getGetterValue(String name) {
 			if ( "getKey".equals( name ) ) {
 				return getKey();
 			}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/bytebuddy/ByteBuddyWrapperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/bytebuddy/ByteBuddyWrapperTest.java
@@ -40,7 +40,6 @@ import org.testng.annotations.Test;
  */
 public class ByteBuddyWrapperTest {
 
-
 	@Test
 	public void testByteBuddy() throws Exception {
 		Class<?> clazz = Foo.class;
@@ -53,13 +52,13 @@ public class ByteBuddyWrapperTest {
 		Class<?> aClass = new ByteBuddy().rebase( clazz )
 				.implement( HibernateValidatorEnhancedBean.class )
 				.method(
-						named( "getFieldValue" )
+						named( HibernateValidatorEnhancedBean.GET_FIELD_VALUE_METHOD_NAME )
 								.and( ElementMatchers.takesArguments( String.class ) )
 								.and( ElementMatchers.returns( Object.class ) )
 				)
 				.intercept( new Implementation.Simple( new GetFieldValue( clazz ) ) )
 				.method(
-						named( "getGetterValue" )
+						named( HibernateValidatorEnhancedBean.GET_GETTER_VALUE_METHOD_NAME )
 								.and( ElementMatchers.takesArguments( String.class ) )
 								.and( ElementMatchers.returns( Object.class ) )
 				)
@@ -70,13 +69,13 @@ public class ByteBuddyWrapperTest {
 
 		Object object = aClass.newInstance();
 
-		Method getFieldValue = aClass.getMethod( "getFieldValue", String.class );
+		Method getFieldValue = aClass.getMethod( HibernateValidatorEnhancedBean.GET_FIELD_VALUE_METHOD_NAME, String.class );
 
 		assertThat( getFieldValue.invoke( object, "num" ) ).isEqualTo( -1 );
 		assertThat( getFieldValue.invoke( object, "string" ) ).isEqualTo( "test" );
 		assertThat( getFieldValue.invoke( object, "looooong" ) ).isEqualTo( 100L );
 
-		Method getGetterValue = aClass.getMethod( "getGetterValue", String.class );
+		Method getGetterValue = aClass.getMethod( HibernateValidatorEnhancedBean.GET_GETTER_VALUE_METHOD_NAME, String.class );
 
 		assertThat( getGetterValue.invoke( object, "getMessage" ) ).isEqualTo( "messssssage" );
 		assertThat( getGetterValue.invoke( object, "getKey" ) ).isEqualTo( false );
@@ -84,10 +83,12 @@ public class ByteBuddyWrapperTest {
 
 	private static class GetFieldValue implements ByteCodeAppender {
 
+		@SuppressWarnings("rawtypes")
 		private final Class clazz;
 
 		private final Field[] fields;
 
+		@SuppressWarnings("rawtypes")
 		public GetFieldValue(Class clazz) {
 			this.clazz = clazz;
 			this.fields = clazz.getDeclaredFields();
@@ -204,10 +205,12 @@ public class ByteBuddyWrapperTest {
 
 	private static class GetGetterValue implements ByteCodeAppender {
 
+		@SuppressWarnings("rawtypes")
 		private final Class clazz;
 
 		private final Method[] methods;
 
+		@SuppressWarnings("rawtypes")
 		public GetGetterValue(Class clazz) {
 			this.clazz = clazz;
 			this.methods = clazz.getDeclaredMethods();
@@ -324,6 +327,7 @@ public class ByteBuddyWrapperTest {
 	}
 
 
+	@SuppressWarnings("unused")
 	public static class Foo {
 		private String string;
 		private Integer num;
@@ -348,7 +352,7 @@ public class ByteBuddyWrapperTest {
 		}
 	}
 
-
+	@SuppressWarnings("unused")
 	public static class Bar extends Foo {
 		private final List<String> strings;
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/bytebuddy/ByteBuddyWrapperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/bytebuddy/ByteBuddyWrapperTest.java
@@ -36,6 +36,10 @@ import net.bytebuddy.matcher.ElementMatchers;
 import org.testng.annotations.Test;
 
 /**
+ * Note that this implementation is not complete and is only for testing purposes.
+ * <p>
+ * It typically doesn't implement the support for instrumented parent classes.
+ *
  * @author Marko Bekhta
  */
 public class ByteBuddyWrapperTest {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/bytebuddy/ByteBuddyWrapperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/bytebuddy/ByteBuddyWrapperTest.java
@@ -1,0 +1,369 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.metadata.bytebuddy;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.List;
+
+import org.hibernate.validator.engine.HibernateValidatorEnhancedBean;
+import org.hibernate.validator.internal.util.StringHelper;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.loading.ByteArrayClassLoader;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.implementation.bytecode.ByteCodeAppender;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
+import net.bytebuddy.implementation.bytecode.assign.primitive.PrimitiveBoxingDelegate;
+import net.bytebuddy.implementation.bytecode.assign.reference.ReferenceTypeAwareAssigner;
+import net.bytebuddy.jar.asm.Label;
+import net.bytebuddy.jar.asm.MethodVisitor;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.jar.asm.Type;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+public class ByteBuddyWrapperTest {
+
+
+	@Test
+	public void testByteBuddy() throws Exception {
+		Class<?> clazz = Foo.class;
+
+		ClassLoader classLoader = new ByteArrayClassLoader(
+				ClassLoadingStrategy.BOOTSTRAP_LOADER,
+				ClassFileLocator.ForClassLoader.readToNames( Foo.class, HibernateValidatorEnhancedBean.class,
+						MyContracts.class, StringHelper.class ) );
+
+		Class<?> aClass = new ByteBuddy().rebase( clazz )
+				.implement( HibernateValidatorEnhancedBean.class )
+				.method(
+						named( "getFieldValue" )
+								.and( ElementMatchers.takesArguments( String.class ) )
+								.and( ElementMatchers.returns( Object.class ) )
+				)
+				.intercept( new Implementation.Simple( new GetFieldValue( clazz ) ) )
+				.method(
+						named( "getGetterValue" )
+								.and( ElementMatchers.takesArguments( String.class ) )
+								.and( ElementMatchers.returns( Object.class ) )
+				)
+				.intercept( new Implementation.Simple( new GetGetterValue( clazz ) ) )
+				.make()
+				.load( classLoader, ClassLoadingStrategy.Default.INJECTION )
+				.getLoaded();
+
+		Object object = aClass.newInstance();
+
+		Method getFieldValue = aClass.getMethod( "getFieldValue", String.class );
+
+		assertThat( getFieldValue.invoke( object, "num" ) ).isEqualTo( -1 );
+		assertThat( getFieldValue.invoke( object, "string" ) ).isEqualTo( "test" );
+		assertThat( getFieldValue.invoke( object, "looooong" ) ).isEqualTo( 100L );
+
+		Method getGetterValue = aClass.getMethod( "getGetterValue", String.class );
+
+		assertThat( getGetterValue.invoke( object, "getMessage" ) ).isEqualTo( "messssssage" );
+		assertThat( getGetterValue.invoke( object, "getKey" ) ).isEqualTo( false );
+	}
+
+	private static class GetFieldValue implements ByteCodeAppender {
+
+		private final Class clazz;
+
+		private final Field[] fields;
+
+		public GetFieldValue(Class clazz) {
+			this.clazz = clazz;
+			this.fields = clazz.getDeclaredFields();
+		}
+
+		@Override
+		public Size apply(MethodVisitor methodVisitor, Implementation.Context implementationContext, MethodDescription instrumentedMethod) {
+			try {
+				// Contracts.assertNotEmpty(propertyName, "Property cannot be blank");
+				Label contractsPropertyNameCheckLabel = new Label();
+				methodVisitor.visitLabel( contractsPropertyNameCheckLabel );
+				methodVisitor.visitVarInsn( Opcodes.ALOAD, 1 );
+				methodVisitor.visitLdcInsn( "Property cannot be blank" );
+				methodVisitor.visitMethodInsn(
+						Opcodes.INVOKESTATIC,
+						Type.getType( MyContracts.class ).getInternalName(),
+						"assertNotEmpty",
+						Type.getType( MyContracts.class.getDeclaredMethod( "assertNotEmpty", String.class, String.class ) ).getDescriptor(),
+						false
+				);
+
+				Label l1 = new Label();
+				methodVisitor.visitLabel( l1 );
+				int index = 0;
+				for ( Field field : fields ) {
+					String fieldName = field.getName();
+
+					if ( index > 0 ) {
+						methodVisitor.visitFrame( Opcodes.F_SAME, 0, null, 0, null );
+					}
+
+					//		if (propertyName.equals(field_name_goes_here)) {
+					//			return field;
+					//		}
+					methodVisitor.visitVarInsn( Opcodes.ALOAD, 1 );
+					methodVisitor.visitLdcInsn( fieldName );
+					methodVisitor.visitMethodInsn(
+							Opcodes.INVOKEVIRTUAL,
+							Type.getType( String.class ).getInternalName(),
+							"equals",
+							Type.getType( String.class.getDeclaredMethod( "equals", Object.class ) ).getDescriptor(),
+							false
+					);
+
+					Label ifCheckLabel = new Label();
+					methodVisitor.visitJumpInsn( Opcodes.IFEQ, ifCheckLabel );
+
+					Label returnFieldLabel = new Label();
+					methodVisitor.visitLabel( returnFieldLabel );
+					methodVisitor.visitVarInsn( Opcodes.ALOAD, 0 );
+					methodVisitor.visitFieldInsn(
+							Opcodes.GETFIELD,
+							Type.getInternalName( clazz ),
+							fieldName,
+							Type.getDescriptor( field.getType() )
+					);
+					if ( field.getType().isPrimitive() ) {
+						PrimitiveBoxingDelegate.forPrimitive( new TypeDescription.ForLoadedType( field.getType() ) )
+								.assignBoxedTo(
+										TypeDescription.Generic.OBJECT,
+										ReferenceTypeAwareAssigner.INSTANCE,
+										Assigner.Typing.STATIC
+								)
+								.apply( methodVisitor, implementationContext );
+					}
+					methodVisitor.visitInsn( Opcodes.ARETURN );
+					methodVisitor.visitLabel( ifCheckLabel );
+
+					index++;
+				}
+
+				// throw new IllegalArgumentException("No property was found for a given name");
+
+				methodVisitor.visitFrame( Opcodes.F_SAME, 0, null, 0, null );
+				methodVisitor.visitTypeInsn( Opcodes.NEW, Type.getInternalName( IllegalArgumentException.class ) );
+				methodVisitor.visitInsn( Opcodes.DUP );
+				methodVisitor.visitLdcInsn( "No property was found for a given name" );
+				methodVisitor.visitMethodInsn(
+						Opcodes.INVOKESPECIAL,
+						Type.getInternalName( IllegalArgumentException.class ),
+						"<init>",
+						Type.getType( IllegalArgumentException.class.getDeclaredConstructor( String.class ) ).getDescriptor(),
+						false
+				);
+				methodVisitor.visitInsn( Opcodes.ATHROW );
+
+				Label label = new Label();
+				methodVisitor.visitLabel( label );
+				methodVisitor.visitLocalVariable(
+						"this",
+						Type.getDescriptor( clazz ),
+						null,
+						contractsPropertyNameCheckLabel,
+						label,
+						0
+				);
+				methodVisitor.visitLocalVariable(
+						"name",
+						Type.getDescriptor( String.class ),
+						null,
+						contractsPropertyNameCheckLabel,
+						label,
+						1
+				);
+				methodVisitor.visitMaxs( 3, 2 );
+
+				return new Size( 6, instrumentedMethod.getStackSize() );
+			}
+			catch (NoSuchMethodException e) {
+				throw new IllegalArgumentException( e );
+			}
+		}
+	}
+
+	private static class GetGetterValue implements ByteCodeAppender {
+
+		private final Class clazz;
+
+		private final Method[] methods;
+
+		public GetGetterValue(Class clazz) {
+			this.clazz = clazz;
+			this.methods = clazz.getDeclaredMethods();
+		}
+
+		@Override
+		public Size apply(MethodVisitor methodVisitor, Implementation.Context implementationContext, MethodDescription instrumentedMethod) {
+			try {
+				// Contracts.assertNotEmpty(propertyName, "Property cannot be blank");
+				Label contractsPropertyNameCheckLabel = new Label();
+				methodVisitor.visitLabel( contractsPropertyNameCheckLabel );
+				methodVisitor.visitVarInsn( Opcodes.ALOAD, 1 );
+				methodVisitor.visitLdcInsn( "Property cannot be blank" );
+				methodVisitor.visitMethodInsn(
+						Opcodes.INVOKESTATIC,
+						Type.getType( MyContracts.class ).getInternalName(),
+						"assertNotEmpty",
+						Type.getType( MyContracts.class.getDeclaredMethod( "assertNotEmpty", String.class, String.class ) ).getDescriptor(),
+						false
+				);
+
+				Label l1 = new Label();
+				methodVisitor.visitLabel( l1 );
+				int index = 0;
+				for ( Method method : methods ) {
+					String fieldName = method.getName();
+
+					if ( index > 0 ) {
+						methodVisitor.visitFrame( Opcodes.F_SAME, 0, null, 0, null );
+					}
+
+					//		if (propertyName.equals(field_name_goes_here)) {
+					//			return field;
+					//		}
+					methodVisitor.visitVarInsn( Opcodes.ALOAD, 1 );
+					methodVisitor.visitLdcInsn( fieldName );
+					methodVisitor.visitMethodInsn(
+							Opcodes.INVOKEVIRTUAL,
+							Type.getType( String.class ).getInternalName(),
+							"equals",
+							Type.getType( String.class.getDeclaredMethod( "equals", Object.class ) ).getDescriptor(),
+							false
+					);
+
+					Label ifCheckLabel = new Label();
+					methodVisitor.visitJumpInsn( Opcodes.IFEQ, ifCheckLabel );
+
+					Label returnFieldLabel = new Label();
+					methodVisitor.visitLabel( returnFieldLabel );
+					methodVisitor.visitVarInsn( Opcodes.ALOAD, 0 );
+					methodVisitor.visitMethodInsn(
+							Opcodes.INVOKEVIRTUAL,
+							Type.getInternalName( clazz ),
+							method.getName(),
+							Type.getMethodDescriptor( method ),
+							method.getDeclaringClass().isInterface()
+					);
+					if ( method.getReturnType().isPrimitive() ) {
+						PrimitiveBoxingDelegate.forPrimitive( new TypeDescription.ForLoadedType( method.getReturnType() ) )
+								.assignBoxedTo(
+										TypeDescription.Generic.OBJECT,
+										ReferenceTypeAwareAssigner.INSTANCE,
+										Assigner.Typing.STATIC
+								)
+								.apply( methodVisitor, implementationContext );
+					}
+					methodVisitor.visitInsn( Opcodes.ARETURN );
+					methodVisitor.visitLabel( ifCheckLabel );
+
+					index++;
+				}
+
+				// throw new IllegalArgumentException("No property was found for a given name");
+
+				methodVisitor.visitFrame( Opcodes.F_SAME, 0, null, 0, null );
+				methodVisitor.visitTypeInsn( Opcodes.NEW, Type.getInternalName( IllegalArgumentException.class ) );
+				methodVisitor.visitInsn( Opcodes.DUP );
+				methodVisitor.visitLdcInsn( "No property was found for a given name" );
+				methodVisitor.visitMethodInsn(
+						Opcodes.INVOKESPECIAL,
+						Type.getInternalName( IllegalArgumentException.class ),
+						"<init>",
+						Type.getType( IllegalArgumentException.class.getDeclaredConstructor( String.class ) ).getDescriptor(),
+						false
+				);
+				methodVisitor.visitInsn( Opcodes.ATHROW );
+
+				Label label = new Label();
+				methodVisitor.visitLabel( label );
+				methodVisitor.visitLocalVariable(
+						"this",
+						Type.getDescriptor( clazz ),
+						null,
+						contractsPropertyNameCheckLabel,
+						label,
+						0
+				);
+				methodVisitor.visitLocalVariable(
+						"name",
+						Type.getDescriptor( String.class ),
+						null,
+						contractsPropertyNameCheckLabel,
+						label,
+						1
+				);
+				methodVisitor.visitMaxs( 3, 2 );
+
+				return new Size( 6, instrumentedMethod.getStackSize() );
+			}
+			catch (NoSuchMethodException e) {
+				throw new IllegalArgumentException( e );
+			}
+		}
+	}
+
+
+	public static class Foo {
+		private String string;
+		private Integer num;
+		private long looooong;
+
+		public Foo() {
+			this( "test", -1 );
+			this.looooong = 100L;
+		}
+
+		public Foo(String string, Integer num) {
+			this.string = string;
+			this.num = num;
+		}
+
+		public String getMessage() {
+			return "messssssage";
+		}
+
+		public boolean getKey() {
+			return false;
+		}
+	}
+
+
+	public static class Bar extends Foo {
+		private final List<String> strings;
+
+		public Bar() {
+			super();
+			this.strings = Collections.emptyList();
+		}
+	}
+
+	public static final class MyContracts {
+		public static void assertNotEmpty(String s, String message) {
+			if ( StringHelper.isNullOrEmptyString( s ) ) {
+				throw new IllegalArgumentException( message );
+			}
+		}
+	}
+
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
@@ -40,9 +40,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.hibernate.validator.engine.HibernateValidatorEnhancedBean;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 import org.hibernate.validator.internal.util.TypeHelper;
 import org.hibernate.validator.testutil.TestForIssue;
+
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -873,6 +875,25 @@ public class TypeHelperTest {
 		ParameterizedType childEntityType = TypeHelper.parameterizedType( ChildEntity.class, ChildEntity.class.getTypeParameters() );
 
 		assertTrue( TypeHelper.isAssignable( parentEntityType, childEntityType ) );
+	}
+
+	@Test
+	public void testIsHibernateValidatorEnhancedBean() {
+		class Foo {
+		}
+		class Bar implements HibernateValidatorEnhancedBean {
+			@Override
+			public Object getFieldValue(String name) {
+				return null;
+			}
+
+			@Override
+			public Object getGetterValue(String name) {
+				return null;
+			}
+		}
+		assertTrue( TypeHelper.isHibernateValidatorEnhancedBean( Bar.class ) );
+		assertFalse( TypeHelper.isHibernateValidatorEnhancedBean( Foo.class ) );
 	}
 
 	private static void assertAsymmetricallyAssignable(Type supertype, Type type) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/TypeHelperTest.java
@@ -883,12 +883,12 @@ public class TypeHelperTest {
 		}
 		class Bar implements HibernateValidatorEnhancedBean {
 			@Override
-			public Object getFieldValue(String name) {
+			public Object $$_hibernateValidator_getFieldValue(String name) {
 				return null;
 			}
 
 			@Override
-			public Object getGetterValue(String name) {
+			public Object $$_hibernateValidator_getGetterValue(String name) {
 				return null;
 			}
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
         <!-- JavaMoney dependencies -->
         <version.javax.money>1.0.1</version.javax.money>
         <version.org.javamoney.moneta>1.1</version.org.javamoney.moneta>
+
         <!-- Used in the Karaf features file: it is a dependency of Moneta, and for the documentation -->
         <version.javax.annotation>1.2</version.javax.annotation>
 
@@ -172,6 +173,7 @@
         <version.org.jboss.arquillian.container.arquillian-weld-se-embedded-1.1>1.0.0.Final</version.org.jboss.arquillian.container.arquillian-weld-se-embedded-1.1>
         <version.com.fasterxml.jackson.core.jackson-databind>2.9.9.2</version.com.fasterxml.jackson.core.jackson-databind>
         <version.com.fasterxml.jackson.core.jackson-annotations>2.9.9</version.com.fasterxml.jackson.core.jackson-annotations>
+        <version.net.bytebuddy.byte-buddy>1.10.1</version.net.bytebuddy.byte-buddy>
 
         <!-- OSGi dependencies -->
         <version.org.apache.karaf>4.2.0</version.org.apache.karaf>
@@ -362,6 +364,11 @@
                 <groupId>org.javamoney</groupId>
                 <artifactId>moneta</artifactId>
                 <version>${version.org.javamoney.moneta}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${version.net.bytebuddy.byte-buddy}</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1680

First commit just adds the interface and uses that interface when possible to get the values from the beans.
Second one adds a test with byte-buddy instrumentation. There are two cases one when the beans super class is object and the other one when it's a sublass of an enhanced bean. The difference is should we throw an exception when we reached the end of a method or call super method.

I'm also thinking that it might be a good idea to add another pair of methods to the interface which would give the list of "supported" properties (fields/getters). Having them in place would help us decide if we can use the enhanced bean interface or if we should fallback to regular reflection access for a particular property.

And a quick benchmark that I've put together :
```bash
Benchmark                                           Mode  Cnt    Score    Error   Units
NotSoSimpleValidation.testSimpleBeanValidationBar  thrpt   20  325.398 ±  4.597  ops/ms
NotSoSimpleValidation.testSimpleBeanValidationFoo  thrpt   20  357.233 ± 79.813  ops/ms
```
`Bar` is regular bean, `Foo` is enhanced one.