### PR TITLE
HV-1718 Support validating unconstrained beans with PredefinedScopeValidatorFactory

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -879,9 +879,6 @@ public interface Log extends BasicLogger {
 	@Message(id = 248, value = "Unable to get an XML schema named %s.")
 	ValidationException unableToGetXmlSchema(String schemaResourceName);
 
-	@Message(id = 249, value = "Uninitialized bean metadata for class: %s. Please register your bean class as a class to initialize when initializing your ValidatorFactory.")
-	ValidationException uninitializedBeanMetaData(@FormatWith(ClassObjectFormatter.class) Class<?> clazz);
-
 	@Message(id = 250, value = "Uninitialized locale: %s. Please register your locale as a locale to initialize when initializing your ValidatorFactory.")
 	ValidationException uninitializedLocale(Locale locale);
 


### PR DESCRIPTION
@marko-bekhta could you take a look at that one, please?

I have been a bit too pedantic considering that only initialized classes could be validated as, well, unconstrained bean can also be validated...

This fixes it. The main drawback is that the framework really needs to be thorough in initializing everything, otherwise the constraints are not validated. But I don't think we have other options.