### PR TITLE
HV-823 Provide contract for customization of property names in constraint violation

### DIFF
--- a/copyright.txt
+++ b/copyright.txt
@@ -11,6 +11,7 @@ Carlo de Wolf
 Chris Beckey
 Christian Ivan
 Dag Hovland
+Damir Alibegovic
 Davide D'Alto
 Davide Marchignoli
 Denis Tiago

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -103,6 +103,16 @@
             <artifactId>javax.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/documentation/src/main/asciidoc/ch12.asciidoc
+++ b/documentation/src/main/asciidoc/ch12.asciidoc
@@ -51,6 +51,9 @@ Note that when a package is part of the public API this is not necessarily true 
 `org.hibernate.validator.spi.constraintdefinition`::
 			An SPI for registering additional constraint validators programmatically, see <<section-constraint-definition-contribution>>.
 
+`org.hibernate.validator.spi.nodenameprovider`::
+			An SPI that can be used to alter how the names of properties will be resolved when the property path is constructed. See <<section-property-node-name-provider>>.
+
 [NOTE]
 ====
 The public packages of Hibernate Validator fall into two categories: while the actual API parts are
@@ -760,3 +763,93 @@ It is important to mention that in cases where programmatic constraints are adde
 always be done after the required getter property selection strategy is configured.
 Otherwise, the default strategy will be used for the mappings added before defining the strategy.
 ====
