### PR TITLE
Fix bug that Regon validation may accept incorrect length Regon

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/pl/REGONValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/pl/REGONValidator.java
@@ -6,46 +6,62 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.hv.pl;
 
-import java.util.List;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
 
 import org.hibernate.validator.constraints.pl.REGON;
 
 /**
  * Validator for {@link REGON}. Validates both 9 and 14 digits REGON numbers.
  *
- * @author Marko Bekhta
+ * @author Michal Domagala
  */
-public class REGONValidator extends PolishNumberValidator<REGON> {
+public class REGONValidator implements ConstraintValidator<REGON, CharSequence> {
 
-	private static final int[] WEIGHTS_REGON_14 = { 2, 4, 8, 5, 0, 9, 7, 3, 6, 1, 2, 4, 8 };
+	// last weight is zero to ignore check digit when sum and modulo is calculated
+	private static final int[] WEIGHTS_REGON_9 = {8, 9, 2, 3, 4, 5, 6, 7, 0};
 
-	private static final int[] WEIGHTS_REGON_9 = { 8, 9, 2, 3, 4, 5, 6, 7 };
+	private static final int[] WEIGHTS_REGON_14 = {2, 4, 8, 5, 0, 9, 7, 3, 6, 1, 2, 4, 8, 0};
 
 	@Override
 	public void initialize(REGON constraintAnnotation) {
-		super.initialize(
-				0,
-				Integer.MAX_VALUE,
-				-1,
-				false
-		);
 	}
 
-	/**
-	 * @param digits a list of digits to be verified. They are used to determine a size of REGON number - is it 9 or 14 digit number
-	 *
-	 * @return an array of weights to be used to calculate a checksum
-	 */
 	@Override
-	protected int[] getWeights(List<Integer> digits) {
-		if ( digits.size() == 8 ) {
-			return WEIGHTS_REGON_9;
+	public boolean isValid(final CharSequence value, final ConstraintValidatorContext context) {
+		if ( value == null ) {
+			return true;
 		}
-		else if ( digits.size() == 13 ) {
-			return WEIGHTS_REGON_14;
+
+		int[] digits = value.chars()
+			.map( Character::getNumericValue )
+			.toArray();
+
+		for ( int digit : digits ) {
+			if ( digit < 0 || digit > 9 ) {
+				return false; // non-digit in input string
+			}
 		}
-		else {
-			return new int[] { };
+
+		switch ( digits.length ) {
+			case 9:
+				int checkDigit9 = digits[8];
+				return mod11mod10( digits, WEIGHTS_REGON_9 ) == checkDigit9;
+			case 14:
+				int checkDigit14 = digits[13];
+				return mod11mod10( digits, WEIGHTS_REGON_14 ) == checkDigit14;
+			default:
+				return false;
 		}
+	}
+
+	// check digit has weight 0 -> check digit is effectively ignored by sum and modulo
+	private int mod11mod10(int[] digits, int[] weigths) {
+		int sum = 0;
+		for ( int i = 0; i < digits.length; i++ ) {
+			sum += digits[i] * weigths[i];
+		}
+		// sum modulo 11 could be 10. 10 is treat as zero
+		return ( sum % 11 ) % 10;
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/REGONValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/REGONValidatorTest.java
@@ -54,6 +54,21 @@ public class REGONValidatorTest extends AbstractConstrainedTest {
 	}
 
 	@Test
+	public void testIncorrectLengthRegon() {
+		// 10 digits must be rejected
+		assertThat( validator.validate( new Company( "1234567845" ) ) )
+				.containsOnlyViolations(
+						violationOf( REGON.class ).withProperty( "regon" ) );
+	};
+
+	@Test
+	public void testNonDigitInRegon() {
+		assertThat( validator.validate( new Company( "4990553136851x" ) ) )
+				.containsOnlyViolations(
+						violationOf( REGON.class ).withProperty( "regon" ) );
+	};
+
+	@Test
 	public void testIncorrectRegon9Number() {
 		assertThat( validator.validate( new Company( "123456784" ) ) )
 				.containsOnlyViolations(


### PR DESCRIPTION
Current Regon validator implementation has a bug: it accepts for example
1234567845 - but Regon may have only 9 or 14 digits.

Regon validator is implemented from scratch, as existing design follows
yo-yo antipattern and is impossimble to use.