### PR TITLE
Move master aka 6.1 to Jakarta Bean Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 
 ## What is it?
 
-This is the reference implementation of [JSR-380 - Bean Validation 2.0](http://beanvalidation.org/).
-Bean Validation defines a metadata model and API for JavaBean as well as method validation.
+This is the reference implementation of [Jakarta Bean Validation 2.0](http://beanvalidation.org/).
+Jakarta Bean Validation defines a metadata model and API for JavaBean as well as method validation.
 The default metadata source are annotations, with the ability to override and extend
 the metadata through the use of XML validation descriptors.
 
@@ -47,7 +47,7 @@ Logging will delegate any log requests to that provider.
            <version>3.0.1-b09</version>
         </dependency>
 
-* Bean Validation defines integration points with [CDI](http://jcp.org/en/jsr/detail?id=346). If your application runs
+* Jakarta Bean Validation defines integration points with [CDI](http://jcp.org/en/jsr/detail?id=346). If your application runs
 in an environment which does not provide this integration out of the box, you may use the Hibernate Validator CDI portable
 extension by adding the following dependency:
 
@@ -63,7 +63,7 @@ documentation](https://docs.jboss.org/hibernate/stable/validator/reference/en-US
 
 ## Licensing
 
-Hibernate Validator itself as well as the Bean Validation API and TCK are all provided and distributed under
+Hibernate Validator itself as well as the Jakarta Bean Validation API and TCK are all provided and distributed under
 the Apache Software License 2.0. Refer to license.txt for more information.
 
 ## Build from Source
@@ -84,7 +84,7 @@ We provide a `.travis.yml` file so that you can enable CI for your GitHub fork b
 ## Hibernate Validator URLs
 
 * [Home Page](http://hibernate.org/validator/)
-* [Bean Validation Home](http://beanvalidation.org/)
+* [Jakarta Bean Validation Home](http://beanvalidation.org/)
 * [Downloads](http://hibernate.org/validator/downloads/)
 * [Mailing Lists](http://hibernate.org/community/)
 * [Issue Tracking](https://hibernate.atlassian.net/browse/HV)

--- a/annotation-processor/src/main/resources/org/hibernate/validator/ap/ValidationProcessorMessages.properties
+++ b/annotation-processor/src/main/resources/org/hibernate/validator/ap/ValidationProcessorMessages.properties
@@ -48,6 +48,6 @@ INVALID_GROUP_SEQUENCE_VALUE_NOT_INTERFACES=Invalid @GroupSequence configuration
 INVALID_GROUP_SEQUENCE_VALUE_CYCLIC_DEFINITION=Invalid @GroupSequence configuration. The defined group sequence should be expandable (no cyclic definition).
 INVALID_GROUP_SEQUENCE_VALUE_MISSING_HOSTING_BEAN_DECLARATION=Invalid default group sequence redefinition. The value should contain the hosting bean class.
 INVALID_GROUP_SEQUENCE_VALUE_MULTIPLE_DECLARATIONS_OF_THE_SAME_INTERFACE=Invalid @GroupSequence configuration. {0} was already declared in this group sequence.
-INVALID_GROUP_SEQUENCE_EXTEND_INTERFACES=Having group sequences extending other interfaces is discouraged by the Bean Validation specification.
+INVALID_GROUP_SEQUENCE_EXTEND_INTERFACES=Having group sequences extending other interfaces is discouraged by the Jakarta Bean Validation specification.
 MIXED_LIST_AND_DIRECT_ANNOTATION_DECLARATION=Constraint @{0} is declared both directly and as a list. Which is not allowed.
 INVALID_PAYLOAD_UNWRAPPING_VALUE_ANNOTATION_PARAMETERS=Having both Unwrapping.Unwrap and Unwrapping.Skip in the payload is not allowed.

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testutil/CompilerTestHelper.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testutil/CompilerTestHelper.java
@@ -50,7 +50,7 @@ public class CompilerTestHelper {
 
 		HIBERNATE_VALIDATOR( "hibernate-validator.jar" ),
 
-		VALIDATION_API( "validation-api.jar" ),
+		VALIDATION_API( "jakarta.validation-api.jar" ),
 
 		JODA_TIME( "joda-time.jar" ),
 

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -152,7 +152,7 @@
                             <archive>
                                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                                 <manifestEntries>
-                                    <Specification-Title>Bean Validation</Specification-Title>
+                                    <Specification-Title>Jakarta Bean Validation</Specification-Title>
                                     <Specification-Version>2.0</Specification-Version>
                                     <Automatic-Module-Name>${hibernate-validator-cdi.module-name}</Automatic-Module-Name>
                                 </manifestEntries>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -33,18 +33,18 @@
             <artifactId>hibernate-validator</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.interceptor</groupId>
-            <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -63,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -45,7 +45,7 @@
 
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
 
         <!-- Need to list out optional dependencies here again in order to include them via assembly dependency set -->
@@ -54,8 +54,8 @@
             <artifactId>log4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
@@ -74,16 +74,16 @@
             <artifactId>paranamer</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.interceptor</groupId>
-            <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -33,10 +33,10 @@
         <dependencySet>
             <outputDirectory>dist/lib/required</outputDirectory>
             <includes>
-                <include>javax.validation:validation-api</include>
+                <include>jakarta.validation:jakarta.validation-api</include>
                 <include>org.jboss.logging:jboss-logging</include>
                 <include>com.fasterxml:classmate</include>
-                <include>org.glassfish:javax.el</include>
+                <include>org.glassfish:jakarta.el</include>
             </includes>
         </dependencySet>
         <dependencySet>
@@ -44,7 +44,7 @@
             <includes>
                 <include>log4j:log4j</include>
                 <include>joda-time:joda-time</include>
-                <include>javax.persistence:javax.persistence-api</include>
+                <include>jakarta.persistence:jakarta.persistence-api</include>
                 <include>org.jsoup:jsoup</include>
                 <include>com.thoughtworks.paranamer:paranamer</include>
             </includes>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -54,7 +54,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -63,8 +63,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -99,8 +99,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>javax.annotation-api</artifactId>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -265,10 +265,10 @@
                         <osgi-integrationtest-sourcedir>${asciidoctor.osgi-integrationtest-source-dir}</osgi-integrationtest-sourcedir>
 
                         <hvVersion>${project.version}</hvVersion>
-                        <bvVersion>${version.javax.validation}</bvVersion>
+                        <bvVersion>${version.jakarta.validation-api}</bvVersion>
                         <jbossLoggingVersion>${version.org.jboss.logging.jboss-logging}</jbossLoggingVersion>
                         <classmateVersion>${version.com.fasterxml.classmate}</classmateVersion>
-                        <javaxElVersion>${version.org.glassfish.javax.el}</javaxElVersion>
+                        <javaxElVersion>${version.org.glassfish.jakarta.el}</javaxElVersion>
 
                         <wildflyVersion>${version.wildfly}</wildflyVersion>
                         <wildflySecondaryVersion>${version.wildfly.secondary}</wildflySecondaryVersion>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -31,7 +31,7 @@
         <asciidoctor.osgi-integrationtest-source-dir>${basedir}/../osgi/integrationtest/src/test/java</asciidoctor.osgi-integrationtest-source-dir>
 
         <html.meta.description>Hibernate Validator, Annotation based constraints for your domain model - Reference Documentation</html.meta.description>
-        <html.meta.keywords>hibernate, validator, hibernate validator, validation, bean validation</html.meta.keywords>
+        <html.meta.keywords>hibernate, validator, hibernate validator, validation, jakarta bean validation, bean validation</html.meta.keywords>
         <html.meta.project-key>validator</html.meta.project-key>
         <html.google-analytics.id>UA-45270411-3</html.google-analytics.id>
         <html.google-analytics.tag-manager.id>GTM-NJWS5L</html.google-analytics.tag-manager.id>
@@ -268,7 +268,7 @@
                         <bvVersion>${version.jakarta.validation-api}</bvVersion>
                         <jbossLoggingVersion>${version.org.jboss.logging.jboss-logging}</jbossLoggingVersion>
                         <classmateVersion>${version.com.fasterxml.classmate}</classmateVersion>
-                        <javaxElVersion>${version.org.glassfish.jakarta.el}</javaxElVersion>
+                        <jakartaElVersion>${version.org.glassfish.jakarta.el}</jakartaElVersion>
 
                         <wildflyVersion>${version.wildfly}</wildflyVersion>
                         <wildflySecondaryVersion>${version.wildfly.secondary}</wildflySecondaryVersion>

--- a/documentation/src/main/asciidoc/ch01.asciidoc
+++ b/documentation/src/main/asciidoc/ch01.asciidoc
@@ -1,7 +1,7 @@
 [[validator-gettingstarted]]
 == Getting started
 
-This chapter will show you how to get started with Hibernate Validator, the reference implementation (RI) of Bean Validation. For the following quick-start you need:
+This chapter will show you how to get started with Hibernate Validator, the reference implementation (RI) of Jakarta Bean Validation. For the following quick-start you need:
 
 * A JDK 8
 * http://maven.apache.org/[Apache Maven]
@@ -26,18 +26,18 @@ your __pom.xml__:
 ----
 ====
 
-This transitively pulls in the dependency to the Bean Validation API
-(`javax.validation:validation-api:{bvVersion}`).
+This transitively pulls in the dependency to the Jakarta Bean Validation API
+(`jakarta.validation:jakarta.validation-api:{bvVersion}`).
 
 [[validator-gettingstarted-uel]]
 ==== Unified EL
 
-Hibernate Validator requires an implementation of the Unified Expression Language
-(http://jcp.org/en/jsr/detail?id=341[JSR 341]) for evaluating dynamic expressions in constraint
+Hibernate Validator requires an implementation of https://projects.eclipse.org/projects/ee4j.el[Jakarta Expression Language]
+for evaluating dynamic expressions in constraint
 violation messages (see <<section-message-interpolation>>). When your application runs in a Java EE
 container such as JBoss AS, an EL implementation is already provided by the container. In a Java SE
 environment, however, you have to add an implementation as dependency to your POM file. For instance
-you can add the following dependency to use the JSR 341 https://javaee.github.io/uel-ri/[reference
+you can add the following dependency to use the Jakarta EL https://github.com/eclipse-ee4j/el-ri[reference
 implementation]:
 
 .Maven dependencies for Unified EL reference implementation
@@ -47,8 +47,8 @@ implementation]:
 ----
 <dependency>
     <groupId>org.glassfish</groupId>
-    <artifactId>javax.el</artifactId>
-    <version>{javaxElVersion}</version>
+    <artifactId>jakarta.el</artifactId>
+    <version>{jakartaElVersion}</version>
 </dependency>
 ----
 ====
@@ -57,14 +57,15 @@ implementation]:
 ====
 For environments where one cannot provide a EL implementation Hibernate Validator is offering a
 <<non-el-message-interpolator>>. However, the use of this interpolator
-is not Bean Validation specification compliant.
+is not Jakarta Bean Validation specification compliant.
 ====
 
 [[section-getting-started-cdi]]
 ==== CDI
 
-Bean Validation defines integration points with CDI (Contexts and Dependency Injection for Java ^TM^
-EE, http://jcp.org/en/jsr/detail?id=346[JSR 346]). If your application runs in an
+Jakarta Bean Validation defines integration points with CDI
+(https://projects.eclipse.org/projects/ee4j.cdi[Contexts and Dependency Injection for Jakarta EE]).
+If your application runs in an
 environment which does not provide this integration out of the box, you may use the Hibernate
 Validator CDI portable extension by adding the following Maven dependency to your POM:
 
@@ -82,14 +83,14 @@ Validator CDI portable extension by adding the following Maven dependency to you
 ====
 
 Note that adding this dependency is usually not required for applications running on a Java EE
-application server. You can learn more about the integration of Bean Validation and CDI in
+application server. You can learn more about the integration of Jakarta Bean Validation and CDI in
 <<section-integration-with-cdi>>.
 
 [[section-getting-started-security-manager]]
 ==== Running with a security manager
 
 Hibernate Validator supports running with a {javaTechnotesBaseUrl}/guides/security/index.html[security manager] being enabled.
-To do so, you must assign several permissions to the code bases of Hibernate Validator, the Bean Validation API, Classmate and JBoss Logging and also to the code base calling Bean Validation.
+To do so, you must assign several permissions to the code bases of Hibernate Validator, the Jakarta Bean Validation API, Classmate and JBoss Logging and also to the code base calling Jakarta Bean Validation.
 The following shows how to do this via a {javaTechnotesBaseUrl}/guides/security/PolicyFiles.html[policy file] as processed by the Java default policy implementation:
 
 .Policy file for using Hibernate Validator with a security manager
@@ -108,7 +109,7 @@ grant codeBase "file:path/to/hibernate-validator-{hvVersion}.jar" {
     permission java.util.PropertyPermission "mapAnyUriToUri", "read";
 };
 
-grant codeBase "file:path/to/validation-api-{bvVersion}.jar" {
+grant codeBase "file:path/to/jakarta.validation-api-{bvVersion}.jar" {
     permission java.io.FilePermission "path/to/hibernate-validator-{hvVersion}.jar", "read";
 };
 
@@ -130,7 +131,7 @@ grant codeBase "file:path/to/validation-caller-x.y.z.jar" {
 ==== Updating Hibernate Validator in WildFly
 
 The http://wildfly.org/[WildFly application server] contains Hibernate Validator out of the box.
-In order to update the server modules for Bean Validation API and Hibernate Validator to the latest and greatest, the patch mechanism of WildFly can be used.
+In order to update the server modules for Jakarta Bean Validation API and Hibernate Validator to the latest and greatest, the patch mechanism of WildFly can be used.
 
 You can download the patch file from http://sourceforge.net/projects/hibernate/files/hibernate-validator[SourceForge] or from Maven Central using the following dependency:
 
@@ -198,7 +199,7 @@ There are no JPMS module descriptors provided yet, but Hibernate Validator is us
 
 These are the module names as declared using the `Automatic-Module-Name` header:
 
-* Bean Validation API: `java.validation`
+* Jakarta Bean Validation API: `java.validation`
 * Hibernate Validator core: `org.hibernate.validator`
 * Hibernate Validator CDI extension: `org.hibernate.validator.cdi`
 * Hibernate Validator test utilities: `org.hibernate.validator.testutils`
@@ -209,14 +210,14 @@ These module names are preliminary and may be changed when providing real module
 [WARNING]
 ====
 When using Hibernate Validator with CDI, be careful to not enable the `java.xml.ws.annotation` module of the JDK.
-This module contains a subset of the JSR 250 API ("Commons Annotations"), but some annotations such as `javax.annotation.Priority` are missing.
+This module contains a subset of Jakarta Annotations, but some annotations such as `javax.annotation.Priority` are missing.
 This causes the method validation interceptor of Hibernate Validator to not be registered, i.e. method validation won't work.
 
-Instead, add the full JSR 250 API to the unnamed module (i.e. the classpath), e.g. by pulling in the _javax.annotation:javax.annotation-api_ dependency
-(there already is a transitive dependency to the JSR 250 API when depending on _org.hibernate.validator:hibernate-validator-cdi_).
+Instead, add the full Jakarta Annotations API to the unnamed module (i.e. the classpath), e.g. by pulling in the _jakarta.annotation:jakarta.annotation-api_ dependency
+(there already is a transitive dependency to the Jakarta Annotations API when depending on _org.hibernate.validator:hibernate-validator-cdi_).
 
 If you need to enable the `java.xml.ws.annotation` module for some reason, you should patch it with the contents of the full API
-by appending `--patch-module java.xml.ws.annotation=/path/to/complete-jsr250-api.jar` to your _java_ invocation.
+by appending `--patch-module java.xml.ws.annotation=/path/to/complete-jakarta.annotation-api.jar` to your _java_ invocation.
 ====
 
 [[validator-gettingstarted-createmodel]]
@@ -284,11 +285,11 @@ code.
 [[validator-gettingstarted-whatsnext]]
 === Where to go next?
 
-That concludes the 5 minutes tour through the world of Hibernate Validator and Bean Validation.
+That concludes the 5 minutes tour through the world of Hibernate Validator and Jakarta Bean Validation.
 Continue exploring the code examples or look at further examples referenced in
 <<validator-further-reading>>.
 
 To learn more about the validation of beans and properties, just continue reading
-<<chapter-bean-constraints>>. If you are interested in using Bean Validation for the validation of
+<<chapter-bean-constraints>>. If you are interested in using Jakarta Bean Validation for the validation of
 method pre- and postcondition refer to <<chapter-method-constraints>>. In case your application has
 specific validation requirements have a look at <<validator-customconstraints>>.

--- a/documentation/src/main/asciidoc/ch02.asciidoc
+++ b/documentation/src/main/asciidoc/ch02.asciidoc
@@ -12,7 +12,7 @@ If you are interested in applying constraints to method parameters and return va
 [[section-declaring-bean-constraints]]
 === Declaring bean constraints
 
-Constraints in Bean Validation are expressed via Java annotations. In this section you will learn
+Constraints in Jakarta Bean Validation are expressed via Java annotations. In this section you will learn
 how to enhance an object model with these annotations. There are four types of bean constraints:
 
 * field constraints
@@ -23,7 +23,7 @@ how to enhance an object model with these annotations. There are four types of b
 [NOTE]
 ====
 Not all constraints can be placed on all of these levels. In fact, none of the default constraints
-defined by Bean Validation can be placed at class level. The `java.lang.annotation.Target` annotation
+defined by Jakarta Bean Validation can be placed at class level. The `java.lang.annotation.Target` annotation
 in the constraint annotation itself determines on which elements a constraint can be placed. See
 <<validator-customconstraints>> for more information.
 ====
@@ -95,7 +95,7 @@ It is possible to specify constraints directly on the type argument of a
 parameterized type: these constraints are called container element constraints.
 
 This requires that `ElementType.TYPE_USE` is specified via `@Target`
-in the constraint definition. As of Bean Validation 2.0, built-in Bean Validation as well as
+in the constraint definition. As of Jakarta Bean Validation 2.0, built-in Jakarta Bean Validation as well as
 Hibernate Validator specific constraints specify `ElementType.TYPE_USE` and can be used
 directly in this context.
 
@@ -332,7 +332,7 @@ evaluated in addition to the `@NotNull` constraint from the superclass.
 [[section-object-graph-validation]]
 ==== Object graphs
 
-The Bean Validation API does not only allow to validate single class instances but also complete
+The Jakarta Bean Validation API does not only allow to validate single class instances but also complete
 object graphs (cascaded validation). To do so, just annotate a field or property representing a
 reference to another object with `@Valid` as demonstrated in <<example-cascaded-validation>>.
 
@@ -410,7 +410,7 @@ as it is more expressive.
 [[section-validating-bean-constraints]]
 === Validating bean constraints
 
-The `Validator` interface is the most important object in Bean Validation. The next section shows how
+The `Validator` interface is the most important object in Jakarta Bean Validation. The next section shows how
 to obtain a `Validator` instance. Afterwards you'll learn how to use the different methods of the
 `Validator` interface.
 
@@ -496,7 +496,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter02/validation
 ====
 
 
-`Validator#validateProperty()` is for example used in the integration of Bean Validation into JSF 2
+`Validator#validateProperty()` is for example used in the integration of Jakarta Bean Validation into JSF 2
 (see <<section-presentation-layer>>) to perform a validation of the values entered into a form
 before they are propagated to the model.
 
@@ -539,28 +539,28 @@ The returned `Path` is composed of ``Node``s describing the path to the element.
 
 More information about the structure of the `Path` and the various types of ``Node``s can be found in
 {bvSpecUrl}#validationapi-constraintviolation[the `ConstraintViolation` section] of the
-Bean Validation specification.
+Jakarta Bean Validation specification.
 
 [[section-builtin-constraints]]
 === Built-in constraints
 
 Hibernate Validator comprises a basic set of commonly used constraints. These are foremost the
-constraints defined by the Bean Validation specification (see <<validator-defineconstraints-spec>>).
+constraints defined by the Jakarta Bean Validation specification (see <<validator-defineconstraints-spec>>).
 Additionally, Hibernate Validator provides useful custom constraints (see
 <<validator-defineconstraints-hv-constraints>>).
 
 [[validator-defineconstraints-spec]]
-==== Bean Validation constraints
+==== Jakarta Bean Validation constraints
 
-Below you can find a list of all constraints specified in the Bean Validation API.
-All these constraints apply to the field/property level, there are no class-level constraints defined in the Bean Validation specification.
+Below you can find a list of all constraints specified in the Jakarta Bean Validation API.
+All these constraints apply to the field/property level, there are no class-level constraints defined in the Jakarta Bean Validation specification.
 If you are using the Hibernate object-relational mapper, some of the constraints are taken into account when creating the DDL for your model (see "Hibernate metadata impact").
 
 [NOTE]
 ====
 Hibernate Validator allows some constraints to be applied to more data types than required by the
-Bean Validation specification (e.g. `@Max` can be applied to strings). Relying on this feature can
-impact portability of your application between Bean Validation providers.
+Jakarta Bean Validation specification (e.g. `@Max` can be applied to strings). Relying on this feature can
+impact portability of your application between Jakarta Bean Validation providers.
 ====
 
 `@AssertFalse`:: Checks that the annotated element is false
@@ -654,13 +654,13 @@ impact portability of your application between Bean Validation providers.
 [NOTE]
 ====
 On top of the parameters listed above each constraint has the parameters
-message, groups and payload. This is a requirement of the Bean Validation specification.
+message, groups and payload. This is a requirement of the Jakarta Bean Validation specification.
 ====
 
 [[validator-defineconstraints-hv-constraints]]
 ==== Additional constraints
 
-In addition to the constraints defined by the Bean Validation API, Hibernate Validator provides several useful custom constraints which are listed below.
+In addition to the constraints defined by the Jakarta Bean Validation API, Hibernate Validator provides several useful custom constraints which are listed below.
 With one exception also these constraints apply to the field/property level, only `@ScriptAssert` is a class-level constraint.
 
 `@CreditCardNumber(ignoreNonDigitCharacters=)`:: Checks that the annotated character sequence passes the Luhn checksum test. Note, this validation aims to check for user mistakes, not credit card validity! See also http://www.dirigodev.com/blog/ecommerce/anatomy-of-a-credit-card-number/[Anatomy of a credit card number]. `ignoreNonDigitCharacters` allows to ignore non digit characters. The default is `false`.
@@ -771,7 +771,7 @@ Hibernate Validator!
 
 [TIP]
 ====
-In some cases neither the Bean Validation constraints nor the custom constraints provided by
+In some cases neither the Jakarta Bean Validation constraints nor the custom constraints provided by
 Hibernate Validator will fulfill your requirements. In this case you can easily write your own
 constraint. You can find more information in <<validator-customconstraints>>.
 ====

--- a/documentation/src/main/asciidoc/ch03.asciidoc
+++ b/documentation/src/main/asciidoc/ch03.asciidoc
@@ -3,7 +3,7 @@
 
 As of Bean Validation 1.1, constraints can not only be applied to JavaBeans and their properties,
 but also to the parameters and return values of the methods and constructors of any Java type. That
-way Bean Validation constraints can be used to specify
+way Jakarta Bean Validation constraints can be used to specify
 
 * the preconditions that must be satisfied by the caller before a method or constructor may be
 invoked (by applying constraints to the parameters of an executable)
@@ -232,7 +232,7 @@ fail to satisfy these preconditions as is not aware of them. The rules of behavi
 also known as the http://en.wikipedia.org/wiki/Liskov_substitution_principle[Liskov
 substitution principle].
 
-The Bean Validation specification implements the first rule by disallowing parameter constraints on
+The Jakarta Bean Validation specification implements the first rule by disallowing parameter constraints on
 methods which override or implement a method declared in a supertype (superclass or interface).
 <<example-illegal-parameter-constraints>> shows a violation of this rule.
 

--- a/documentation/src/main/asciidoc/ch04.asciidoc
+++ b/documentation/src/main/asciidoc/ch04.asciidoc
@@ -1,7 +1,7 @@
 [[chapter-message-interpolation]]
 == Interpolating constraint error messages
 
-Message interpolation is the process of creating error messages for violated Bean Validation
+Message interpolation is the process of creating error messages for violated Jakarta Bean Validation
 constraints. In this chapter you will learn how such messages are defined and resolved and how you
 can plug in custom message interpolators in case the default algorithm is not sufficient for your
 requirements.
@@ -42,7 +42,7 @@ this bundle, such as _$$ValidationMessages_en_US.properties$$_. By default, the 
 (`Locale#getDefault()`) will be used when looking up messages in the bundle.
 
 . Resolve any message parameters by using them as key for a resource bundle containing the standard
-error messages for the built-in constraints as defined in Appendix B of the Bean Validation
+error messages for the built-in constraints as defined in Appendix B of the Jakarta Bean Validation
 specification. In the case of Hibernate Validator, this bundle is named
 `org.hibernate.validator.ValidationMessages`. If this step triggers a replacement, step 1 is executed
 again, otherwise step 3 is applied.
@@ -61,7 +61,7 @@ Unified EL in error messages.
 ====
 You can find the formal definition of the interpolation algorithm in section
 {bvSpecUrl}#validationapi-message-defaultmessageinterpolation-resolutionalgorithm[6.3.1.1]
-of the Bean Validation specification.
+of the Jakarta Bean Validation specification.
 ====
 
 [[section-special-characters]]
@@ -79,8 +79,8 @@ escaped if you want to use them literally. The following rules apply:
 [[section-interpolation-with-message-expressions]]
 ==== Interpolation with message expressions
 
-As of Hibernate Validator 5 (Bean Validation 1.1) it is possible to use the Unified Expression
-Language (as defined by link:http://jcp.org/en/jsr/detail?id=341[JSR 341]) in constraint
+As of Hibernate Validator 5 (Bean Validation 1.1) it is possible to use the
+https://projects.eclipse.org/projects/ee4j.el[Jakarta Expression Language] in constraint
 violation messages. This allows to define error messages based on conditional logic and also enables
 advanced formatting options. The validation engine makes the following objects available in the EL
 context:
@@ -111,7 +111,7 @@ Validating an invalid `Car` instance yields constraint violations with the messa
 assertions in <<example-expected-error-messages>>:
 
 * the `@NotNull` constraint on the `manufacturer` field causes the error message "must not be null", as
-this is the default message defined by the Bean Validation specification and no specific descriptor
+this is the default message defined by the Jakarta Bean Validation specification and no specific descriptor
 is given in the message attribute
 
 * the `@Size` constraint on the `licensePlate` field shows the interpolation of message parameters
@@ -157,7 +157,7 @@ final implementation to the default interpolator, which can be obtained via
 `Configuration#getDefaultMessageInterpolator()`.
 
 In order to use a custom message interpolator it must be registered either by configuring it in the
-Bean Validation XML descriptor _META-INF/validation.xml_ (see
+Jakarta Bean Validation XML descriptor _META-INF/validation.xml_ (see
 <<section-configuration-validation-xml>>) or by passing it when bootstrapping a `ValidatorFactory` or
 `Validator` (see <<section-validator-factory-message-interpolator>> and
 <<section-configuring-validator>>, respectively).

--- a/documentation/src/main/asciidoc/ch06.asciidoc
+++ b/documentation/src/main/asciidoc/ch06.asciidoc
@@ -1,7 +1,7 @@
 [[validator-customconstraints]]
 == Creating custom constraints
 
-The Bean Validation API defines a whole set of standard constraint annotations such as `@NotNull`,
+The Jakarta Bean Validation API defines a whole set of standard constraint annotations such as `@NotNull`,
 `@Size` etc. In cases where these built-in constraints are not sufficient, you can easily create
 custom constraints tailored to your specific validation requirements.
 
@@ -46,7 +46,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter06/CheckCase.
 ====
 
 An annotation type is defined using the `@interface` keyword. All attributes of an annotation type are
-declared in a method-like manner. The specification of the Bean Validation API demands, that any
+declared in a method-like manner. The specification of the Jakarta Bean Validation API demands, that any
 constraint annotation defines:
 
 * an attribute `message` that returns the default key for creating error messages in case the
@@ -55,7 +55,7 @@ constraint is violated
 * an attribute `groups` that allows the specification of validation groups, to which this constraint
 belongs (see <<chapter-groups>>). This must default to an empty array of type Class<?>.
 
-* an attribute `payload` that can be used by clients of the Bean Validation API to assign custom
+* an attribute `payload` that can be used by clients of the Jakarta Bean Validation API to assign custom
 payload objects to a constraint. This attribute is not used by the API itself. An example for a
 custom payload could be the definition of a severity:
 +
@@ -109,14 +109,14 @@ same place, usually with a different configuration. `List` is the containing ann
 
 This containing annotation type named `List` is also shown in the example. It allows to specify several
 `@CheckCase` annotations on the same element, e.g. with different validation groups and messages.
-While another name could be used, the Bean Validation specification recommends to use the name
+While another name could be used, the Jakarta Bean Validation specification recommends to use the name
 `List` and make the annotation an inner annotation of the corresponding constraint type.
 
 [[section-constraint-validator]]
 ==== The constraint validator
 
 Having defined the annotation, you need to create a constraint validator, which is able to validate
-elements with a `@CheckCase` annotation. To do so, implement the Bean Validation interface `ConstraintValidator`
+elements with a `@CheckCase` annotation. To do so, implement the Jakarta Bean Validation interface `ConstraintValidator`
 as shown below:
 
 [[example-constraint-validator]]
@@ -140,7 +140,7 @@ validator as shown in the example.
 
 The `isValid()` method contains the actual validation logic. For `@CheckCase` this is the check whether
 a given string is either completely lower case or upper case, depending on the case mode retrieved
-in `initialize()`. Note that the Bean Validation specification recommends to consider null values as
+in `initialize()`. Note that the Jakarta Bean Validation specification recommends to consider null values as
 being valid. If `null` is not a valid value for an element, it should be annotated with `@NotNull`
 explicitly.
 
@@ -183,7 +183,7 @@ sensitive data.
 
 If you need to integrate user input, you should:
 
- * either escape it by using the http://beanvalidation.org/2.0/spec/#validationapi-message-defaultmessageinterpolation[Bean Validation message interpolation escaping rules];
+ * either escape it by using the http://beanvalidation.org/2.0/spec/#validationapi-message-defaultmessageinterpolation[Jakarta Bean Validation message interpolation escaping rules];
  * or, even better, <<section-hibernateconstraintvalidatorcontext,pass it as message parameters or expression variables>> by unwrapping the context to `HibernateConstraintValidatorContext`.
 ====
 
@@ -206,7 +206,7 @@ The `initialize()` method of `HibernateConstraintValidator` takes two parameters
    information, such as the clock provider or the temporal validation tolerance.
 
 This extension is marked as incubating so it might be subject to change.
-The plan is to standardize it and to include it in Bean Validation in the future.
+The plan is to standardize it and to include it in Jakarta Bean Validation in the future.
 
 The example below shows how to base your validators on `HibernateConstraintValidator`:
 
@@ -384,7 +384,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter06/custompath
 [[section-cross-parameter-constraints]]
 === Cross-parameter constraints
 
-Bean Validation distinguishes between two different kinds of constraints.
+Jakarta Bean Validation distinguishes between two different kinds of constraints.
 
 Generic constraints (which have been discussed so far) apply to the annotated element, e.g. a type,
 field, container element, method parameter or return value etc.

--- a/documentation/src/main/asciidoc/ch07.asciidoc
+++ b/documentation/src/main/asciidoc/ch07.asciidoc
@@ -27,7 +27,7 @@ Built-in value extractors are present for all the following container types:
 
 The complete list of built-in value extractors with all the details on how they
 behave can be found in the
-{bvSpecUrl}#valueextractordefinition-builtinvalueextractors[Bean Validation specification].
+{bvSpecUrl}#valueextractordefinition-builtinvalueextractors[Jakarta Bean Validation specification].
 
 === Implementing a `ValueExtractor`
 
@@ -178,7 +178,7 @@ annotation allows to provide this information to the validation engine.
 Then you have to tell the validation engine that the `Min` constraint you want to
 add to the `OptionalInt` property relates to the wrapped value and not the wrapper.
 
-Bean Validation provides the `Unwrapping.Unwrap` payload for this situation:
+Jakarta Bean Validation provides the `Unwrapping.Unwrap` payload for this situation:
 
 [[example-valueextraction-optionalint-unwrapping]]
 .Using `Unwrapping.Unwrap` payload
@@ -319,7 +319,7 @@ given at lower priorities.
 
 In most cases, you should not have to worry about this but, if you are overriding
 existing value extractors, you can find a detailed description of the value
-extractors resolution algorithms in the Bean Validation specification:
+extractors resolution algorithms in the Jakarta Bean Validation specification:
 
  * for {bvSpecUrl}#constraintdeclarationvalidationprocess-validationroutine-valueextractorresolution-algorithm-constraints[container element constraints],
  * for {bvSpecUrl}#constraintdeclarationvalidationprocess-validationroutine-valueextractorresolution-algorithm-cascaded[cascaded validation],

--- a/documentation/src/main/asciidoc/ch08.asciidoc
+++ b/documentation/src/main/asciidoc/ch08.asciidoc
@@ -1,9 +1,9 @@
 [[chapter-xml-configuration]]
 == Configuring via XML
 
-So far we have used the default configuration source for Bean Validation, namely annotations.
+So far we have used the default configuration source for Jakarta Bean Validation, namely annotations.
 However, there also exist two kinds of XML descriptors allowing configuration via XML. The first
-descriptor describes general Bean Validation behaviour and is provided as _META-INF/validation.xml_.
+descriptor describes general Jakarta Bean Validation behaviour and is provided as _META-INF/validation.xml_.
 The second one describes constraint declarations and closely matches the constraint declaration
 approach via annotations. Let's have a look at these two document types.
 
@@ -14,7 +14,7 @@ http://xmlns.jcp.org/xml/ns/validation/configuration and
 http://xmlns.jcp.org/xml/ns/validation/mapping.
 
 More information about the XML schemas can be found on the
-http://beanvalidation.org/xml/ns/validation/[Bean Validation website].
+http://beanvalidation.org/xml/ns/validation/[Jakarta Bean Validation website].
 ====
 
 [[section-configuration-validation-xml]]
@@ -51,7 +51,7 @@ There must only be one file named _META-INF/validation.xml_ on the classpath. If
 found an exception is thrown.
 ====
 
-The node `default-provider` allows to choose the Bean Validation provider. This is useful if there is
+The node `default-provider` allows to choose the Jakarta Bean Validation provider. This is useful if there is
 more than one provider on the classpath. `message-interpolator`, `traversable-resolver`,
 `constraint-validator-factory`, `parameter-name-provider` and `clock-provider` allow to customize
 the used implementations for the interfaces `MessageInterpolator`, `TraversableResolver`,
@@ -64,7 +64,7 @@ interfaces.
 container types or to override the built-in value extractors. See <<chapter-valueextraction>> for
 more information about how to implement `javax.validation.valueextraction.ValueExtractor`.
 
-`executable-validation` and its subnodes define defaults for method validation. The Bean Validation
+`executable-validation` and its subnodes define defaults for method validation. The Jakarta Bean Validation
 specification defines constructor and non getter methods as defaults. The enabled attribute acts as
 global switch to turn method validation on and off (see also <<chapter-method-constraints>>).
 
@@ -136,7 +136,7 @@ The nodes `class`, `field`, `getter`, `container-element-type`, `constructor` an
 The `valid` node is used to enable cascaded validation and the `constraint` node to add a constraint
 on the corresponding level.
 Each constraint definition must define the class via the `annotation` attribute.
-The constraint attributes required by the Bean Validation specification (`message`, `groups` and
+The constraint attributes required by the Jakarta Bean Validation specification (`message`, `groups` and
 `payload`) have dedicated nodes. All other constraint specific attributes are configured using the
 `element` node.
 

--- a/documentation/src/main/asciidoc/ch09.asciidoc
+++ b/documentation/src/main/asciidoc/ch09.asciidoc
@@ -30,7 +30,7 @@ Hibernate Validator uses the factory as context for caching constraint metadata 
 work with one factory instance within an application.
 ====
 
-Bean Validation supports working with several providers such as Hibernate Validator within one
+Jakarta Bean Validation supports working with several providers such as Hibernate Validator within one
 application. If more than one provider is present on the classpath, it is not guaranteed which one
 is chosen when creating a factory via `buildDefaultValidatorFactory()`.
 
@@ -71,7 +71,7 @@ If a `ValidatorFactory` instance is no longer in use, it should be disposed by c
 [[section-validation-provider-resolver]]
 ==== `ValidationProviderResolver`
 
-By default, available Bean Validation providers are discovered using the
+By default, available Jakarta Bean Validation providers are discovered using the
 {javaTechnotesBaseUrl}/guides/jar/jar.html#Service_Provider[Java
 Service Provider] mechanism.
 
@@ -114,7 +114,7 @@ If you want to disable the XML based configuration, you can do so by invoking
 
 The different values of the XML configuration can be accessed via
 `Configuration#getBootstrapConfiguration()`. This can for instance be helpful if you want to integrate
-Bean Validation into a managed environment and want to create managed instances of the objects
+Jakarta Bean Validation into a managed environment and want to create managed instances of the objects
 configured via XML.
 
 Using the fluent configuration API, you can override one or more of the settings when bootstrapping

--- a/documentation/src/main/asciidoc/ch10.asciidoc
+++ b/documentation/src/main/asciidoc/ch10.asciidoc
@@ -1,7 +1,7 @@
 [[validator-metadata-api]]
 == Using constraint metadata
 
-The Bean Validation specification provides not only a validation engine, but also an API for
+The Jakarta Bean Validation specification provides not only a validation engine, but also an API for
 retrieving constraint metadata in a uniform way, no matter whether the constraints are declared
 using annotations or via XML mappings. Read this chapter to learn more about this API and its
 possibilities. You can find all the metadata API types in the package `javax.validation.metadata`.

--- a/documentation/src/main/asciidoc/ch11.asciidoc
+++ b/documentation/src/main/asciidoc/ch11.asciidoc
@@ -98,7 +98,7 @@ configuration in _hibernate.cfg.xml_:
 ==== JPA
 
 If you are using JPA 2 and Hibernate Validator is in the classpath, the JPA2 specification requires
-that Bean Validation gets enabled. The properties `javax.persistence.validation.group.pre-persist`,
+that Jakarta Bean Validation gets enabled. The properties `javax.persistence.validation.group.pre-persist`,
 `javax.persistence.validation.group.pre-update` and `javax.persistence.validation.group.pre-remove` as
 described in <<validator-checkconstraints-orm-hibernateevent>> can in this case be configured in
 _persistence.xml_. _persistence.xml_ also defines a node validation-mode which can be set to `AUTO`,
@@ -108,7 +108,7 @@ _persistence.xml_. _persistence.xml_ also defines a node validation-mode which c
 
 === JSF & Seam
 
-When working with JSF2 or JBoss Seam and Hibernate Validator (Bean Validation) is present in the
+When working with JSF2 or JBoss Seam and Hibernate Validator (Jakarta Bean Validation) is present in the
 runtime environment, validation is triggered for every field in the application. <<example-jsf2>>
 shows an example of the `f:validateBean` tag in a JSF page. The `validationGroups` attribute is optional
 and can be used to specify a comma separated list of validation groups. The default is
@@ -117,7 +117,7 @@ specification.
 
 
 [[example-jsf2]]
-.Usage of Bean Validation within JSF2
+.Usage of Jakarta Bean Validation within JSF2
 ====
 [source, XML]
 ----
@@ -137,12 +137,12 @@ specification.
 
 [TIP]
 ====
-The integration between JSF 2 and Bean Validation is described in the "Bean Validation Integration"
+The integration between JSF 2 and Jakarta Bean Validation is described in the "Jakarta Bean Validation Integration"
 chapter of http://jcp.org/en/jsr/detail?id=314[JSR-314]. It is interesting to know that JSF
 2 implements a custom `MessageInterpolator` to ensure proper localization. To encourage the use
-of the Bean Validation message facility, JSF 2 will per default only display the generated Bean
+of the Jakarta Bean Validation message facility, JSF 2 will per default only display the generated Bean
 Validation message. This can, however, be configured via the application resource bundle by
-providing the following configuration (`{0}` is replaced with the Bean Validation message and `{1}` is
+providing the following configuration (`{0}` is replaced with the Jakarta Bean Validation message and `{1}` is
 replaced with the JSF component label):
 
 ----
@@ -160,8 +160,8 @@ javax.faces.validator.BeanValidator.MESSAGE={0}
 [[section-integration-with-cdi]]
 === CDI
 
-As of version 1.1, Bean Validation is integrated with CDI (Contexts and Dependency Injection for
-Java^TM^ EE).
+As of version 1.1, Bean Validation (and therefore Jakarta Bean Validation) is integrated with CDI
+(Contexts and Dependency Injection for Jakarta EE).
 
 This integration provides CDI managed beans for `Validator` and `ValidatorFactory` and enables
 dependency injection in constraint validators as well as custom message interpolators, traversable
@@ -192,10 +192,10 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/cdi/valida
 ====
 
 The injected beans are the default validator factory and validator instances. In order to configure
-them - e.g. to use a custom message interpolator - you can use the Bean Validation XML descriptors
+them - e.g. to use a custom message interpolator - you can use the Jakarta Bean Validation XML descriptors
 as discussed in <<chapter-xml-configuration>>.
 
-If you are working with several Bean Validation providers, you can make sure that factory and
+If you are working with several Jakarta Bean Validation providers, you can make sure that factory and
 validator from Hibernate Validator are injected by annotating the injection points with the
 `@HibernateValidator` qualifier which is demonstrated in <<example-dependency-injection-using-hv>>.
 
@@ -217,7 +217,7 @@ used for selecting Hibernate Validator when working with the bootstrapping API (
 <<section-retrieving-validator-factory-validator>>).
 ====
 
-Via `@Inject` you also can inject dependencies into constraint validators and other Bean Validation
+Via `@Inject` you also can inject dependencies into constraint validators and other Jakarta Bean Validation
 objects such as `MessageInterpolator` implementations etc.
 
 <<example-constraint-validator-injected-bean>>
@@ -237,7 +237,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter11/cdi/inject
 
 ==== Method validation
 
-The method interception facilities of CDI allow for a very tight integration with Bean Validation's
+The method interception facilities of CDI allow for a very tight integration with Jakarta Bean Validation's
 method validation functionality. Just put constraint annotations to the parameters and return values
 of the executables of your CDI beans and they will be validated automatically before (parameter
 constraints) and after (return value constraints) a method or constructor is invoked.
@@ -283,7 +283,7 @@ value is marked with `@Valid`.
 
 ===== Validated executable types
 
-Bean Validation allows for a fine-grained control of the executable types which are automatically
+Jakarta Bean Validation allows for a fine-grained control of the executable types which are automatically
 validated. By default, constraints on constructors and non-getter methods are validated. Therefore
 the `@NotNull` constraint on the method `RentalStation#getAvailableCars()` in
 <<example-cdi-method-validation>> does not get validated when the method is invoked.

--- a/documentation/src/main/asciidoc/ch12.asciidoc
+++ b/documentation/src/main/asciidoc/ch12.asciidoc
@@ -2,7 +2,7 @@
 == Hibernate Validator Specifics
 
 In this chapter you will learn how to make use of several features provided by Hibernate Validator
-in addition to the functionality defined by the Bean Validation specification. This includes the
+in addition to the functionality defined by the Jakarta Bean Validation specification. This includes the
 fail fast mode, the API for programmatic constraint configuration and the boolean composition of
 constraints.
 
@@ -16,7 +16,7 @@ Validator.
 [NOTE]
 ====
 Using the features described in the following sections may result in application code which is not
-portable between Bean Validation providers.
+portable between Jakarta Bean Validation providers.
 ====
 
 === Public API
@@ -25,13 +25,13 @@ Let's start, however, with a look at the public API of Hibernate Validator. Belo
 Note that when a package is part of the public API this is not necessarily true for its sub-packages.
 
 `org.hibernate.validator`::
-			Classes used by the Bean Validation bootstrap mechanism (eg. validation provider, configuration class); for more details see <<chapter-bootstrapping>>.
+			Classes used by the Jakarta Bean Validation bootstrap mechanism (eg. validation provider, configuration class); for more details see <<chapter-bootstrapping>>.
 
 `org.hibernate.validator.cfg`, `org.hibernate.validator.cfg.context`, `org.hibernate.validator.cfg.defs`, `org.hibernate.validator.spi.cfg`::
 			Hibernate Validator's fluent API for constraint declaration; in `org.hibernate.validator.cfg` you will find the `ConstraintMapping` interface, in `org.hibernate.validator.cfg.defs` all constraint definitions and in `org.hibernate.validator.spi.cfg` a callback for using the API for configuring the default validator factory. Refer to <<section-programmatic-api>> for the details.
 
 `org.hibernate.validator.constraints`, `org.hibernate.validator.constraints.br`, `org.hibernate.validator.constraints.pl`::
-			Some useful custom constraints provided by Hibernate Validator in addition to the built-in constraints defined by the Bean Validation specification; the constraints are described in detail in <<validator-defineconstraints-hv-constraints>>.
+			Some useful custom constraints provided by Hibernate Validator in addition to the built-in constraints defined by the Jakarta Bean Validation specification; the constraints are described in detail in <<validator-defineconstraints-hv-constraints>>.
 
 `org.hibernate.validator.constraintvalidation`::
 			Extended constraint validator context which allows to set custom attributes for message interpolation. <<section-hibernateconstraintvalidatorcontext>> describes how to make use of that feature.
@@ -107,13 +107,13 @@ fail fast mode when bootstrapping a validator.
 [[section-method-validation-prerequisite-relaxation]]
 === Relaxation of requirements for method validation in class hierarchies
 
-The Bean Validation specification defines a set of preconditions which apply when defining
+The Jakarta Bean Validation specification defines a set of preconditions which apply when defining
 constraints on methods within class hierarchies. These preconditions are defined in
 {bvSpecUrl}#constraintdeclarationvalidationprocess-methodlevelconstraints-inheritance[section 5.6.5]
-of the Bean Validation 2.0 specification. See also <<section-method-constraints-inheritance-hierarchies>>
+of the Jakarta Bean Validation 2.0 specification. See also <<section-method-constraints-inheritance-hierarchies>>
 in this guide.
 
-As per specification, a Bean Validation provider is allowed to relax these preconditions.
+As per specification, a Jakarta Bean Validation provider is allowed to relax these preconditions.
 With Hibernate Validator you can do this in one of two ways.
 
 First you can use the configuration properties _hibernate.validator.allow_parameter_constraint_override_,
@@ -154,7 +154,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/relaxation
 ====
 
 By default, all of these properties are false, implementing the default behavior as defined in the
-Bean Validation specification.
+Jakarta Bean Validation specification.
 
 [WARNING]
 ====
@@ -166,7 +166,7 @@ requires changes to the default behaviour.
 [[section-programmatic-api]]
 === Programmatic constraint definition and declaration
 
-As per the Bean Validation specification, you can define and declare constraints using Java annotations and XML
+As per the Jakarta Bean Validation specification, you can define and declare constraints using Java annotations and XML
 based constraint mappings.
 
 In addition, Hibernate Validator provides a fluent API which allows for the programmatic
@@ -333,7 +333,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/purelycomp
 [[section-boolean-constraint-composition]]
 ==== Boolean composition of constraints
 
-Bean Validation specifies that the constraints of a composed constraint (see
+Jakarta Bean Validation specifies that the constraints of a composed constraint (see
 <<section-constraint-composition>>) are all combined via a logical _AND_. This means all of the
 composing constraints need to return true to obtain an overall successful validation.
 
@@ -421,7 +421,7 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/dynamicpay
 
 Hibernate Validator requires per default an implementation of the Unified EL (see
 <<validator-gettingstarted-uel>>) to be available. This is needed to allow the interpolation
-of constraint error messages using EL expressions as defined by the Bean Validation specification.
+of constraint error messages using EL expressions as defined by the Jakarta Bean Validation specification.
 
 For environments where you cannot or do not want to provide an EL implementation, Hibernate Validator
 offers a non EL based message interpolator - `org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator`.
@@ -445,7 +445,7 @@ interpolation algorithm as defined by the specification. Refer to
 
 === Custom contexts
 
-The Bean Validation specification offers at several points in its API the possibility to unwrap a
+The Jakarta Bean Validation specification offers at several points in its API the possibility to unwrap a
 given interface to an implementor specific subtype. In the case of constraint violation creation in
 `ConstraintValidator` implementations as well as message interpolation in `MessageInterpolator`
 instances, there exist `unwrap()` methods for the provided context instances -
@@ -546,7 +546,7 @@ Alternatively you can specify a `Paranamer` implementation of your choice when c
 [[section-constraint-definition-contribution]]
 === Providing constraint definitions
 
-Bean Validation allows to (re-)define constraint definitions via XML in its constraint mapping
+Jakarta Bean Validation allows to (re-)define constraint definitions via XML in its constraint mapping
 files. See <<section-mapping-xml-constraints>> for more information and <<example-constraints-car>>
 for an example. While this approach is sufficient for many use cases,  it has its shortcomings
 in others. Imagine for example a constraint library wanting to contribute constraint

--- a/documentation/src/main/asciidoc/ch13.asciidoc
+++ b/documentation/src/main/asciidoc/ch13.asciidoc
@@ -57,7 +57,7 @@ The behavior of the Hibernate Validator Annotation Processor can be controlled u
 `methodConstraintsSupported`:: Controls whether constraints are allowed at methods of any
             kind. Must be set to `true` when working with method level constraints as supported by
             Hibernate Validator. Can be set to `false` to allow constraints only at
-            JavaBeans getter methods as defined by the Bean Validation API. Defaults to `true`.
+            JavaBeans getter methods as defined by the Jakarta Bean Validation API. Defaults to `true`.
 
 `verbose`:: Controls whether detailed processing information shall be
             displayed or not, useful for debugging purposes. Must be either

--- a/documentation/src/main/asciidoc/ch14.asciidoc
+++ b/documentation/src/main/asciidoc/ch14.asciidoc
@@ -3,11 +3,11 @@
 
 Last but not least, a few pointers to further information.
 
-A great source for examples is the Bean Validation TCK which is available for anonymous access on
+A great source for examples is the Jakarta Bean Validation TCK which is available for anonymous access on
 https://github.com/beanvalidation/beanvalidation-tck/[GitHub]. In particular the TCK's
 https://github.com/beanvalidation/beanvalidation-tck/tree/master/tests[tests] might be
-of interest. {bvSpecUrl}[The JSR 380] specification itself
-is also a great way to deepen your understanding of Bean Validation and Hibernate Validator.
+of interest. {bvSpecUrl}[The Jakarta Bean Validation] specification itself
+is also a great way to deepen your understanding of Jakarta Bean Validation and Hibernate Validator.
 
 If you have any further questions about Hibernate Validator or want to share some of your use cases,
 have a look at the http://community.jboss.org/en/hibernate/validator[Hibernate Validator

--- a/documentation/src/main/asciidoc/index.asciidoc
+++ b/documentation/src/main/asciidoc/index.asciidoc
@@ -1,4 +1,4 @@
-= Hibernate Validator {hvVersion} - JSR 380 Reference Implementation: Reference Guide
+= Hibernate Validator {hvVersion} - Jakarta Bean Validation Reference Implementation: Reference Guide
 Hardy Ferentschik; Gunnar Morling; Guillaume Smet
 :doctype: book
 :revdate: {docdate}

--- a/documentation/src/main/asciidoc/pr01.asciidoc
+++ b/documentation/src/main/asciidoc/pr01.asciidoc
@@ -11,7 +11,7 @@ code which is really metadata about the class itself.
 
 image::application-layers.png[]
 
-JSR 380 - Bean Validation 2.0 - defines a metadata model and API for entity and method validation.
+Jakarta Bean Validation 2.0 - defines a metadata model and API for entity and method validation.
 The default metadata source are annotations, with the ability to override and extend the meta-data
 through the use of XML. The API is not tied to a specific application tier nor programming model. It
 is specifically not tied to either web or persistence tier, and is available for both server-side
@@ -19,8 +19,8 @@ application programming, as well as rich client Swing application developers.
 
 image::application-layers2.png[]
 
-Hibernate Validator is the reference implementation of this JSR 380. The implementation itself as
-well as the Bean Validation API and TCK are all provided and distributed under the
+Hibernate Validator is the reference implementation of Jakarta Bean Validation. The implementation itself as
+well as the Jakarta Bean Validation API and TCK are all provided and distributed under the
 http://www.apache.org/licenses/LICENSE-2.0[Apache Software License 2.0].
 
-Hibernate Validator 6 and Bean Validation 2.0 require Java 8 or later.
+Hibernate Validator 6 and Jakarta Bean Validation 2.0 require Java 8 or later.

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -36,8 +36,8 @@
         Compile time dependencies
         -->
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>
@@ -53,7 +53,7 @@
         -->
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -79,8 +79,8 @@
         Optional dependencies
         -->
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>hibernate-validator</artifactId>
 
     <name>Hibernate Validator Engine</name>
-    <description>Hibernate's Bean Validation (JSR-380) reference implementation.</description>
+    <description>Hibernate's Jakarta Bean Validation reference implementation.</description>
 
     <properties>
         <hibernate-validator-parent.path>..</hibernate-validator-parent.path>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -207,7 +207,7 @@
                             <archive>
                                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                                 <manifestEntries>
-                                    <Specification-Title>Bean Validation</Specification-Title>
+                                    <Specification-Title>Jakarta Bean Validation</Specification-Title>
                                     <Specification-Version>2.0</Specification-Version>
                                     <Automatic-Module-Name>${hibernate-validator.module-name}</Automatic-Module-Name>
                                 </manifestEntries>

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/MethodValidationConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/MethodValidationConfiguration.java
@@ -21,7 +21,7 @@ import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.stereotypes.Immutable;
 
 /**
- * These properties modify the behavior of the {@code Validator} with respect to the Bean Validation
+ * These properties modify the behavior of the {@code Validator} with respect to the Jakarta Bean Validation
  * specification section 5.6.5. In particular:
  * <pre>
  * "Out of the box, a conforming Bean Validation provider must throw a
@@ -164,7 +164,7 @@ public class MethodValidationConfiguration {
 		 * Define whether overriding methods that override constraints should throw a {@code ConstraintDefinitionException}.
 		 * The default value is {@code false}, i.e. do not allow.
 		 *
-		 * See Section 5.6.5 of the JSR-380 Specification, specifically
+		 * See Section 5.6.5 of the Jakarta Bean Validation Specification, specifically
 		 * <pre>
 		 * "In sub types (be it sub classes/interfaces or interface implementations), no parameter constraints may
 		 * be declared on overridden or implemented methods, nor may parameters be marked for cascaded validation.
@@ -202,7 +202,7 @@ public class MethodValidationConfiguration {
 		 * Define whether parallel methods that define constraints should throw a {@code ConstraintDefinitionException}. The
 		 * default value is {@code false}, i.e. do not allow.
 		 *
-		 * See Section 5.6.5 of the JSR-380 Specification, specifically
+		 * See Section 5.6.5 of the Jakarta Bean Validation Specification, specifically
 		 * "If a sub type overrides/implements a method originally defined in several parallel types of the hierarchy
 		 * (e.g. two interfaces not extending each other, or a class and an interface not implemented by said class),
 		 * no parameter constraints may be declared for that method at all nor parameters be marked for cascaded validation.

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/package-info.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/package-info.java
@@ -6,6 +6,6 @@
  */
 
 /**
- * Implementations for the core interfaces of JSR-380.
+ * Implementations for the core interfaces of Jakarta Bean Validation.
  */
 package org.hibernate.validator.internal.engine;

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Messages.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Messages.java
@@ -86,7 +86,7 @@ public interface Messages {
 			"This can happen most notably in a Google App Engine environment or when running Hibernate Validator as Java 9 named module. " +
 			"A PlatformResourceBundleLocator without bundle aggregation was created. " +
 			"This only affects you in case you are using multiple ConstraintDefinitionContributor JARs. " +
-			"ConstraintDefinitionContributors are a Hibernate Validator specific feature. All Bean Validation " +
+			"ConstraintDefinitionContributors are a Hibernate Validator specific feature. All Jakarta Bean Validation " +
 			"features work as expected. See also https://hibernate.atlassian.net/browse/HV-1023.")
 	String unableToUseResourceBundleAggregation();
 

--- a/engine/src/main/java/org/hibernate/validator/overview.html
+++ b/engine/src/main/java/org/hibernate/validator/overview.html
@@ -10,7 +10,7 @@
 </head>
 <body>
 <p>This is the Hibernate Validator API documentation. Hibernate Validator is the reference implementation of
- Bean Validation 2.0 - <a href="http://jcp.org/en/jsr/detail?id=380">JSR-380</a>
+ https://projects.eclipse.org/projects/ee4j.bean-validation[Jakarta Bean Validation 2.0].
 </p>
 <p>
 All classes fall into three categories:

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -93,13 +93,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.spec.javax.ejb</groupId>
-            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+            <groupId>jakarta.ejb</groupId>
+            <artifactId>jakarta.ejb-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -212,13 +212,13 @@
                             <artifactItems>
                                 <!-- WildFly current -->
                                 <artifactItem>
-                                    <groupId>javax.validation</groupId>
-                                    <artifactId>validation-api</artifactId>
-                                    <version>${version.javax.validation}</version>
+                                    <groupId>jakarta.validation</groupId>
+                                    <artifactId>jakarta.validation-api</artifactId>
+                                    <version>${version.jakarta.validation-api}</version>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${wildfly-main.patched.target-dir}/modules/system/layers/base/javax/validation/api/main</outputDirectory>
                                     <!-- Specifying name to avoid timestamp in version on CI -->
-                                    <destFileName>validation-api-${version.javax.validation}.jar</destFileName>
+                                    <destFileName>jakarta.validation-api-${version.jakarta.validation-api}.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>${project.groupId}</groupId>
@@ -238,13 +238,13 @@
                                 </artifactItem>
                                 <!-- WildFly secondary version -->
                                 <artifactItem>
-                                    <groupId>javax.validation</groupId>
-                                    <artifactId>validation-api</artifactId>
-                                    <version>${version.javax.validation}</version>
+                                    <groupId>jakarta.validation</groupId>
+                                    <artifactId>jakarta.validation-api</artifactId>
+                                    <version>${version.jakarta.validation-api}</version>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${wildfly-secondary.patched.target-dir}/modules/system/layers/base/javax/validation/api/main</outputDirectory>
                                     <!-- Specifying name to avoid timestamp in version on CI -->
-                                    <destFileName>validation-api-${version.javax.validation}.jar</destFileName>
+                                    <destFileName>jakarta.validation-api-${version.jakarta.validation-api}.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>${project.groupId}</groupId>

--- a/modules/src/script/setupModules.groovy
+++ b/modules/src/script/setupModules.groovy
@@ -21,10 +21,10 @@ def removeDependency(File file, String dependencyToRemove) {
     file.write( file.text.replaceAll( /<module name="${dependencyToRemove}"[^\/]*\/>/, '' ) )
 }
 
-// BV API
+// Jakarta Bean Validation API
 bvModuleXml = new File( wildflyPatchedTargetDir, 'modules/system/layers/base/javax/validation/api/main/module.xml' )
-def bvArtifactName = 'validation-api-' + project.properties['version.javax.validation'] + '.jar';
-println "[INFO] Using BV version " + bvArtifactName;
+def bvArtifactName = 'jakarta.validation-api-' + project.properties['version.jakarta.validation-api'] + '.jar';
+println "[INFO] Using Jakarta Bean Validation version " + bvArtifactName;
 processFileInplace( bvModuleXml ) { text ->
     text.replaceAll( /validation-api.*jar/, bvArtifactName )
 }

--- a/osgi/felixtest/pom.xml
+++ b/osgi/felixtest/pom.xml
@@ -48,13 +48,13 @@
         </dependency>
     
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -163,6 +163,15 @@
                                     <type>jar</type>
                                     <outputDirectory>${project.build.directory}/payara5/glassfish/modules</outputDirectory>
                                     <destFileName>hibernate-validator-cdi.jar</destFileName>
+                                    <overWrite>true</overWrite>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>jakarta.validation</groupId>
+                                    <artifactId>jakarta.validation-api</artifactId>
+                                    <version>${bv.api.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}/payara5/glassfish/modules</outputDirectory>
+                                    <destFileName>validation-api.jar</destFileName>
                                     <overWrite>true</overWrite>
                                 </artifactItem>
                             </artifactItems>

--- a/osgi/integrationtest/pom.xml
+++ b/osgi/integrationtest/pom.xml
@@ -31,8 +31,8 @@
     <dependencies>
         <!-- BV / HV -->
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -143,7 +143,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/osgi/karaf-features/src/main/features/features.xml
+++ b/osgi/karaf-features/src/main/features/features.xml
@@ -12,11 +12,11 @@
 
     <feature name="hibernate-validator" version="${project.version}">
         <bundle>mvn:org.hibernate.validator/hibernate-validator/${project.version}</bundle>
-        <bundle>mvn:javax.validation/validation-api/${version.javax.validation}</bundle>
+        <bundle>mvn:jakarta.validation/jakarta.validation-api/${version.jakarta.validation-api}</bundle>
 
         <bundle>mvn:org.jboss.logging/jboss-logging/${version.org.jboss.logging.jboss-logging}</bundle>
         <bundle>mvn:com.fasterxml/classmate/${version.com.fasterxml.classmate}</bundle>
-        <bundle>mvn:org.glassfish/javax.el/${version.org.glassfish.javax.el}</bundle>
+        <bundle>mvn:org.glassfish/jakarta.el/${version.org.glassfish.jakarta.el}</bundle>
     </feature>
     <feature name="hibernate-validator-jsoup" version="${project.version}">
         <feature>hibernate-validator</feature>
@@ -30,7 +30,7 @@
         <feature>hibernate-validator</feature>
         <bundle>mvn:javax.money/money-api/${version.javax.money}</bundle>
         <bundle>mvn:org.javamoney/moneta/${version.org.javamoney.moneta}</bundle>
-        <bundle>mvn:javax.annotation/javax.annotation-api/${version.javax.annotation}</bundle>
+        <bundle>mvn:jakarta.annotation/jakarta.annotation-api/${version.jakarta.annotation-api}</bundle>
     </feature>
     <feature name="hibernate-validator-groovy" version="${project.version}">
         <feature>hibernate-validator</feature>

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -53,8 +53,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -166,8 +166,8 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>javax.validation</groupId>
-                    <artifactId>validation-api</artifactId>
+                    <groupId>jakarta.validation</groupId>
+                    <artifactId>jakarta.validation-api</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
@@ -176,7 +176,7 @@
                 </dependency>
                 <dependency>
                     <groupId>org.glassfish</groupId>
-                    <artifactId>javax.el</artifactId>
+                    <artifactId>jakarta.el</artifactId>
                 </dependency>
                 <dependency>
                     <groupId>log4j</groupId>
@@ -243,6 +243,7 @@
                 </property>
             </activation>
             <properties>
+                <validation-api.version>2.0.1.Final</validation-api.version>
                 <beanvalidation-impl.name>Hibernate Validator</beanvalidation-impl.name>
                 <beanvalidation-impl.version>6.0.16.Final</beanvalidation-impl.version>
             </properties>
@@ -250,6 +251,7 @@
                 <dependency>
                     <groupId>javax.validation</groupId>
                     <artifactId>validation-api</artifactId>
+                    <version>${validation-api.version}</version>
                 </dependency>
                 <dependency>
                     <groupId>${project.groupId}</groupId>
@@ -259,6 +261,7 @@
                 <dependency>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.el</artifactId>
+                    <version>3.0.1-b11</version>
                 </dependency>
                 <dependency>
                     <groupId>log4j</groupId>
@@ -302,6 +305,7 @@
                 <dependency>
                     <groupId>org.glassfish</groupId>
                     <artifactId>javax.el</artifactId>
+                    <version>3.0.1-b11</version>
                 </dependency>
                 <dependency>
                     <groupId>log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,11 +113,11 @@
 
         <!-- Dependencies versions -->
 
-        <version.javax.validation>2.0.1.Final</version.javax.validation>
-        <version.org.hibernate.beanvalidation.tck>2.0.4.Final</version.org.hibernate.beanvalidation.tck>
+        <version.jakarta.validation-api>2.0.2</version.jakarta.validation-api>
+        <version.org.hibernate.beanvalidation.tck>2.0.5</version.org.hibernate.beanvalidation.tck>
 
         <version.com.thoughtworks.paranamer>2.8</version.com.thoughtworks.paranamer>
-        <version.org.glassfish.javax.el>3.0.1-b09</version.org.glassfish.javax.el>
+        <version.org.glassfish.jakarta.el>3.0.3</version.org.glassfish.jakarta.el>
         <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
 
@@ -137,18 +137,19 @@
         <version.joda-time>2.9.7</version.joda-time>
         <version.org.slf4j>1.7.22</version.org.slf4j>
         <version.log4j>1.2.17</version.log4j>
-        <version.javax.persistence>2.2</version.javax.persistence>
+        <version.jakarta.persistence-api>2.2.3</version.jakarta.persistence-api>
 
         <!--
             These dependencies are used for integration tests with WildFly.
             They should be aligned with the ones from the Wildfly version we support
             See http://search.maven.org/#search|gav|1|g%3A"org.wildfly"%20AND%20a%3A"wildfly-parent"
         -->
-        <version.javax.enterprise>2.0.SP1</version.javax.enterprise>
+        <version.jakarta.enterprise.cdi-api>2.0.1</version.jakarta.enterprise.cdi-api>
         <version.org.jboss.weld.weld>3.1.1.Final</version.org.jboss.weld.weld>
         <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
-        <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.2.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
-        <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>
+        <version.jakarta.ejb-api>3.2.5</version.jakarta.ejb-api>
+        <version.jakarta.interceptor-api>1.2.4</version.jakarta.interceptor-api>
+        <version.jakarta.annotation-api>1.3.5</version.jakarta.annotation-api>
 
         <!-- JavaMoney dependencies -->
         <version.javax.money>1.0.1</version.javax.money>
@@ -321,9 +322,9 @@
                 <type>zip</type>
             </dependency>
             <dependency>
-                <groupId>javax.validation</groupId>
-                <artifactId>validation-api</artifactId>
-                <version>${version.javax.validation}</version>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${version.jakarta.validation-api}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logging</groupId>
@@ -342,8 +343,8 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
-                <version>${version.org.glassfish.javax.el}</version>
+                <artifactId>jakarta.el</artifactId>
+                <version>${version.org.glassfish.jakarta.el}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml</groupId>
@@ -396,9 +397,9 @@
                 <version>${version.org.slf4j}</version>
             </dependency>
             <dependency>
-                <groupId>javax.persistence</groupId>
-                <artifactId>javax.persistence-api</artifactId>
-                <version>${version.javax.persistence}</version>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
+                <version>${version.jakarta.persistence-api}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -433,32 +434,32 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>javax.annotation</groupId>
-                <artifactId>javax.annotation-api</artifactId>
-                <version>1.2</version>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${version.jakarta.annotation-api}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.spec.javax.interceptor</groupId>
-                <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec}</version>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
+                <version>${version.jakarta.interceptor-api}</version>
             </dependency>
             <dependency>
-                <groupId>org.jboss.spec.javax.ejb</groupId>
-                <artifactId>jboss-ejb-api_3.2_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec}</version>
+                <groupId>jakarta.ejb</groupId>
+                <artifactId>jakarta.ejb-api</artifactId>
+                <version>${version.jakarta.ejb-api}</version>
             </dependency>
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>${version.javax.enterprise}</version>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${version.jakarta.enterprise.cdi-api}</version>
                 <exclusions>
                     <exclusion>
-                        <groupId>javax.interceptor</groupId>
-                        <artifactId>javax.interceptor-api</artifactId>
+                        <groupId>jakarta.interceptor</groupId>
+                        <artifactId>jakarta.interceptor-api</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>javax.el</groupId>
-                        <artifactId>javax.el-api</artifactId>
+                        <groupId>jakarta.el</groupId>
+                        <artifactId>jakarta.el-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -31,8 +31,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -40,11 +40,11 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+            <artifactId>jakarta.el</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.persistence</groupId>
-            <artifactId>javax.persistence-api</artifactId>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -18,7 +18,7 @@
     <artifactId>hibernate-validator-tck-runner</artifactId>
 
     <name>Hibernate Validator TCK Runner</name>
-    <description>Aggregates dependencies and runs the JSR-380 TCK</description>
+    <description>Aggregates dependencies and runs the Jakarta Bean Validation TCK</description>
 
     <properties>
         <tck.suite.file>${project.build.directory}/dependency/beanvalidation-tck-tests-suite.xml</tck.suite.file>

--- a/tck-runner/src/test/resources/test.policy
+++ b/tck-runner/src/test/resources/test.policy
@@ -54,11 +54,11 @@ grant codeBase "file:${localRepository}/org/jboss/logging/jboss-logging/-" {
     permission java.util.PropertyPermission "org.jboss.logging.locale", "read";
 };
 
-/* =================== */
-/* Bean Validation API */
-/* =================== */
+/* =========================== */
+/* Jakarta Bean Validation API */
+/* =========================== */
 
-grant codeBase "file:${localRepository}/javax/validation/validation-api/-" {
+grant codeBase "file:${localRepository}/jakarta/validation/jakarta.validation-api/-" {
     permission java.io.FilePermission "<<ALL FILES>>", "read";
 
     // in some tests this property is accessed by the TCK when the API JAR is on the callstack; the TCK doesn't

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -54,8 +54,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>


### PR DESCRIPTION
This PR is basically a "backport" of the work done in the 6.2 branch on master.

6.1 would be the first version based on Jakarta. Quarkus not being ready to move to Jakarta yet, I will add the appropriate exclusion and explicit dependencies there.

@gunnarmorling I thought about it some more and I really want the BVTCK artifacts to be on Central, even if they are not official and shouldn't be used to properly validate the TCK so I will push them tomorrow. For now, the build of this PR will fail.