### PR TITLE
HV-1730 JavaBeanExecutable fails to initialize for enum type

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -892,4 +892,12 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 253, value = "Unable to instantiate property node name provider class %s.")
 	ValidationException getUnableToInstantiatePropertyNodeNameProviderClassException(String propertyNodeNameProviderClassName, @Cause Exception e);
+
+	@LogMessage(level = WARN)
+	@Message(id = 254, value = "Missing parameter metadata for %s, which declares implicit or synthetic parameters."
+			+ " Automatic resolution of generic type information for method parameters"
+			+ " may yield incorrect results if multiple parameters have the same erasure."
+			+ " To solve this, compile your code with the '-parameters' flag."
+	)
+	void missingParameterMetadataWithSyntheticOrImplicitParameters(@FormatWith(ExecutableFormatter.class) Executable executable);
 }

--- a/engine/src/test/java/org/hibernate/validator/test/predefinedscope/PredefinedScopeValidatorFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/predefinedscope/PredefinedScopeValidatorFactoryTest.java
@@ -13,8 +13,11 @@ import static org.hibernate.validator.testutil.ConstraintViolationAssert.violati
 import static org.testng.Assert.fail;
 
 import java.lang.annotation.ElementType;
+import java.util.AbstractCollection;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Set;
 
@@ -243,6 +246,7 @@ public class PredefinedScopeValidatorFactoryTest {
 		Set<Class<?>> beanMetaDataToInitialize = new HashSet<>();
 		beanMetaDataToInitialize.add( Bean.class );
 		beanMetaDataToInitialize.add( AnotherBean.class );
+		beanMetaDataToInitialize.add( SomeEnum.class );
 
 		ValidatorFactory validatorFactory = Validation.byProvider( PredefinedScopeHibernateValidator.class )
 				.configure()
@@ -258,6 +262,23 @@ public class PredefinedScopeValidatorFactoryTest {
 		catch (ValidationException e) {
 			Assertions.assertThat( e ).hasCauseExactlyInstanceOf( ValidatorSpecificTraversableResolverUsedException.class );
 		}
+	}
+
+	@Test
+	public void variousObjectTypes() {
+		Set<Class<?>> beanMetaDataToInitialize = new HashSet<>();
+		beanMetaDataToInitialize.add( Bean.class );
+		beanMetaDataToInitialize.add( AnotherBean.class );
+		beanMetaDataToInitialize.add( SomeEnum.class );
+		beanMetaDataToInitialize.add( Values.Itr.class );
+
+		ValidatorFactory validatorFactory = Validation.byProvider( PredefinedScopeHibernateValidator.class )
+				.configure()
+				.initializeBeanMetaData( beanMetaDataToInitialize )
+				.buildValidatorFactory();
+
+		Validator validator = validatorFactory.getValidator();
+		validator.validate( new Bean() );
 	}
 
 	private static Validator getValidator() {
@@ -284,6 +305,40 @@ public class PredefinedScopeValidatorFactoryTest {
 				.buildValidatorFactory();
 
 		return validatorFactory.getValidator();
+	}
+
+	private enum SomeEnum {
+		VALUE;
+	}
+
+	final class Values extends AbstractCollection<String> implements Collection<String> {
+		public Iterator<String> iterator() {
+			return new Itr( null );
+		}
+
+		public int size() {
+			return 0;
+		}
+
+		public boolean isEmpty() {
+			return true;
+		}
+
+		final class Itr implements Iterator<String> {
+			private final Iterator<String> iterator;
+
+			Itr(final Iterator<String> iterator) {
+				this.iterator = iterator;
+			}
+
+			public boolean hasNext() {
+				return iterator.hasNext();
+			}
+
+			public String next() {
+				return "";
+			}
+		}
 	}
 
 	private static class Bean {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1730

Supersedes #1049 .

It turns out the problem is really caused by the lack of a `-parameters` flag when model classes are compiled. When the flag is missing, we don't have any information about which parameter is implicit/synthetic, and the existing code assumes we always have that information. As a result, it inspects all the parameters without finding the implicit/synthetic ones, and ends up triggering an `ArrayIndexOutOfBoundsException`.

The solution provided in #1049 solves the out-of bound exception, and goes a little further by trying to "guess" which type is implicit/synthetic or not based on type erasure. This will work in some cases, but will lead to incorrect results in other cases.

This PR just takes the fix from #1049, and adds the following changes:

* Splits marko's commits in two, so that it's easier to revert the fix and only keep the test, to reproduce the problem.
* Adds a warning when parameter metadata (`isImplicit`/`isSynthetic`) is missing, because that may lead to incorrect generic type information being detected for method parameters.
