### PR TITLE
HV-1713 Missing violation when a bean is validated with different groups

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java
@@ -609,13 +609,15 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 
 	private void validateCascadedAnnotatedObjectForCurrentGroup(Object value, BaseBeanValidationContext<?> validationContext, ValueContext<?, Object> valueContext,
 			CascadingMetaData cascadingMetaData) {
-		if ( validationContext.isBeanAlreadyValidated( value, valueContext.getCurrentGroup(), valueContext.getPropertyPath() ) ||
+		// We need to convert the group before checking if the bean was processed or not
+		// as group defines the processed status.
+		Class<?> originalGroup = valueContext.getCurrentGroup();
+		Class<?> currentGroup = cascadingMetaData.convertGroup( originalGroup );
+
+		if ( validationContext.isBeanAlreadyValidated( value, currentGroup, valueContext.getPropertyPath() ) ||
 				shouldFailFast( validationContext ) ) {
 			return;
 		}
-
-		Class<?> originalGroup = valueContext.getCurrentGroup();
-		Class<?> currentGroup = cascadingMetaData.convertGroup( originalGroup );
 
 		// expand the group only if was created by group conversion;
 		// otherwise we're looping through the right validation order
@@ -686,14 +688,16 @@ public class ValidatorImpl implements Validator, ExecutableValidator {
 		}
 
 		private void doValidate(Object value, String nodeName) {
+			// We need to convert the group before checking if the bean was processed or not
+			// as group defines the processed status.
+			Class<?> originalGroup = valueContext.getCurrentGroup();
+			Class<?> currentGroup = cascadingMetaData.convertGroup( originalGroup );
+
 			if ( value == null ||
-					validationContext.isBeanAlreadyValidated( value, valueContext.getCurrentGroup(), valueContext.getPropertyPath() ) ||
+					validationContext.isBeanAlreadyValidated( value, currentGroup, valueContext.getPropertyPath() ) ||
 					shouldFailFast( validationContext ) ) {
 				return;
 			}
-
-			Class<?> originalGroup = valueContext.getCurrentGroup();
-			Class<?> currentGroup = cascadingMetaData.convertGroup( originalGroup );
 
 			// expand the group only if was created by group conversion;
 			// otherwise we're looping through the right validation order

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/conversion/AbstractGroupConversionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/conversion/AbstractGroupConversionTest.java
@@ -23,6 +23,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.GroupSequence;
 import javax.validation.Valid;
 import javax.validation.Validator;
+import javax.validation.constraints.AssertTrue;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import javax.validation.groups.ConvertGroup;
@@ -30,6 +31,7 @@ import javax.validation.groups.Default;
 
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
+import org.hibernate.validator.testutils.CandidateForTck;
 import org.testng.annotations.Test;
 
 /**
@@ -214,6 +216,19 @@ public abstract class AbstractGroupConversionTest {
 		validator.validate( new User8() );
 	}
 
+	@Test
+	@CandidateForTck
+	public void sameBeanDifferentGroups() {
+		Set<ConstraintViolation<User9>> violations = validator.validate( new User9() );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( AssertTrue.class ).withPropertyPath( pathWith()
+						.property( "a" )
+						.property( "b" )
+				)
+		);
+	}
+
+
 	public interface Complete extends Default {
 	}
 
@@ -340,5 +355,13 @@ public abstract class AbstractGroupConversionTest {
 		@Valid
 		@ConvertGroup(from = PostalSequence.class, to = BasicPostal.class)
 		private final List<Address> addresses = Arrays.asList( new Address() );
+	}
+
+	private static class User9 {
+		@Valid
+		@ConvertGroup(from = Default.class, to = BasicNumber.class)
+		User9 a = this;
+		@AssertTrue(groups = BasicNumber.class)
+		boolean b;
 	}
 }


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1713

Convert current group before checking if the bean is processed:
- We need to convert the group before checking if the bean was processed or not as group defines the processed status.

Groups, processed beans .. all the things we like :smile: 

I think this test would be a good candidate for TCK.