+
+[[section-property-node-name-provider]]
+==== Changing the way property names are resolved when the property path is constructed
+
+Imagine that we have a simple data class that has `@NotNull` constraints on some fields:
+[[example-person-class]]
+.Person data class
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/Person.java[tags=include]
+----
+====
+
+This class can be serialized to JSON by using the https://github.com/FasterXML/jackson[Jackson] library:
+[[example-person-object-to-json]]
+.Serializing Person object to JSON
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/PersonSerializationTest.java[tags=include]
+----
+====
+
+As we can see, the object is serialized to:
+[[example-person-json]]
+.Person as json
+====
+[source, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/clarkKent.json[]
+----
+====
+
+Notice how the names of the properties differ. In the Java object, we have `firstName` and `lastName`, whereas in the JSON output, we have
+`first_name` and `last_name`. We defined this behaviour through `@JsonProperty` annotations.
+
+Now imagine, that we use this class in a REST environment, where a user can send <<example-person-json, person as json>> in the request body.
+It would be nice, when telling the user on which field the validation failed, to tell them the name they use in their JSON request, `first_name`,
+and not the name we use internally in our Java code, `firstName`.
+
+The `org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider` contract allows us to do this. By implementing it,
+we can define how the name of a property will be resolved during validation. In our case, we want to read the value from the Jackson configuration.
+
+So, one example of how to do this is to leverage the Jackson API:
+[[example-jackson-property-node-name-provider]]
+.JacksonPropertyNodeNameProvider implementation
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/JacksonPropertyNodeNameProvider.java[tags=include]
+----
+====
+
+And when doing the validation:
+[[example-jackson-property-node-name-provider-field]]
+.JacksonPropertyNodeNameProvider usage
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/JacksonPropertyNodeNameProviderTest.java[tags=field]
+----
+====
+
+We can see that the property path now returns `first_name`.
+
+Note that this also works when the annotations are on the getter:
+[[example-jackson-property-node-name-provider-getter]]
+.Annotation on a getter
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/JacksonPropertyNodeNameProviderTest.java[tags=getter]
+----
+====
+
+This is just one use case of why we would like to change how the property names are resolved.
+
+`org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider` can be implemented to provide a property name in
+whatever way you see fit (reading from annotations, for instance).
+
+There are two more interfaces that are worth mentioning:
+
+- `org.hibernate.validator.spi.nodenameprovider.Property` is a base interface that holds metadata about a property. It
+has a single `String getName()` method that can be used to get the "original" name of a property. This interface
+should be used as a default way of resolving the name (see how it is used in <<example-jackson-property-node-name-provider>>).
+
+- `org.hibernate.validator.spi.nodenameprovider.JavaBeanProperty` is an interface that holds metada about a bean property. It
+extends `org.hibernate.validator.spi.nodenameprovider.Property` and provide some more data like `Class<?> getDeclaringClass()`
+which is the class that is the owner of the property. This additional metadata can be useful when revolving the name.

--- a/documentation/src/main/asciidoc/ch12.asciidoc
+++ b/documentation/src/main/asciidoc/ch12.asciidoc
@@ -765,7 +765,7 @@ Otherwise, the default strategy will be used for the mappings added before defin
 ====
 
 [[section-property-node-name-provider]]
-==== Changing the way property names are resolved when the property path is constructed
+=== Customizing the property name resolution for constraint violations
 
 Imagine that we have a simple data class that has `@NotNull` constraints on some fields:
 [[example-person-class]]
@@ -798,16 +798,18 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/nodenamepr
 ====
 
 Notice how the names of the properties differ. In the Java object, we have `firstName` and `lastName`, whereas in the JSON output, we have
-`first_name` and `last_name`. We defined this behaviour through `@JsonProperty` annotations.
+`first_name` and `last_name`.
+We customized this behavior through `@JsonProperty` annotations.
 
-Now imagine, that we use this class in a REST environment, where a user can send <<example-person-json, person as json>> in the request body.
-It would be nice, when telling the user on which field the validation failed, to tell them the name they use in their JSON request, `first_name`,
+Now imagine that we use this class in a REST environment, where a user can send <<example-person-json, a `Person` instance as JSON>> in the request body.
+It would be nice, when indicating on which field the validation failed, to indicate the name they use in their JSON request, `first_name`,
 and not the name we use internally in our Java code, `firstName`.
 
-The `org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider` contract allows us to do this. By implementing it,
-we can define how the name of a property will be resolved during validation. In our case, we want to read the value from the Jackson configuration.
+The `org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider` contract allows us to do this.
+By implementing it, we can define how the name of a property will be resolved during validation.
+In our case, we want to read the value from the Jackson configuration.
 
-So, one example of how to do this is to leverage the Jackson API:
+One example of how to do this is to leverage the Jackson API:
 [[example-jackson-property-node-name-provider]]
 .JacksonPropertyNodeNameProvider implementation
 ====
@@ -829,7 +831,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/nodenamepr
 
 We can see that the property path now returns `first_name`.
 
-Note that this also works when the annotations are on the getter:
+Note that this also works when the annotations are on a getter:
 [[example-jackson-property-node-name-provider-getter]]
 .Annotation on a getter
 ====
@@ -850,6 +852,6 @@ There are two more interfaces that are worth mentioning:
 has a single `String getName()` method that can be used to get the "original" name of a property. This interface
 should be used as a default way of resolving the name (see how it is used in <<example-jackson-property-node-name-provider>>).
 
-- `org.hibernate.validator.spi.nodenameprovider.JavaBeanProperty` is an interface that holds metada about a bean property. It
-extends `org.hibernate.validator.spi.nodenameprovider.Property` and provide some more data like `Class<?> getDeclaringClass()`
-which is the class that is the owner of the property. This additional metadata can be useful when revolving the name.
+- `org.hibernate.validator.spi.nodenameprovider.JavaBeanProperty` is an interface that holds metadata about a bean property. It
+extends `org.hibernate.validator.spi.nodenameprovider.Property` and provide some additional methods like `Class<?> getDeclaringClass()`
+which returns the class that is the owner of the property.

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/JacksonPropertyNodeNameProvider.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/JacksonPropertyNodeNameProvider.java
@@ -1,0 +1,41 @@
+package org.hibernate.validator.referenceguide.chapter12.nodenameprovider;
+
+//tag::include[]
+import org.hibernate.validator.spi.nodenameprovider.JavaBeanProperty;
+import org.hibernate.validator.spi.nodenameprovider.Property;
+import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+
+public class JacksonPropertyNodeNameProvider implements PropertyNodeNameProvider {
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public String getName(Property property) {
+		if ( property instanceof JavaBeanProperty ) {
+			return getJavaBeanPropertyName( (JavaBeanProperty) property );
+		}
+
+		return getDefaultName( property );
+	}
+
+	private String getJavaBeanPropertyName(JavaBeanProperty property) {
+		JavaType type = objectMapper.constructType( property.getDeclaringClass() );
+		BeanDescription desc = objectMapper.getSerializationConfig().introspect( type );
+
+		return desc.findProperties()
+				.stream()
+				.filter( prop -> prop.getInternalName().equals( property.getName() ) )
+				.map( BeanPropertyDefinition::getName )
+				.findFirst()
+				.orElse( property.getName() );
+	}
+
+	private String getDefaultName(Property property) {
+		return property.getName();
+	}
+}
+//end::include[]

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/JacksonPropertyNodeNameProviderTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/JacksonPropertyNodeNameProviderTest.java
@@ -1,0 +1,74 @@
+package org.hibernate.validator.referenceguide.chapter12.nodenameprovider;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.HibernateValidator;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+//tag::field[]
+public class JacksonPropertyNodeNameProviderTest {
+	@Test
+	public void nameIsReadFromJacksonAnnotationOnField() {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.propertyNodeNameProvider( new JacksonPropertyNodeNameProvider() )
+				.buildValidatorFactory();
+
+		Validator validator = validatorFactory.getValidator();
+
+		Person clarkKent = new Person( null, "Kent" );
+
+		Set<ConstraintViolation<Person>> violations = validator.validate( clarkKent );
+		ConstraintViolation<Person> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "first_name" );
+	}
+//end::field[]
+
+//tag::getter[]
+	@Test
+	public void nameIsReadFromJacksonAnnotationOnGetter() {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.propertyNodeNameProvider( new JacksonPropertyNodeNameProvider() )
+				.buildValidatorFactory();
+
+		Validator validator = validatorFactory.getValidator();
+
+		Person clarkKent = new Person( null, "Kent" );
+
+		Set<ConstraintViolation<Person>> violations = validator.validate( clarkKent );
+		ConstraintViolation<Person> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "first_name" );
+	}
+
+	public class Person {
+		private final String firstName;
+
+		@JsonProperty("last_name")
+		private final String lastName;
+
+		public Person(String firstName, String lastName) {
+			this.firstName = firstName;
+			this.lastName = lastName;
+		}
+
+		@NotNull
+		@JsonProperty("first_name")
+		public String getFirstName() {
+			return firstName;
+		}
+	}
+//end::getter[]
+}

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/Person.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/Person.java
@@ -1,0 +1,21 @@
+package org.hibernate.validator.referenceguide.chapter12.nodenameprovider;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+//tag::include[]
+public class Person {
+	@NotNull
+	@JsonProperty("first_name")
+	private final String firstName;
+
+	@JsonProperty("last_name")
+	private final String lastName;
+
+	public Person(String firstName, String lastName) {
+		this.firstName = firstName;
+		this.lastName = lastName;
+	}
+}
+//end::include[]

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/PersonSerializationTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/PersonSerializationTest.java
@@ -1,0 +1,23 @@
+package org.hibernate.validator.referenceguide.chapter12.nodenameprovider;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+//tag::include[]
+public class PersonSerializationTest {
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Test
+	public void personIsSerialized() throws JsonProcessingException {
+		Person person = new Person( "Clark", "Kent" );
+
+		String serializedPerson = objectMapper.writeValueAsString( person );
+
+		assertEquals( "{\"first_name\":\"Clark\",\"last_name\":\"Kent\"}", serializedPerson );
+	}
+}
+//tag::include[]

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/clarkKent.json
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/nodenameprovider/clarkKent.json
@@ -1,0 +1,4 @@
+{
+  "first_name": "Clark",
+  "last_name": "Kent"
+}

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -147,6 +147,16 @@
             <artifactId>moneta</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 import java.util.Set;
 
 import javax.validation.Configuration;
