### PR TITLE
HV-1709 Polish Identification numbers are not considering length of the value

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/pl/PESELValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/pl/PESELValidator.java
@@ -30,13 +30,18 @@ public class PESELValidator extends ModCheckBase implements ConstraintValidator<
 				0,
 				Integer.MAX_VALUE,
 				-1,
-				true
+				false
 		);
 	}
 
 	@Override
 	public boolean isCheckDigitValid(List<Integer> digits, char checkDigit) {
 		Collections.reverse( digits );
+
+		// if the length of the number is incorrect we can return fast
+		if ( digits.size() != WEIGHTS_PESEL.length  ) {
+			return false;
+		}
 
 		int modResult = ModUtil.calculateModXCheckWithWeights( digits, 10, Integer.MAX_VALUE, WEIGHTS_PESEL );
 		switch ( modResult ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/pl/PolishNumberValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/pl/PolishNumberValidator.java
@@ -27,8 +27,15 @@ public abstract class PolishNumberValidator<T extends Annotation> extends ModChe
 	public boolean isCheckDigitValid(List<Integer> digits, char checkDigit) {
 		Collections.reverse( digits );
 
+		int[] weights = getWeights( digits );
+
+		// if the length of the number is incorrect we can return fast
+		if ( weights.length != digits.size() ) {
+			return false;
+		}
+
 		// as we need sum % 11 rather than 11 - (sum % 11) returned by Mod11 algorithm:
-		int modResult = 11 - ModUtil.calculateModXCheckWithWeights( digits, 11, Integer.MAX_VALUE, getWeights( digits ) );
+		int modResult = 11 - ModUtil.calculateModXCheckWithWeights( digits, 11, Integer.MAX_VALUE, weights );
 		switch ( modResult ) {
 			case 10:
 			case 11:

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/NIPValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/NIPValidatorTest.java
@@ -24,10 +24,26 @@ import org.testng.annotations.Test;
 public class NIPValidatorTest extends AbstractConstrainedTest {
 
 	@Test
-	public void testCorrectNipNumber() {
+	public void testAdditionalCharactersAreAllowed() {
 		assertNoViolations( validator.validate( new Person( "123-456-78-19" ) ) );
 		assertNoViolations( validator.validate( new Person( "123-45-67-819" ) ) );
 		assertNoViolations( validator.validate( new Person( "123-456-32-18" ) ) );
+	}
+
+	@Test
+	public void testIncorrectLength() {
+		assertThat( validator.validate( new Person( "123-456-78-14113-312-310" ) ) )
+				.containsOnlyViolations(
+						violationOf( NIP.class ).withProperty( "nip" )
+				);
+		assertThat( validator.validate( new Person( "123-45-62" ) ) )
+				.containsOnlyViolations(
+						violationOf( NIP.class ).withProperty( "nip" )
+				);
+	}
+
+	@Test
+	public void testCorrectNipNumber() {
 		assertNoViolations( validator.validate( new Person( "5931423811" ) ) );
 		assertNoViolations( validator.validate( new Person( "2596048500" ) ) );
 		assertNoViolations( validator.validate( new Person( "4163450312" ) ) );

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/PESELValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/PESELValidatorTest.java
@@ -24,6 +24,30 @@ import org.testng.annotations.Test;
 public class PESELValidatorTest extends AbstractConstrainedTest {
 
 	@Test
+	public void testAdditionalCharactersNotAllowed() {
+		assertThat( validator.validate( new Person( "9204-190-37-90" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+		assertThat( validator.validate( new Person( "44-0-5-1-4-01359" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+	}
+
+	@Test
+	public void testIncorrectLength() {
+		assertThat( validator.validate( new Person( "920419795" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+		assertThat( validator.validate( new Person( "92041903790123" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+	}
+
+	@Test
 	public void testCorrectPESELNumber() {
 		assertNoViolations( validator.validate( new Person( "92041903790" ) ) );
 		assertNoViolations( validator.validate( new Person( "44051401359" ) ) );

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/REGONValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/REGONValidatorTest.java
@@ -24,6 +24,30 @@ import org.testng.annotations.Test;
 public class REGONValidatorTest extends AbstractConstrainedTest {
 
 	@Test
+	public void testAdditionalCharactersNotAllowed() {
+		assertThat( validator.validate( new Company( "123-456-785" ) ) )
+				.containsOnlyViolations(
+						violationOf( REGON.class ).withProperty( "regon" )
+				);
+		assertThat( validator.validate( new Company( "6-9-1-6-5-7-1-8-2" ) ) )
+				.containsOnlyViolations(
+						violationOf( REGON.class ).withProperty( "regon" )
+				);
+	}
+
+	@Test
+	public void testIncorrectLength() {
+		assertThat( validator.validate( new Company( "1234567845" ) ) )
+				.containsOnlyViolations(
+						violationOf( REGON.class ).withProperty( "regon" )
+				);
+		assertThat( validator.validate( new Company( "12345673" ) ) )
+				.containsOnlyViolations(
+						violationOf( REGON.class ).withProperty( "regon" )
+				);
+	}
+
+	@Test
 	public void testCorrectRegon9Number() {
 		assertNoViolations( validator.validate( new Company( "123456785" ) ) );
 		assertNoViolations( validator.validate( new Company( "691657182" ) ) );


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1709

Check that Polish Identification numbers are of correct length:
- Check the length of validated identification number
- Add tests for short/long values
- Add tests for nondigits in the values
- Disallow nondigits in PESEL