### PR TITLE
HV-1732 Change tarLongFileMode to posix for assembly building

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -166,7 +166,7 @@
                         <descriptor>${basedir}/src/main/assembly/dist.xml</descriptor>
                     </descriptors>
                     <finalName>hibernate-validator-${project.version}</finalName>
-                    <tarLongFileMode>gnu</tarLongFileMode>
+                    <tarLongFileMode>posix</tarLongFileMode>
                     <outputDirectory>${project.build.directory}/dist/</outputDirectory>
                 </configuration>
                 <executions>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1732

The currently selected `gnu` results in the following errors in environments with large user ids:
```
Execution make-assembly of goal org.apache.maven.plugins:maven-assembly-plugin:3.1.0:single failed: user id '...' is too big 
```