+import javax.validation.ConstraintViolation;
 import javax.validation.TraversableResolver;
 import javax.validation.constraints.Future;
 import javax.validation.constraints.FutureOrPresent;
@@ -20,6 +21,7 @@ import javax.validation.valueextraction.ValueExtractor;
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.constraints.ParameterScriptAssert;
 import org.hibernate.validator.constraints.ScriptAssert;
+import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
 import org.hibernate.validator.spi.properties.GetterPropertySelectionStrategy;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
 import org.hibernate.validator.spi.scripting.ScriptEvaluator;
@@ -118,6 +120,15 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 */
 	@Incubating
 	String GETTER_PROPERTY_SELECTION_STRATEGY_CLASSNAME = "hibernate.validator.getter_property_selection_strategy";
+
+	/**
+	 * Property for configuring the property node name provider, allowing to select an implementation of {@link PropertyNodeNameProvider}
+	 * which will be used for property name resolution when creating a property path.
+	 *
+	 * @since 6.1.0
+	 */
+	@Incubating
+	String PROPERTY_NODE_NAME_PROVIDER_CLASSNAME = "hibernate.validator.property_node_name_provider";
 
 	/**
 	 * <p>
@@ -336,4 +347,17 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 */
 	@Incubating
 	S getterPropertySelectionStrategy(GetterPropertySelectionStrategy getterPropertySelectionStrategy);
