### PR TITLE
HV-1723 Provide a DigitsValidatorForMonetaryAmount to support @Digits on MonetaryAmounts

### DIFF
--- a/annotation-processor/src/main/java/org/hibernate/validator/ap/internal/util/ConstraintHelper.java
+++ b/annotation-processor/src/main/java/org/hibernate/validator/ap/internal/util/ConstraintHelper.java
@@ -254,6 +254,7 @@ public class ConstraintHelper {
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.DECIMAL_MIN, Number.class, String.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.DECIMAL_MIN, JavaMoneyTypes.MONETARY_AMOUNT );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.DIGITS, Number.class, String.class );
+		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.DIGITS, JavaMoneyTypes.MONETARY_AMOUNT );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.EMAIL, CharSequence.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.FUTURE, Calendar.class, Date.class );
 		registerAllowedTypesForBuiltInConstraint( BeanValidationTypes.FUTURE, JodaTypes.READABLE_PARTIAL, JodaTypes.READABLE_INSTANT );

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/ModelWithJavaMoneyTypes.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/ModelWithJavaMoneyTypes.java
@@ -9,6 +9,7 @@ package org.hibernate.validator.ap.testmodel;
 import javax.money.MonetaryAmount;
 import javax.validation.constraints.DecimalMax;
 import javax.validation.constraints.DecimalMin;
