### PR TITLE
HV-1720  Support bounded wildcard types in container value unwrapping

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/util/TypeHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/TypeHelper.java
@@ -538,6 +538,7 @@ public final class TypeHelper {
 	 * <li>a parameterized type</li>
 	 * <li>a type variable</li>
 	 * <li>the null type</li>
+	 * <li>a wildcard type</li>
 	 * </ul>
 	 *
 	 * @param type the type to check
@@ -551,7 +552,8 @@ public final class TypeHelper {
 				|| type instanceof Class<?>
 				|| type instanceof ParameterizedType
 				|| type instanceof TypeVariable<?>
-				|| type instanceof GenericArrayType;
+				|| type instanceof GenericArrayType
+				|| type instanceof WildcardType;
 	}
 
 	private static boolean isArraySupertype(Class<?> type) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/ContainerWithWildcardTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/valueextraction/ContainerWithWildcardTest.java
@@ -1,0 +1,84 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.valueextraction;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.testutil.TestForIssue;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Marko Bekhta
+ */
+@TestForIssue(jiraKey = "HV-1720")
+public class ContainerWithWildcardTest {
+
+	@Test
+	public void containerWithUpperBoundWildcard() {
+		Set<ConstraintViolation<Foo>> constraintViolations = getValidator().validate( new Foo( Arrays.asList( null, null ) ) );
+
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( NotNull.class )
+		);
+	}
+
+	@Test
+	public void containerWithWildcard() {
+		Set<ConstraintViolation<Bar>> constraintViolations = getValidator().validate( new Bar( Arrays.asList( null, null ) ) );
+
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( NotNull.class )
+		);
+	}
+
+	@Test
+	public void containerWithLowerBoundWildcard() {
+		Set<ConstraintViolation<FooBar>> constraintViolations = getValidator().validate( new FooBar( Arrays.asList( null, null ) ) );
+
+		assertThat( constraintViolations ).containsOnlyViolations(
+				violationOf( NotNull.class ),
+				violationOf( NotNull.class )
+		);
+	}
+
+	private static class Foo {
+		private final List<@NotNull ? extends BigDecimal> list;
+
+		private Foo(List<? extends BigDecimal> list) {
+			this.list = list;
+		}
+	}
+
+	private static class Bar {
+		private final List<@NotNull ?> list;
+
+		private Bar(List<?> list) {
+			this.list = list;
+		}
+	}
+
+	private static class FooBar {
+		private final List<@NotNull ? super BigDecimal> list;
+
+		private FooBar(List<? super BigDecimal> list) {
+			this.list = list;
+		}
+	}
+}


### PR DESCRIPTION
- https://hibernate.atlassian.net/browse/HV-1720

Add wildcard type to allowed reference types list.

As it was mentioned on SO this `isReferenceType()` was only used prior to the call to `getErasedType()` which can handle wildcard types. hence it seems appropriate to include the wildcard type in the assert as well. 