+
+	/**
+	 * Allows to set a property node name provider, defining how the name of a property node will be resolved
+	 * when constructing a property path as the one returned by {@link ConstraintViolation#getPropertyPath()}.
+	 *
+	 * @param propertyNodeNameProvider the {@link PropertyNodeNameProvider} to be used
+	 *
+	 * @return {@code this} following the chaining method pattern
+	 *
+	 * @since 6.1.0
+	 */
+	@Incubating
+	S propertyNodeNameProvider(PropertyNodeNameProvider propertyNodeNameProvider);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/DefaultPropertyNodeNameProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/DefaultPropertyNodeNameProvider.java
@@ -1,0 +1,24 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine;
+
+import java.io.Serializable;
+
+import org.hibernate.validator.spi.nodenameprovider.Property;
+import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
+
+/**
+ * A default {@link PropertyNodeNameProvider} implementation which returns the property name.
+ *
+ * @author Damir Alibegovic
+ */
+public class DefaultPropertyNodeNameProvider implements PropertyNodeNameProvider, Serializable {
+	@Override
+	public String getName(Property property) {
+		return property.getName();
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
@@ -139,7 +139,8 @@ public class PredefinedScopeValidatorFactoryImpl implements PredefinedScopeHiber
 				constraintValidatorManager, typeResolutionHelper, valueExtractorManager );
 
 		ExecutableHelper executableHelper = new ExecutableHelper( typeResolutionHelper );
-		JavaBeanHelper javaBeanHelper = new JavaBeanHelper( ValidatorFactoryConfigurationHelper.determineGetterPropertySelectionStrategy( hibernateSpecificConfig, properties, externalClassLoader ) );
+		JavaBeanHelper javaBeanHelper = new JavaBeanHelper( ValidatorFactoryConfigurationHelper.determineGetterPropertySelectionStrategy( hibernateSpecificConfig, properties, externalClassLoader ),
+				ValidatorFactoryConfigurationHelper.determinePropertyNodeNameProvider( hibernateSpecificConfig, properties, externalClassLoader ) );
 
 		// HV-302; don't load XmlMappingParser if not necessary
 		XmlMetaDataProvider xmlMetaDataProvider;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -169,7 +169,8 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		this.constraintCreationContext = new ConstraintCreationContext( constraintHelper, constraintValidatorManager, typeResolutionHelper, valueExtractorManager );
 
 		this.executableHelper = new ExecutableHelper( typeResolutionHelper );
-		this.javaBeanHelper = new JavaBeanHelper( ValidatorFactoryConfigurationHelper.determineGetterPropertySelectionStrategy( hibernateSpecificConfig, properties, externalClassLoader ) );
+		this.javaBeanHelper = new JavaBeanHelper( ValidatorFactoryConfigurationHelper.determineGetterPropertySelectionStrategy( hibernateSpecificConfig, properties, externalClassLoader ),
+				ValidatorFactoryConfigurationHelper.determinePropertyNodeNameProvider( hibernateSpecificConfig, properties, externalClassLoader ) );
 
 		// HV-302; don't load XmlMappingParser if not necessary
 		if ( configurationState.getMappingStreams().isEmpty() ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/AbstractPropertyCascadable.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/AbstractPropertyCascadable.java
@@ -48,7 +48,7 @@ public abstract class AbstractPropertyCascadable<T extends Property> implements 
 
 	@Override
 	public void appendTo(PathImpl path) {
-		path.addPropertyNode( property.getPropertyName() );
+		path.addPropertyNode( property.getResolvedPropertyName() );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/location/AbstractPropertyConstraintLocation.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/location/AbstractPropertyConstraintLocation.java
@@ -54,7 +54,7 @@ public abstract class AbstractPropertyConstraintLocation<T extends Property> imp
 
 	@Override
 	public void appendTo(ExecutableParameterNameProvider parameterNameProvider, PathImpl path) {
-		path.addPropertyNode( property.getPropertyName() );
+		path.addPropertyNode( property.getResolvedPropertyName() );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
@@ -220,7 +220,7 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 				continue;
 			}
 
-			JavaBeanField javaBeanField = new JavaBeanField( field );
+			JavaBeanField javaBeanField = javaBeanHelper.field( field );
 
 			if ( annotationProcessingOptions.areMemberConstraintsIgnoredFor( javaBeanField ) ) {
 				continue;

--- a/engine/src/main/java/org/hibernate/validator/internal/properties/Property.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/properties/Property.java
@@ -13,5 +13,7 @@ public interface Property extends Constrainable {
 
 	String getPropertyName();
 
+	String getResolvedPropertyName();
+
 	PropertyAccessor createAccessor();
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanField.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanField.java
@@ -25,13 +25,15 @@ import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredField;
 public class JavaBeanField implements org.hibernate.validator.internal.properties.Field, JavaBeanAnnotatedConstrainable {
 
 	private final Field field;
+	private final String resolvedPropertyName;
 	private final Type typeForValidatorResolution;
 	private final Type type;
 
-	public JavaBeanField(Field field) {
+	public JavaBeanField(Field field, String resolvedPropertyName) {
 		this.field = field;
 		this.type = ReflectionHelper.typeOf( field );
 		this.typeForValidatorResolution = ReflectionHelper.boxedType( this.type );
+		this.resolvedPropertyName = resolvedPropertyName;
 	}
 
 	@Override
@@ -57,6 +59,11 @@ public class JavaBeanField implements org.hibernate.validator.internal.propertie
 	@Override
 	public String getPropertyName() {
 		return getName();
+	}
+
+	@Override
+	public String getResolvedPropertyName() {
+		return resolvedPropertyName;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanGetter.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanGetter.java
@@ -25,6 +25,7 @@ import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredMethod
 public class JavaBeanGetter extends JavaBeanMethod implements Getter {
 
 	private final String propertyName;
+	private final String resolvedPropertyName;
 
 	/**
 	 * The class of the method for which the constraint was defined.
@@ -34,17 +35,23 @@ public class JavaBeanGetter extends JavaBeanMethod implements Getter {
 	 */
 	private final Class<?> declaringClass;
 
-	public JavaBeanGetter(Class<?> declaringClass, Method method, String propertyName) {
+	public JavaBeanGetter(Class<?> declaringClass, Method method, String propertyName, String resolvedPropertyName) {
 		super( method );
 		Contracts.assertNotNull( propertyName, "Property name cannot be null." );
 
 		this.declaringClass = declaringClass;
 		this.propertyName = propertyName;
+		this.resolvedPropertyName = resolvedPropertyName;
 	}
 
 	@Override
 	public String getPropertyName() {
 		return propertyName;
+	}
+
+	@Override
+	public String getResolvedPropertyName() {
+		return resolvedPropertyName;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -63,6 +63,7 @@ import org.hibernate.validator.internal.util.logging.formatter.ExecutableFormatt
 import org.hibernate.validator.internal.util.logging.formatter.ObjectArrayFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.TypeFormatter;
 import org.hibernate.validator.internal.xml.mapping.ContainerElementTypePath;
+import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
 import org.hibernate.validator.spi.properties.GetterPropertySelectionStrategy;
 import org.hibernate.validator.spi.scripting.ScriptEvaluationException;
 import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
@@ -887,4 +888,11 @@ public interface Log extends BasicLogger {
 	@LogMessage(level = ERROR)
 	@Message(id = 251, value = "An error occurred while loading an instance of service %s.")
 	void unableToLoadInstanceOfService(String serviceName, @Cause ServiceConfigurationError e);
+
+	@LogMessage(level = DEBUG)
+	@Message(id = 252, value = "Using %s as property node name provider.")
+	void usingPropertyNodeNameProvider(@FormatWith(ClassObjectFormatter.class) Class<? extends PropertyNodeNameProvider> propertyNodeNameProviderClass);
+
+	@Message(id = 253, value = "Unable to instantiate property node name provider class %s.")
+	ValidationException getUnableToInstantiatePropertyNodeNameProviderClassException(String propertyNodeNameProviderClassName, @Cause Exception e);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/config/ValidationBootstrapParameters.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/config/ValidationBootstrapParameters.java
@@ -32,6 +32,7 @@ import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
 import org.hibernate.validator.internal.util.privilegedactions.NewInstance;
+import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
 
 /**
  * @author Hardy Ferentschik
@@ -50,6 +51,7 @@ public class ValidationBootstrapParameters {
 	private final Map<String, String> configProperties = new HashMap<>();
 	private final Set<InputStream> mappings = new HashSet<>();
 	private final Map<ValueExtractorDescriptor.Key, ValueExtractorDescriptor> valueExtractorDescriptors = new HashMap<>();
+	private PropertyNodeNameProvider propertyNodeNameProvider;
 
 	public ValidationBootstrapParameters() {
 	}
@@ -148,6 +150,14 @@ public class ValidationBootstrapParameters {
 
 	public void addValueExtractorDescriptor(ValueExtractorDescriptor descriptor) {
 		valueExtractorDescriptors.put( descriptor.getKey(), descriptor );
+	}
+
+	public PropertyNodeNameProvider getPropertyNodeNameProvider() {
+		return propertyNodeNameProvider;
+	}
+
+	public void setPropertyNodeNameProvider(PropertyNodeNameProvider propertyNodeNameProvider) {
+		this.propertyNodeNameProvider = propertyNodeNameProvider;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/engine/src/main/java/org/hibernate/validator/spi/nodenameprovider/JavaBeanProperty.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/nodenameprovider/JavaBeanProperty.java
@@ -1,0 +1,25 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.spi.nodenameprovider;
+
+import org.hibernate.validator.Incubating;
+
+/**
+ * Contains metadata for a JavaBean property.
+ *
+ * @author Damir Alibegovic
+ * @since 6.1.0
+ */
+@Incubating
+public interface JavaBeanProperty extends Property {
+	/**
+	 * Owner class of the property.
+	 *
+	 * @return {@link Class} owning class of the property
+	 */
+	Class<?> getDeclaringClass();
+}

--- a/engine/src/main/java/org/hibernate/validator/spi/nodenameprovider/Property.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/nodenameprovider/Property.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.spi.nodenameprovider;
+
+
+import org.hibernate.validator.Incubating;
+
+/**
+ * Base interface for property metadata.
+ *
+ * @author Damir Alibegovic
+ * @since 6.1.0
+ */
+@Incubating
+public interface Property {
+	/**
+	 * Returns the property name.
+	 *
+	 * @return {@link String} representing the property name
+	 */
+	String getName();
+}

--- a/engine/src/main/java/org/hibernate/validator/spi/nodenameprovider/PropertyNodeNameProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/nodenameprovider/PropertyNodeNameProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.spi.nodenameprovider;
+
+import org.hibernate.validator.Incubating;
+
+/**
+ * This interface is used to resolve the name of a property node when creating the property path.
+ *
+ * @author Damir Alibegovic
+ * @since 6.1.0
+ */
+@Incubating
+public interface PropertyNodeNameProvider {
+	/**
+	 * Returns the resolved name of a property.
+	 * <p>
+	 * Depending on the subtype of the {@link Property},
+	 * a different strategy for name resolution could be applied, defaulting to {@link Property#getName()}. For example:
+	 *
+	 * <pre>
+	 * if (property instanceof {@link JavaBeanProperty}) {
+	 *     // for instance, generate a property name based on the annotations of the property
+	 * } else {
+	 *     return property.getName();
+	 * }
+	 * </pre>
+	 *
+	 * @param property who's name needs to be resolved
+	 *
+	 * @return String representing the resolved name
+	 */
+	String getName(Property property);
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
@@ -29,6 +29,7 @@ import javax.validation.Validator;
 import javax.validation.constraints.NotNull;
 
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.DefaultPropertyNodeNameProvider;
 import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.engine.path.PathImpl;
@@ -196,7 +197,7 @@ public class PathImplTest {
 				getDummyConstraintCreationContext(),
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
-				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() ),
+				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.DefaultPropertyNodeNameProvider;
 import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManagerImpl;
@@ -55,7 +56,7 @@ public class BeanMetaDataManagerTest {
 				getDummyConstraintCreationContext(),
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
-				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() ),
+				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
@@ -24,6 +24,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.groups.Default;
 
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.DefaultPropertyNodeNameProvider;
 import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
@@ -61,7 +62,7 @@ public class ExecutableMetaDataTest {
 				getDummyConstraintCreationContext(),
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
-				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() ),
+				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
@@ -25,6 +25,7 @@ import javax.validation.executable.ValidateOnExecution;
 import javax.validation.groups.Default;
 
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.DefaultPropertyNodeNameProvider;
 import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
@@ -61,7 +62,7 @@ public class ParameterMetaDataTest {
 				getDummyConstraintCreationContext(),
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
-				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() ),
+				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()
@@ -130,7 +131,7 @@ public class ParameterMetaDataTest {
 				getDummyConstraintCreationContext(),
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new SkewedParameterNameProvider() ),
-				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() ),
+				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
@@ -18,6 +18,7 @@ import javax.validation.groups.ConvertGroup;
 import javax.validation.groups.Default;
 
 import org.hibernate.validator.internal.engine.DefaultParameterNameProvider;
+import org.hibernate.validator.internal.engine.DefaultPropertyNodeNameProvider;
 import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
@@ -45,7 +46,7 @@ public class PropertyMetaDataTest {
 				getDummyConstraintCreationContext(),
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
-				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() ),
+				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/core/MetaConstraintTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/core/MetaConstraintTest.java
@@ -56,7 +56,7 @@ public class MetaConstraintTest {
 	@Test
 	@TestForIssue(jiraKey = "HV-930")
 	public void two_meta_constraints_for_the_same_constraint_should_be_equal() throws Exception {
-		JavaBeanGetter javaBeanGetter = new JavaBeanGetter( Foo.class, Foo.class.getDeclaredMethod( "getBar" ), "bar" );
+		JavaBeanGetter javaBeanGetter = new JavaBeanGetter( Foo.class, Foo.class.getDeclaredMethod( "getBar" ), "bar", "bar" );
 		ConstraintDescriptorImpl<NotNull> constraintDescriptor1 = new ConstraintDescriptorImpl<>(
 				constraintHelper, javaBeanGetter, constraintAnnotationDescriptor, ConstraintLocationKind.METHOD
 		);

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/location/ConstraintLocationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/location/ConstraintLocationTest.java
@@ -33,8 +33,8 @@ public class ConstraintLocationTest {
 	@TestForIssue(jiraKey = "HV-930")
 	public void two_constraint_locations_for_the_same_member_should_be_equal() throws Exception {
 		Method getter = Foo.class.getMethod( "getBar" );
-		ConstraintLocation location1 = ConstraintLocation.forGetter( new JavaBeanGetter( Foo.class, getter, "bar" ) );
-		ConstraintLocation location2 = ConstraintLocation.forGetter( new JavaBeanGetter( Foo.class, getter, "bar" ) );
+		ConstraintLocation location1 = ConstraintLocation.forGetter( new JavaBeanGetter( Foo.class, getter, "bar", "bar" ) );
+		ConstraintLocation location2 = ConstraintLocation.forGetter( new JavaBeanGetter( Foo.class, getter, "bar", "bar" ) );
 
 		assertEquals( location1, location2, "Two constraint locations for the same type should be equal" );
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTest.java
@@ -29,6 +29,7 @@ import javax.validation.groups.Default;
 import javax.validation.metadata.ConstraintDescriptor;
 
 import org.hibernate.validator.constraints.ScriptAssert;
+import org.hibernate.validator.internal.engine.DefaultPropertyNodeNameProvider;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.location.ConstraintLocation.ConstraintLocationKind;
@@ -58,7 +59,7 @@ public class AnnotationMetaDataProviderTest extends AnnotationMetaDataProviderTe
 	public void setUpProvider() {
 		provider = new AnnotationMetaDataProvider(
 				getDummyConstraintCreationContext(),
-				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() ),
+				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
 				new AnnotationProcessingOptionsImpl()
 		);
 	}
@@ -100,7 +101,7 @@ public class AnnotationMetaDataProviderTest extends AnnotationMetaDataProviderTe
 		assertThat( createEvent.getCrossParameterConstraints() ).hasSize( 1 );
 
 		assertThat( createEvent.getCallable() ).isEqualTo(
-				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() )
+				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() )
 						.findDeclaredMethod( Calendar.class, "createEvent", LocalDate.class, LocalDate.class )
 						.get()
 		);

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTestBase.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/AnnotationMetaDataProviderTestBase.java
@@ -11,6 +11,7 @@ import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 
+import org.hibernate.validator.internal.engine.DefaultPropertyNodeNameProvider;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement.ConstrainedElementKind;
@@ -61,7 +62,7 @@ public abstract class AnnotationMetaDataProviderTestBase {
 	}
 
 	protected ConstrainedElement findConstrainedElement(BeanConfiguration<?> beanConfiguration, Member member) {
-		JavaBeanHelper javaBeanHelper = new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() );
+		JavaBeanHelper javaBeanHelper = new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() );
 		Constrainable constrainable;
 		if ( member instanceof Field ) {
 			constrainable = javaBeanHelper.findDeclaredField( member.getDeclaringClass(), member.getName() ).get();

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationMetaDataRetrievalTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/provider/TypeAnnotationMetaDataRetrievalTest.java
@@ -19,6 +19,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.validator.internal.engine.DefaultPropertyNodeNameProvider;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
 import org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider;
@@ -44,7 +45,7 @@ public class TypeAnnotationMetaDataRetrievalTest extends AnnotationMetaDataProvi
 	public void setup() {
 		provider = new AnnotationMetaDataProvider(
 				getDummyConstraintCreationContext(),
-				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() ),
+				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
 				new AnnotationProcessingOptionsImpl()
 		);
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/MappingXmlParserTest.java
@@ -23,6 +23,7 @@ import javax.validation.ValidationException;
 import javax.validation.constraints.DecimalMin;
 
 import org.hibernate.validator.internal.engine.ConstraintCreationContext;
+import org.hibernate.validator.internal.engine.DefaultPropertyNodeNameProvider;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 import org.hibernate.validator.internal.properties.DefaultGetterPropertySelectionStrategy;
 import org.hibernate.validator.internal.properties.javabean.JavaBeanHelper;
@@ -44,7 +45,7 @@ public class MappingXmlParserTest {
 		constraintCreationContext = getDummyConstraintCreationContext();
 		xmlMappingParser = new MappingXmlParser(
 				constraintCreationContext,
-				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy() ), null
+				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ), null
 		);
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/spi/nodenameprovider/AnnotationPropertyNodeNameProvider.java
+++ b/engine/src/test/java/org/hibernate/validator/test/spi/nodenameprovider/AnnotationPropertyNodeNameProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.spi.nodenameprovider;
+
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.hibernate.validator.internal.util.logging.Log;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
+import org.hibernate.validator.spi.nodenameprovider.JavaBeanProperty;
+import org.hibernate.validator.spi.nodenameprovider.Property;
+import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
+
+/**
+ * An example of how a name can be resolved from an annotation
+ *
+ * @author Damir Alibegovic
+ */
+class AnnotationPropertyNodeNameProvider implements PropertyNodeNameProvider, Serializable {
+	private static final String VALUE = "value";
+	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
+
+	private final Class<? extends Annotation> annotationType;
+	private final String annotationMemberName;
+
+	AnnotationPropertyNodeNameProvider(Class<? extends Annotation> annotationType) {
+		this( annotationType, VALUE );
+	}
+
+	AnnotationPropertyNodeNameProvider(Class<? extends Annotation> annotationType, String annotationMemberName) {
+		this.annotationType = Objects.requireNonNull( annotationType );
+		this.annotationMemberName = Objects.requireNonNull( annotationMemberName );
+	}
+
+	@Override
+	public String getName(Property property) {
+		if ( property instanceof JavaBeanProperty ) {
+			return getJavaBeanPropertyName( (JavaBeanProperty) property );
+		}
+
+		return getDefaultName( property );
+	}
+
+	private String getJavaBeanPropertyName(JavaBeanProperty property) {
+		Optional<Field> field = getField( property );
+
+		if ( field.isPresent() && field.get().isAnnotationPresent( annotationType ) ) {
+			return getAnnotationMemberValue( field.get(), annotationMemberName )
+					.orElse( getDefaultName( property ) );
+		}
+		else {
+			return getDefaultName( property );
+		}
+	}
+
+	private Optional<Field> getField(JavaBeanProperty property) {
+		return Arrays.stream( property.getDeclaringClass().getFields() )
+				.peek( field -> field.setAccessible( true ) )
+				.filter( field -> property.getName().equals( field.getName() ) )
+				.findFirst();
+	}
+
+	private Optional<String> getAnnotationMemberValue(Field field, String annotationMemberName) {
+		Annotation annotation = field.getAnnotation( annotationType );
+
+		try {
+			return Optional.of(
+					(String) annotation.annotationType().getMethod( annotationMemberName ).invoke( annotation ) );
+		}
+		catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+			LOG.error( "Unable to get annotation member value", e );
+
+			return Optional.empty();
+		}
+	}
+
+	private String getDefaultName(Property property) {
+		return property.getName();
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/spi/nodenameprovider/PropertyNodeNameProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/spi/nodenameprovider/PropertyNodeNameProviderTest.java
@@ -1,0 +1,241 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.spi.nodenameprovider;
+
+import static org.testng.Assert.assertEquals;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.Size;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.testutil.TestForIssue;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Damir Alibegovic
+ */
+@TestForIssue(jiraKey = "HV-823")
+public class PropertyNodeNameProviderTest {
+	private static final String INVALID_BRAND_NAME = "BMW";
+	private static final String VALID_BRAND_NAME = "Mercedes";
+
+	private Validator validator;
+
+	@BeforeMethod
+	public void setUp() {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.propertyNodeNameProvider( new AnnotationPropertyNodeNameProvider( PropertyName.class ) )
+				.buildValidatorFactory();
+
+		validator = validatorFactory.getValidator();
+	}
+
+	@Test
+	public void nameIsResolvedFromCustomAnnotationByUsingValidate() {
+		Car testInstance = new Car( INVALID_BRAND_NAME );
+
+		Set<ConstraintViolation<Car>> violations = validator.validate( testInstance );
+		ConstraintViolation<Car> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "brand.brand_name" );
+	}
+
+	@Test
+	public void nameIsResolvedFromCustomAnnotationByUsingValidateProperty() {
+		Car testInstance = new Car( INVALID_BRAND_NAME );
+
+		Set<ConstraintViolation<Car>> violations = validator.validateProperty( testInstance, "brand.name" );
+		ConstraintViolation<Car> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "brand.brand_name" );
+	}
+
+	@Test
+	public void nameIsResolvedFromCustomAnnotationByUsingValidateValue() {
+		Set<ConstraintViolation<Brand>> violations = validator.validateValue( Brand.class, "name", INVALID_BRAND_NAME );
+		ConstraintViolation<Brand> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "brand_name" );
+	}
+
+	@Test
+	public void nameIsResolvedFromCustomAnnotationWithConstraintOnGetter() {
+		int horsePower = 125;
+		int speedInRpm = 500;
+		Airplane testInstance = new Airplane( new Engine( horsePower, speedInRpm ) );
+
+		Set<ConstraintViolation<Airplane>> violations = validator.validate( testInstance );
+		ConstraintViolation<Airplane> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "turbojet_engine.speed_in_rpm" );
+	}
+
+	@Test
+	public void propertyCanBeOfTypeMap() {
+		int horsePower = 0;
+		int speedInRpm = 1000;
+		Car testInstance = new Car( VALID_BRAND_NAME );
+		testInstance.addComponent( "engine", new Engine( horsePower, speedInRpm ) );
+
+		Set<ConstraintViolation<Car>> violations = validator.validate( testInstance );
+		ConstraintViolation<Car> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "components[engine].horse_power" );
+
+	}
+
+	@Test
+	public void defaultValidatorFactoryUsesDefaultPropertyNodeNameProvider() {
+		ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+		Validator val = factory.getValidator();
+
+		Car testInstance = new Car( INVALID_BRAND_NAME );
+
+		Set<ConstraintViolation<Car>> violations = val.validate( testInstance );
+		ConstraintViolation<Car> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "brand.name" );
+	}
+
+	@Test
+	public void defaultProviderUsesDefaultPropertyNodeNameProvider() {
+		ValidatorFactory validatorFactory = Validation.byDefaultProvider()
+				.configure()
+				.buildValidatorFactory();
+		Validator val = validatorFactory.getValidator();
+
+		Car testInstance = new Car( INVALID_BRAND_NAME );
+
+		Set<ConstraintViolation<Car>> violations = val.validate( testInstance );
+		ConstraintViolation<Car> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "brand.name" );
+	}
+
+	@Test
+	public void hibernateValidatorUsesDefaultPropertyNodeProvider() {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.buildValidatorFactory();
+		Validator val = validatorFactory.getValidator();
+
+		Car testInstance = new Car( INVALID_BRAND_NAME );
+
+		Set<ConstraintViolation<Car>> violations = val.validate( testInstance );
+		ConstraintViolation<Car> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "brand.name" );
+	}
+
+	@Test
+	public void hibernateValidatorCanUseCustomPropertyNodeNameProvider() {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.propertyNodeNameProvider( new AnnotationPropertyNodeNameProvider( PropertyName.class ) )
+				.buildValidatorFactory();
+		Validator val = validatorFactory.getValidator();
+
+		Car testInstance = new Car( INVALID_BRAND_NAME );
+
+		Set<ConstraintViolation<Car>> violations = val.validate( testInstance );
+		ConstraintViolation<Car> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "brand.brand_name" );
+	}
+
+	@Test
+	public void hibernateValidatorFallsBackToDefaultPropertyNodeNameProvider() {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.propertyNodeNameProvider( null )
+				.buildValidatorFactory();
+		Validator val = validatorFactory.getValidator();
+
+		Car testInstance = new Car( INVALID_BRAND_NAME );
+
+		Set<ConstraintViolation<Car>> violations = val.validate( testInstance );
+		ConstraintViolation<Car> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "brand.name" );
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.FIELD, ElementType.METHOD })
+	public @interface PropertyName {
+		String value();
+	}
+
+	private class Car {
+		@PropertyName("components")
+		public final Map<String, @Valid Object> comps = new HashMap<>();
+
+		@Valid
+		public final Brand brand;
+
+		Car(String brand) {
+			this.brand = new Brand( brand );
+		}
+
+		public void addComponent(String name, Object component) {
+			comps.put( name, component );
+		}
+	}
+
+	private class Brand {
+		@PropertyName("brand_name")
+		@Size(min = 4)
+		public final String name;
+
+		Brand(String name) {
+			this.name = name;
+		}
+	}
+
+	private class Engine {
+		@PropertyName("horse_power")
+		@Min(1)
+		public final int horsePower;
+
+		@PropertyName("speed_in_rpm")
+		public final int speedInRpm;
+
+		public Engine(int horsePower, int speedInRpm) {
+			this.horsePower = horsePower;
+			this.speedInRpm = speedInRpm;
+		}
+
+		@Min(1000)
+		public int getSpeedInRpm() {
+			return speedInRpm;
+		}
+	}
+
+	private class Airplane {
+		@Valid
+		@PropertyName("turbojet_engine")
+		public final Engine engine;
+
+		public Airplane(Engine engine) {
+			this.engine = engine;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/spi/nodenameprovider/jackson/JacksonAnnotationPropertyNodeNameProvider.java
+++ b/engine/src/test/java/org/hibernate/validator/test/spi/nodenameprovider/jackson/JacksonAnnotationPropertyNodeNameProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.spi.nodenameprovider.jackson;
+
+import org.hibernate.validator.spi.nodenameprovider.JavaBeanProperty;
+import org.hibernate.validator.spi.nodenameprovider.Property;
+import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+
+/**
+ * An example of how a name can be resolved from a Jackson annotation.
+ *
+ * @author Damir Alibegovic
+ */
+public class JacksonAnnotationPropertyNodeNameProvider implements PropertyNodeNameProvider {
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Override
+	public String getName(Property property) {
+		if ( property instanceof JavaBeanProperty ) {
+			return getJavaBeanPropertyName( (JavaBeanProperty) property );
+		}
+
+		return getDefaultName( property );
+	}
+
+	private String getJavaBeanPropertyName(JavaBeanProperty property) {
+		JavaType type = objectMapper.constructType( property.getDeclaringClass() );
+		BeanDescription desc = objectMapper.getSerializationConfig().introspect( type );
+
+		return desc.findProperties()
+				.stream()
+				.filter( prop -> prop.getInternalName().equals( property.getName() ) )
+				.map( BeanPropertyDefinition::getName )
+				.findFirst()
+				.orElse( property.getName() );
+	}
+
+	private String getDefaultName(Property property) {
+		return property.getName();
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/spi/nodenameprovider/jackson/JacksonAnnotationPropertyNodeNameProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/spi/nodenameprovider/jackson/JacksonAnnotationPropertyNodeNameProviderTest.java
@@ -1,0 +1,99 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.spi.nodenameprovider.jackson;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Valid;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.testutil.TestForIssue;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Damir Alibegovic
+ */
+@TestForIssue(jiraKey = "HV-823")
+public class JacksonAnnotationPropertyNodeNameProviderTest {
+	private static final int VALID_HORSE_POWER = 150;
+	private static final int INVALID_HORSE_POWER = 250;
+
+	private Validator validator;
+
+	@BeforeMethod
+	public void setUp() {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.propertyNodeNameProvider( new JacksonAnnotationPropertyNodeNameProvider() )
+				.buildValidatorFactory();
+
+		validator = validatorFactory.getValidator();
+	}
+
+	@Test
+	public void jsonPropertyOnFieldIsUsedForPathResolution() {
+		Car testInstance = new Car( new Engine( INVALID_HORSE_POWER ) );
+
+		Set<ConstraintViolation<Car>> violations = validator.validate( testInstance );
+		ConstraintViolation<Car> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "engine.horse_power" );
+	}
+
+	@Test
+	public void jsonPropertyOnGetterIsUsedForPathResolution() {
+		int invalidNumberOfSeats = 0;
+		Car testInstance = new Car( new Engine( VALID_HORSE_POWER ), invalidNumberOfSeats );
+
+		Set<ConstraintViolation<Car>> violations = validator.validate( testInstance );
+		ConstraintViolation<Car> violation = violations.iterator().next();
+
+		assertEquals( violation.getPropertyPath().toString(), "number_of_seats" );
+	}
+
+	private class Car {
+		@Valid
+		private final Engine engine;
+
+		@Min(1)
+		private final int numberOfSeats;
+
+		Car(Engine engine) {
+			this( engine, 4 );
+		}
+
+		Car(Engine engine, int numberOfSeats) {
+			this.engine = engine;
+			this.numberOfSeats = numberOfSeats;
+		}
+
+		@JsonProperty("number_of_seats")
+		public int getNumberOfSeats() {
+			return numberOfSeats;
+		}
+	}
+
+	private class Engine {
+		@JsonProperty("horse_power")
+		@Max(200)
+		private final int horsePower;
+
+		Engine(int horsePower) {
+			this.horsePower = horsePower;
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,7 @@
         <version.com.google.guava>23.0</version.com.google.guava>
         <version.org.springframework.spring-expression>4.3.10.RELEASE</version.org.springframework.spring-expression>
         <version.org.jboss.arquillian.container.arquillian-weld-se-embedded-1.1>1.0.0.Final</version.org.jboss.arquillian.container.arquillian-weld-se-embedded-1.1>
+        <version.com.fasterxml.jackson.core>2.9.8</version.com.fasterxml.jackson.core>
 
         <!-- OSGi dependencies -->
         <version.org.apache.karaf>4.2.0</version.org.apache.karaf>
@@ -490,6 +491,18 @@
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-expression</artifactId>
                 <version>${version.org.springframework.spring-expression}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.com.fasterxml.jackson.core}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${version.com.fasterxml.jackson.core}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>


### PR DESCRIPTION
Added PropertyNodeNameProvider SPI with Property and JavaBeanProperty as supporting interfaces.

This SPI lives in JavaBeanHelper and is used to get the name when creating JavaBeanField and JavaBeanGetter, so when a property path is constructed, this resolved name is used.

If not set, the default implementation will be used that returns the actual name from the class.

This new SPI can be configured through HibernateValidatorConfiguration.

Testing:
- Added tests for configuration
- Added a sample implementation by using reflection and custom annotation
- Added tests for reflection implementation
- Added a sample implementation by using Jackson lib
- Added tests for Jackson implementation

Added documentation with examples.

This PR is same as: https://github.com/hibernate/hibernate-validator/pull/1012 + the documentation, but the changes are squashed and rebased.