+import javax.validation.constraints.Digits;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.Negative;
@@ -29,6 +30,7 @@ public class ModelWithJavaMoneyTypes {
 	@DecimalMin("0.00")
 	@Positive
 	@PositiveOrZero
+	@Digits(integer = 6, fraction = 2)
 	public MonetaryAmount monetaryAmount;
 
 	@Max(1000L)

--- a/documentation/src/main/asciidoc/ch02.asciidoc
+++ b/documentation/src/main/asciidoc/ch02.asciidoc
@@ -580,7 +580,7 @@ impact portability of your application between Bean Validation providers.
 	Hibernate metadata impact::: None
 
 `@Digits(integer=, fraction=)`:: Checks whether the annotated value is a number having up to `integer` digits and `fraction` fractional digits
-	Supported data types::: BigDecimal, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types; additionally supported by HV: any sub-type of `Number`
+	Supported data types::: BigDecimal, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types; additionally supported by HV: any sub-type of `Number` and `javax.money.MonetaryAmount`
 	Hibernate metadata impact::: Defines column precision and scale
 
 `@Email`:: Checks whether the specified character sequence is a valid email address. The optional parameters `regexp` and `flags` allow to specify an additional regular expression (including regular expression flags) which the email must match.

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/money/DigitsValidatorForMonetaryAmount.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/money/DigitsValidatorForMonetaryAmount.java
@@ -1,0 +1,62 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.constraintvalidators.bv.money;
+
+import java.lang.invoke.MethodHandles;
+import java.math.BigDecimal;
+import javax.money.MonetaryAmount;
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.constraints.Digits;
+
+import org.hibernate.validator.internal.util.logging.Log;
+import org.hibernate.validator.internal.util.logging.LoggerFactory;
+
+/**
+ * Validates that the number part of the {@code MonetaryAmount} being validated matches the pattern
+ * defined in the constraint.
+ *
+ * @author Dario Seidl
+ */
+public class DigitsValidatorForMonetaryAmount implements ConstraintValidator<Digits, MonetaryAmount> {
+
+	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
+
+	private int maxIntegerLength;
+	private int maxFractionLength;
+
+	@Override
+	public void initialize(Digits constraintAnnotation) {
+		this.maxIntegerLength = constraintAnnotation.integer();
+		this.maxFractionLength = constraintAnnotation.fraction();
+		validateParameters();
+	}
+
+	@Override
+	public boolean isValid(MonetaryAmount monetaryAmount, ConstraintValidatorContext constraintValidatorContext) {
+		//null values are valid
+		if ( monetaryAmount == null ) {
+			return true;
+		}
+
+		BigDecimal bigNum = monetaryAmount.getNumber().numberValueExact( BigDecimal.class );
+
+		int integerPartLength = bigNum.precision() - bigNum.scale();
+		int fractionPartLength = bigNum.scale() < 0 ? 0 : bigNum.scale();
+
+		return ( maxIntegerLength >= integerPartLength && maxFractionLength >= fractionPartLength );
+	}
+
+	private void validateParameters() {
+		if ( maxIntegerLength < 0 ) {
+			throw LOG.getInvalidLengthForIntegerPartException();
+		}
+		if ( maxFractionLength < 0 ) {
+			throw LOG.getInvalidLengthForFractionPartException();
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
@@ -95,6 +95,7 @@ import org.hibernate.validator.internal.constraintvalidators.bv.PatternValidator
 import org.hibernate.validator.internal.constraintvalidators.bv.money.CurrencyValidatorForMonetaryAmount;
 import org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMaxValidatorForMonetaryAmount;
 import org.hibernate.validator.internal.constraintvalidators.bv.money.DecimalMinValidatorForMonetaryAmount;
+import org.hibernate.validator.internal.constraintvalidators.bv.money.DigitsValidatorForMonetaryAmount;
 import org.hibernate.validator.internal.constraintvalidators.bv.money.MaxValidatorForMonetaryAmount;
 import org.hibernate.validator.internal.constraintvalidators.bv.money.MinValidatorForMonetaryAmount;
 import org.hibernate.validator.internal.constraintvalidators.bv.money.NegativeOrZeroValidatorForMonetaryAmount;
@@ -366,6 +367,11 @@ public class ConstraintHelper {
 					DecimalMinValidatorForCharSequence.class,
 					DecimalMinValidatorForMonetaryAmount.class
 			) );
+			putConstraints( tmpConstraints, Digits.class, Arrays.asList(
+					DigitsValidatorForCharSequence.class,
+					DigitsValidatorForNumber.class,
+					DigitsValidatorForMonetaryAmount.class
+			) );
 		}
 		else {
 			putConstraints( tmpConstraints, DecimalMax.class, Arrays.asList(
@@ -392,9 +398,12 @@ public class ConstraintHelper {
 					DecimalMinValidatorForShort.class,
 					DecimalMinValidatorForCharSequence.class
 			) );
+			putConstraints( tmpConstraints, Digits.class, Arrays.asList(
+					DigitsValidatorForCharSequence.class,
+					DigitsValidatorForNumber.class
+			) );
 		}
 
-		putConstraints( tmpConstraints, Digits.class, DigitsValidatorForCharSequence.class, DigitsValidatorForNumber.class );
 		putConstraint( tmpConstraints, Email.class, EmailValidator.class );
 
 		List<Class<? extends ConstraintValidator<Future, ?>>> futureValidators = new ArrayList<>( 18 );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/money/DigitsValidatorForMonetaryAmountTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/money/DigitsValidatorForMonetaryAmountTest.java
@@ -1,0 +1,117 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.constraintvalidators.bv.money;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import javax.money.CurrencyUnit;
+import javax.money.Monetary;
+import javax.validation.constraints.Digits;
+
+import org.hibernate.validator.internal.constraintvalidators.bv.money.DigitsValidatorForMonetaryAmount;
+import org.hibernate.validator.internal.util.annotation.ConstraintAnnotationDescriptor;
+import org.hibernate.validator.testutil.TestForIssue;
+
+import org.javamoney.moneta.Money;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Dario Seidl
+ */
+@TestForIssue(jiraKey = "HV-1723")
+public class DigitsValidatorForMonetaryAmountTest {
+
+	private ConstraintAnnotationDescriptor.Builder<Digits> descriptorBuilder;
+
+	@BeforeMethod
+	public void setUp() {
+		descriptorBuilder = new ConstraintAnnotationDescriptor.Builder<>( Digits.class );
+		descriptorBuilder.setMessage( "{validator.digits}" );
+	}
+
+	@Test
+	public void testIsValid() {
+		descriptorBuilder.setAttribute( "integer", 5 );
+		descriptorBuilder.setAttribute( "fraction", 2 );
+		Digits p = descriptorBuilder.build().getAnnotation();
+
+		DigitsValidatorForMonetaryAmount constraint = new DigitsValidatorForMonetaryAmount();
+		constraint.initialize( p );
+
+		CurrencyUnit currency = Monetary.getCurrency( "EUR" );
+
+		assertTrue( constraint.isValid( null, null ) );
+		assertTrue( constraint.isValid( Money.of( Byte.valueOf( "0" ), currency ), null ) );
+		assertTrue( constraint.isValid( Money.of( Double.valueOf( "500.2" ), currency ), null ) );
+
+		assertTrue( constraint.isValid( Money.of( new BigDecimal( "-12345.12" ), currency ), null ) );
+		assertFalse( constraint.isValid( Money.of( new BigDecimal( "-123456.12" ), currency ), null ) );
+		assertFalse( constraint.isValid( Money.of( new BigDecimal( "-123456.123" ), currency ), null ) );
+		assertFalse( constraint.isValid( Money.of( new BigDecimal( "-12345.123" ), currency ), null ) );
+		assertFalse( constraint.isValid( Money.of( new BigDecimal( "12345.123" ), currency ), null ) );
+
+		assertTrue( constraint.isValid( Money.of( Float.valueOf( "-000000000.22" ), currency ), null ) );
+		assertFalse( constraint.isValid( Money.of( Integer.valueOf( "256874" ), currency ), null ) );
+		assertFalse( constraint.isValid( Money.of( Double.valueOf( "12.0001" ), currency ), null ) );
+	}
+
+	@Test
+	public void testIsValidZeroLength() {
+		descriptorBuilder.setAttribute( "integer", 0 );
+		descriptorBuilder.setAttribute( "fraction", 0 );
+		Digits p = descriptorBuilder.build().getAnnotation();
+
+		DigitsValidatorForMonetaryAmount constraint = new DigitsValidatorForMonetaryAmount();
+		constraint.initialize( p );
+
+		CurrencyUnit currency = Monetary.getCurrency( "EUR" );
+
+		assertTrue( constraint.isValid( null, null ) );
+		assertFalse( constraint.isValid( Money.of( Byte.valueOf( "0" ), currency ), null ) );
+		assertFalse( constraint.isValid( Money.of( Double.valueOf( "500.2" ), currency ), null ) );
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testNegativeIntegerLength() {
+		descriptorBuilder.setAttribute( "integer", -1 );
+		descriptorBuilder.setAttribute( "fraction", 1 );
+		Digits p = descriptorBuilder.build().getAnnotation();
+
+		DigitsValidatorForMonetaryAmount constraint = new DigitsValidatorForMonetaryAmount();
+		constraint.initialize( p );
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class)
+	public void testNegativeFractionLength() {
+		descriptorBuilder.setAttribute( "integer", 1 );
+		descriptorBuilder.setAttribute( "fraction", -1 );
+		Digits p = descriptorBuilder.build().getAnnotation();
+
+		DigitsValidatorForMonetaryAmount constraint = new DigitsValidatorForMonetaryAmount();
+		constraint.initialize( p );
+	}
+
+	@Test
+	public void testTrailingZerosAreTrimmed() {
+		descriptorBuilder.setAttribute( "integer", 12 );
+		descriptorBuilder.setAttribute( "fraction", 3 );
+		Digits p = descriptorBuilder.build().getAnnotation();
+
+		DigitsValidatorForMonetaryAmount constraint = new DigitsValidatorForMonetaryAmount();
+		constraint.initialize( p );
+
+		CurrencyUnit currency = Monetary.getCurrency( "EUR" );
+
+		assertTrue( constraint.isValid( Money.of( 0.001d, currency ), null ) );
+		assertTrue( constraint.isValid( Money.of( 0.00100d, currency ), null ) );
+		assertFalse( constraint.isValid( Money.of( 0.0001d, currency ), null ) );
+	}
+
+}


### PR DESCRIPTION
Like the money validators for `DecimalMin`/`DecimalMax`, this new validator for `Digits` obtains a `BigDecimal` from the `MonetaryAmount` and validates that.

https://hibernate.atlassian.net/browse/HV-1723