### PR TITLE
[WIP] HV-1755 WFLY-11566 ConstraintDeclarationException on JAX-RS/EJB Methods with List/Set query parameter

### DIFF
--- a/cdi/src/main/java/org/hibernate/validator/cdi/internal/ValidatorFactoryBean.java
+++ b/cdi/src/main/java/org/hibernate/validator/cdi/internal/ValidatorFactoryBean.java
@@ -142,7 +142,7 @@ public class ValidatorFactoryBean implements Bean<ValidatorFactory>, Passivation
 			if ( beanMetaDataClassNormalizerInstance.isResolvable() ) {
 				BeanMetaDataClassNormalizer normalizer = beanMetaDataClassNormalizerInstance.get();
 				destructibleResources.add( new DestructibleBeanInstance<>( beanManager, normalizer ) );
-				
+
 				hvConfig.beanMetaDataClassNormalizer( normalizer );
 			}
 		}

--- a/cdi/src/main/java/org/hibernate/validator/cdi/spi/BeanNames.java
+++ b/cdi/src/main/java/org/hibernate/validator/cdi/spi/BeanNames.java
@@ -1,0 +1,16 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.cdi.spi;
+
+public final class BeanNames {
+
+	private BeanNames() {
+	}
+
+	public static final String BEAN_META_DATA_CLASS_NORMALIZER = "hibernate-validator-bean-meta-data-class-normalizer";
+
+}

--- a/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/beanmetadataclassnormalizer/CustomProxy.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/beanmetadataclassnormalizer/CustomProxy.java
@@ -1,0 +1,10 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.cdi.internal.beanmetadataclassnormalizer;
+
+public interface CustomProxy {
+}

--- a/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/beanmetadataclassnormalizer/CustomProxyBeanMetaDataClassNormalizer.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/beanmetadataclassnormalizer/CustomProxyBeanMetaDataClassNormalizer.java
@@ -1,0 +1,89 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.cdi.internal.beanmetadataclassnormalizer;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.Set;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.spi.CreationalContext;
+import javax.enterprise.inject.literal.NamedLiteral;
+import javax.enterprise.inject.spi.Bean;
+import javax.enterprise.inject.spi.InjectionPoint;
+
+import org.hibernate.validator.cdi.spi.BeanNames;
+import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
+
+
+public class CustomProxyBeanMetaDataClassNormalizer
+		implements BeanMetaDataClassNormalizer, Bean<BeanMetaDataClassNormalizer> {
+
+	@Override
+	public <T> Class<? super T> normalize(Class<T> clazz) {
+		if ( CustomProxy.class.isAssignableFrom( clazz ) ) {
+			return clazz.getSuperclass();
+		}
+		return clazz;
+	}
+
+	@Override
+	public Class<?> getBeanClass() {
+		return BeanMetaDataClassNormalizer.class;
+	}
+
+	@Override
+	public Set<InjectionPoint> getInjectionPoints() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public boolean isNullable() {
+		return false;
+	}
+
+	@Override
+	public BeanMetaDataClassNormalizer create(CreationalContext<BeanMetaDataClassNormalizer> creationalContext) {
+		return new CustomProxyBeanMetaDataClassNormalizer();
+	}
+
+	@Override
+	public void destroy(BeanMetaDataClassNormalizer beanMetaDataClassNormalizer,
+			CreationalContext<BeanMetaDataClassNormalizer> creationalContext) {
+		// Nothing to do
+	}
+
+	@Override
+	public Set<Type> getTypes() {
+		return Collections.singleton( BeanMetaDataClassNormalizer.class );
+	}
+
+	@Override
+	public Set<Annotation> getQualifiers() {
+		return Collections.singleton( NamedLiteral.of( BeanNames.BEAN_META_DATA_CLASS_NORMALIZER ) );
+	}
+
+	@Override
+	public Class<? extends Annotation> getScope() {
+		return ApplicationScoped.class;
+	}
+
+	@Override
+	public String getName() {
+		return BeanNames.BEAN_META_DATA_CLASS_NORMALIZER;
+	}
+
+	@Override
+	public Set<Class<? extends Annotation>> getStereotypes() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public boolean isAlternative() {
+		return false;
+	}
+}

--- a/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/beanmetadataclassnormalizer/CustomProxyBeanMetadataClassNormalizerCdiExtension.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/beanmetadataclassnormalizer/CustomProxyBeanMetadataClassNormalizerCdiExtension.java
@@ -1,0 +1,18 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.cdi.internal.beanmetadataclassnormalizer;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+
+public class CustomProxyBeanMetadataClassNormalizerCdiExtension implements Extension {
+
+	public void addEjbProxyNormalizer(@Observes AfterBeanDiscovery afterBeanDiscovery) {
+		afterBeanDiscovery.addBean( new CustomProxyBeanMetaDataClassNormalizer() );
+	}
+}

--- a/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/beanmetadataclassnormalizer/ExtensionProvidedBeanMetadataClassNormalizerTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/beanmetadataclassnormalizer/ExtensionProvidedBeanMetadataClassNormalizerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.cdi.internal.beanmetadataclassnormalizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.DecimalMax;
+import javax.validation.constraints.NotNull;
+
+import org.hibernate.validator.cdi.HibernateValidator;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import org.testng.annotations.Test;
+
+public class ExtensionProvidedBeanMetadataClassNormalizerTest extends Arquillian {
+
+	@Deployment
+	public static JavaArchive createDeployment() {
+		return ShrinkWrap.create( JavaArchive.class )
+				.addAsManifestResource( EmptyAsset.INSTANCE, "beans.xml" )
+				// Register the CDI extension that provides the normalizer bean
+				.addAsManifestResource(
+						new StringAsset( CustomProxyBeanMetadataClassNormalizerCdiExtension.class.getName() ),
+						"services/javax.enterprise.inject.spi.Extension"
+				);
+	}
+
+	@HibernateValidator
+	@Inject
+	ValidatorFactory validatorFactory;
+
+	@HibernateValidator
+	@Inject
+	Validator validator;
+
+	@Inject
+	ValidatorFactory defaultValidatorFactory;
+
+	@Inject
+	Validator defaultValidator;
+
+	@Test
+	public void testProxyMetadataIgnoredWithQualifiedValidator() throws Exception {
+		assertThat( validator ).isNotNull();
+		doTest( validator );
+	}
+
+	@Test
+	public void testProxyMetadataIgnoredWithDefaultValidator() throws Exception {
+		assertThat( defaultValidator ).isNotNull();
+		doTest( defaultValidator );
+	}
+
+	@Test
+	public void testProxyMetadataIgnoredWithQualifiedValidatorFactory() throws Exception {
+		assertThat( validatorFactory ).isNotNull();
+		doTest( validatorFactory.getValidator() );
+	}
+
+	@Test
+	public void testProxyMetadataIgnoredWithDefaultValidatorFactory() throws Exception {
+		assertThat( defaultValidatorFactory ).isNotNull();
+		doTest( defaultValidatorFactory.getValidator() );
+	}
+
+	private void doTest(Validator validator) {
+		assertThat( validator ).isNotNull();
+		/*
+		 * Even though we pass an instance of the proxy class that has invalid annotations,
+		 * we expect those to be ignored
+		 * because of the class normalizer we defined.
+		 */
+		assertThat( validator.validate( new TestEntityProxy() ) ).hasSize( 1 );
+	}
+
+	public static class TestEntity {
+		@NotNull
+		private String foo;
+	}
+
+	public static class TestEntityProxy extends TestEntity implements CustomProxy {
+		/*
+		 * This is invalid, but should be ignored because it's defined in a proxy class which gets ignored
+		 * because of the class normalizer we defined.
+		 */
+		@DecimalMax(value = "foo")
+		private String foo;
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
@@ -25,6 +25,7 @@ import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.constraints.ParameterScriptAssert;
 import org.hibernate.validator.constraints.ScriptAssert;
 import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
+import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
 import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
 import org.hibernate.validator.spi.properties.GetterPropertySelectionStrategy;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
@@ -423,4 +424,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 */
 	@Incubating
 	S localeResolver(LocaleResolver localeResolver);
+
+	@Incubating
+	S beanMetaDataClassNormalizer(BeanMetaDataClassNormalizer beanMetaDataClassNormalizer);
 }

--- a/engine/src/main/java/org/hibernate/validator/PredefinedScopeHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/PredefinedScopeHibernateValidatorConfiguration.java
@@ -9,8 +9,6 @@ package org.hibernate.validator;
 import java.util.Locale;
 import java.util.Set;
 
-import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
-
 /**
  * Extension of {@link HibernateValidatorConfiguration} with additional methods dedicated to defining the predefined
  * scope of bean validation e.g. validated classes, constraint validators...
@@ -31,7 +29,4 @@ public interface PredefinedScopeHibernateValidatorConfiguration extends BaseHibe
 	@Incubating
 	@Deprecated
 	PredefinedScopeHibernateValidatorConfiguration initializeLocales(Set<Locale> locales);
-
-	@Incubating
-	PredefinedScopeHibernateValidatorConfiguration beanMetaDataClassNormalizer(BeanMetaDataClassNormalizer beanMetaDataClassNormalizer);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/AbstractConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/AbstractConfigurationImpl.java
@@ -57,6 +57,7 @@ import org.hibernate.validator.internal.util.privilegedactions.SetContextClassLo
 import org.hibernate.validator.internal.xml.config.ValidationBootstrapParameters;
 import org.hibernate.validator.internal.xml.config.ValidationXmlParser;
 import org.hibernate.validator.messageinterpolation.ResourceBundleMessageInterpolator;
+import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
 import org.hibernate.validator.resourceloading.PlatformResourceBundleLocator;
 import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
 import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
@@ -118,6 +119,7 @@ public abstract class AbstractConfigurationImpl<T extends BaseHibernateValidator
 	private Set<Locale> locales = Collections.emptySet();
 	private Locale defaultLocale = Locale.getDefault();
 	private LocaleResolver localeResolver;
+	private BeanMetaDataClassNormalizer beanMetaDataClassNormalizer;
 
 	protected AbstractConfigurationImpl(BootstrapState state) {
 		this();
@@ -596,6 +598,18 @@ public abstract class AbstractConfigurationImpl<T extends BaseHibernateValidator
 	public Set<ValueExtractor<?>> getDefaultValueExtractors() {
 		return ValueExtractorManager.getDefaultValueExtractors();
 	}
+
+	@Override
+	public T beanMetaDataClassNormalizer(
+			BeanMetaDataClassNormalizer beanMetaDataClassNormalizer) {
+		this.beanMetaDataClassNormalizer = beanMetaDataClassNormalizer;
+		return thisAsT();
+	}
+
+	public BeanMetaDataClassNormalizer getBeanMetaDataClassNormalizer() {
+		return beanMetaDataClassNormalizer;
+	}
+
 
 	public final Set<DefaultConstraintMapping> getProgrammaticMappings() {
 		return programmaticMappings;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/AbstractConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/AbstractConfigurationImpl.java
@@ -600,8 +600,13 @@ public abstract class AbstractConfigurationImpl<T extends BaseHibernateValidator
 	}
 
 	@Override
-	public T beanMetaDataClassNormalizer(
-			BeanMetaDataClassNormalizer beanMetaDataClassNormalizer) {
+	public T beanMetaDataClassNormalizer(BeanMetaDataClassNormalizer beanMetaDataClassNormalizer) {
+		if ( LOG.isDebugEnabled() ) {
+			if ( beanMetaDataClassNormalizer != null ) {
+				LOG.debug( "Setting custom BeanMetaDataClassNormalizer of type " + beanMetaDataClassNormalizer.getClass()
+						.getName() );
+			}
+		}
 		this.beanMetaDataClassNormalizer = beanMetaDataClassNormalizer;
 		return thisAsT();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeConfigurationImpl.java
@@ -18,7 +18,6 @@ import javax.validation.spi.ValidationProvider;
 import org.hibernate.validator.PredefinedScopeHibernateValidatorConfiguration;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.Contracts;
-import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
 
 /**
  * @author Guillaume Smet
@@ -27,8 +26,6 @@ public class PredefinedScopeConfigurationImpl extends AbstractConfigurationImpl<
 		implements PredefinedScopeHibernateValidatorConfiguration, ConfigurationState {
 
 	private Set<Class<?>> beanClassesToInitialize;
-
-	private BeanMetaDataClassNormalizer beanMetaDataClassNormalizer;
 
 	public PredefinedScopeConfigurationImpl(BootstrapState state) {
 		super( state );
@@ -53,16 +50,6 @@ public class PredefinedScopeConfigurationImpl extends AbstractConfigurationImpl<
 		Contracts.assertNotNull( localesToInitialize, MESSAGES.parameterMustNotBeNull( "localesToInitialize" ) );
 		locales( localesToInitialize );
 		return thisAsT();
-	}
-
-	@Override
-	public PredefinedScopeHibernateValidatorConfiguration beanMetaDataClassNormalizer(BeanMetaDataClassNormalizer beanMetaDataClassNormalizer) {
-		this.beanMetaDataClassNormalizer = beanMetaDataClassNormalizer;
-		return thisAsT();
-	}
-
-	public BeanMetaDataClassNormalizer getBeanMetaDataClassNormalizer() {
-		return beanMetaDataClassNormalizer;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryConfigurationHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryConfigurationHelper.java
@@ -286,7 +286,7 @@ final class ValidatorFactoryConfigurationHelper {
 		return new DefaultGetterPropertySelectionStrategy();
 	}
 
-	static BeanMetaDataClassNormalizer determineBeanMetaDataClassNormalizer(PredefinedScopeConfigurationImpl hibernateSpecificConfig) {
+	static BeanMetaDataClassNormalizer determineBeanMetaDataClassNormalizer(AbstractConfigurationImpl<?> hibernateSpecificConfig) {
 		if ( hibernateSpecificConfig.getBeanMetaDataClassNormalizer() != null ) {
 			return hibernateSpecificConfig.getBeanMetaDataClassNormalizer();
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.validator.internal.engine;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineAllowMultipleCascadedValidationOnReturnValues;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineAllowOverridingMethodAlterParameterConstraint;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineAllowParallelMethodsDefineParameterConstraints;
+import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineBeanMetaDataClassNormalizer;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintMappings;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintValidatorPayload;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineExternalClassLoader;
@@ -59,6 +60,7 @@ import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.stereotypes.Immutable;
 import org.hibernate.validator.internal.util.stereotypes.ThreadSafe;
+import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
 import org.hibernate.validator.spi.properties.GetterPropertySelectionStrategy;
 import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
 
@@ -122,6 +124,8 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 
 	private final JavaBeanHelper javaBeanHelper;
 
+	private final BeanMetaDataClassNormalizer beanMetadataClassNormalizer;
+
 	private final ValidationOrderGenerator validationOrderGenerator;
 
 	public ValidatorFactoryImpl(ConfigurationState configurationState) {
@@ -171,6 +175,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 		this.executableHelper = new ExecutableHelper( typeResolutionHelper );
 		this.javaBeanHelper = new JavaBeanHelper( ValidatorFactoryConfigurationHelper.determineGetterPropertySelectionStrategy( hibernateSpecificConfig, properties, externalClassLoader ),
 				ValidatorFactoryConfigurationHelper.determinePropertyNodeNameProvider( hibernateSpecificConfig, properties, externalClassLoader ) );
+		this.beanMetadataClassNormalizer = determineBeanMetaDataClassNormalizer( hibernateSpecificConfig );
 
 		// HV-302; don't load XmlMappingParser if not necessary
 		if ( configurationState.getMappingStreams().isEmpty() ) {
@@ -306,6 +311,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 						executableHelper,
 						validatorFactoryScopedContext.getParameterNameProvider(),
 						javaBeanHelper,
+						beanMetadataClassNormalizer,
 						validationOrderGenerator,
 						buildMetaDataProviders(),
 						methodValidationConfiguration

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/DefaultBeanMetaDataClassNormalizer.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/DefaultBeanMetaDataClassNormalizer.java
@@ -18,7 +18,7 @@ import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
 public class DefaultBeanMetaDataClassNormalizer implements BeanMetaDataClassNormalizer {
 
 	@Override
-	public Class<?> normalize(Class<?> beanClass) {
+	public <T> Class<T> normalize(Class<T> beanClass) {
 		return beanClass;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/metadata/BeanMetaDataClassNormalizer.java
+++ b/engine/src/main/java/org/hibernate/validator/metadata/BeanMetaDataClassNormalizer.java
@@ -35,5 +35,5 @@ public interface BeanMetaDataClassNormalizer {
 	 * @param beanClass the original bean class
 	 * @return the normalized class
 	 */
-	Class<?> normalize(Class<?> beanClass);
+	<T> Class<? super T> normalize(Class<T> beanClass);
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/ValidatorFactoryBeanMetadataClassNormalizerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/ValidatorFactoryBeanMetadataClassNormalizerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.ValidationException;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.constraints.Email;
+import javax.validation.valueextraction.Unwrapping;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.internal.engine.ValidatorFactoryImpl;
+import org.hibernate.validator.metadata.BeanMetaDataClassNormalizer;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test for {@link ValidatorFactoryImpl}.
+ *
+ * @author Gunnar Morling
+ */
+public class ValidatorFactoryBeanMetadataClassNormalizerTest {
+
+	@Test(expectedExceptions = ValidationException.class,
+			expectedExceptionsMessageRegExp = ".*No suitable value extractor found for type interface java.util.List.*")
+	public void testBeanMetaDataClassNormalizerNoNormalizer() throws NoSuchMethodException {
+		ValidatorFactory validatorFactory = Validation.byDefaultProvider()
+				.configure()
+				.buildValidatorFactory();
+
+		Validator validator = validatorFactory.getValidator();
+
+		// As the proxy defines invalid constraints (see BeanProxy), we expect this to fail
+		validator.forExecutables().validateParameters(
+				new BeanProxy(), BeanProxy.class.getMethod( "setEmails", List.class ),
+				new Object[] { Arrays.asList( "notAnEmail" ) }
+		);
+	}
+
+	@Test
+	public void testBeanMetaDataClassNormalizer() throws NoSuchMethodException {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.beanMetaDataClassNormalizer( new MyProxyInterfaceBeanMetaDataClassNormalizer() )
+				.buildValidatorFactory();
+
+		Validator validator = validatorFactory.getValidator();
+
+		Set<ConstraintViolation<Bean>> violations = validator.forExecutables().validateParameters(
+				new BeanProxy(), BeanProxy.class.getMethod( "setEmails", List.class ),
+				new Object[] { Arrays.asList( "notAnEmail" ) }
+		);
+
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Email.class ).withPropertyPath(
+						pathWith().method( "setEmails" )
+						.parameter( "emails", 0 )
+						.containerElement( "<list element>", true, null, 0, List.class, 0 )
+				)
+		);
+	}
+
+	private static class Bean {
+
+		private List<String> emails;
+
+		public Bean() {
+		}
+
+		public Bean(List<String> emails) {
+			this.emails = emails;
+		}
+
+		public List<String> getEmails() {
+			return emails;
+		}
+
+		public void setEmails(@Email(payload = Unwrapping.Unwrap.class) List<String> emails) {
+			this.emails = emails;
+		}
+	}
+
+	private interface MyProxyInterface {
+	}
+
+	private static class MyProxyInterfaceBeanMetaDataClassNormalizer implements BeanMetaDataClassNormalizer {
+
+		@Override
+		public <T> Class<? super T> normalize(Class<T> beanClass) {
+			if ( MyProxyInterface.class.isAssignableFrom( beanClass ) ) {
+				return beanClass.getSuperclass();
+			}
+
+			return beanClass;
+		}
+	}
+
+	private static class BeanProxy extends Bean implements MyProxyInterface {
+		// The proxy dropped the generics, but kept constraint annotations,
+		// which will cause trouble unless its metadata is ignored.
+		@Override
+		@SuppressWarnings("unchecked")
+		public void setEmails(@Email(payload = Unwrapping.Unwrap.class) List emails) {
+			super.setEmails( emails );
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
@@ -35,6 +35,7 @@ import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManagerImpl;
+import org.hibernate.validator.internal.metadata.DefaultBeanMetaDataClassNormalizer;
 import org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData;
 import org.hibernate.validator.internal.metadata.provider.MetaDataProvider;
 import org.hibernate.validator.internal.properties.DefaultGetterPropertySelectionStrategy;
@@ -198,6 +199,7 @@ public class PathImplTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
+				new DefaultBeanMetaDataClassNormalizer(),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/BeanMetaDataManagerTest.java
@@ -26,6 +26,7 @@ import org.hibernate.validator.internal.engine.DefaultPropertyNodeNameProvider;
 import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManagerImpl;
+import org.hibernate.validator.internal.metadata.DefaultBeanMetaDataClassNormalizer;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaDataImpl;
 import org.hibernate.validator.internal.metadata.provider.MetaDataProvider;
@@ -57,6 +58,7 @@ public class BeanMetaDataManagerTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
+				new DefaultBeanMetaDataClassNormalizer(),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ExecutableMetaDataTest.java
@@ -29,6 +29,7 @@ import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManagerImpl;
+import org.hibernate.validator.internal.metadata.DefaultBeanMetaDataClassNormalizer;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl;
@@ -63,6 +64,7 @@ public class ExecutableMetaDataTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
+				new DefaultBeanMetaDataClassNormalizer(),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/ParameterMetaDataTest.java
@@ -30,6 +30,7 @@ import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManagerImpl;
+import org.hibernate.validator.internal.metadata.DefaultBeanMetaDataClassNormalizer;
 import org.hibernate.validator.internal.metadata.aggregated.BeanMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData;
 import org.hibernate.validator.internal.metadata.aggregated.ParameterMetaData;
@@ -63,6 +64,7 @@ public class ParameterMetaDataTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
+				new DefaultBeanMetaDataClassNormalizer(),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()
@@ -132,6 +134,7 @@ public class ParameterMetaDataTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new SkewedParameterNameProvider() ),
 				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
+				new DefaultBeanMetaDataClassNormalizer(),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()

--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/aggregated/PropertyMetaDataTest.java
@@ -23,6 +23,7 @@ import org.hibernate.validator.internal.engine.MethodValidationConfiguration;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManagerImpl;
+import org.hibernate.validator.internal.metadata.DefaultBeanMetaDataClassNormalizer;
 import org.hibernate.validator.internal.metadata.aggregated.PropertyMetaData;
 import org.hibernate.validator.internal.metadata.provider.MetaDataProvider;
 import org.hibernate.validator.internal.properties.DefaultGetterPropertySelectionStrategy;
@@ -47,6 +48,7 @@ public class PropertyMetaDataTest {
 				new ExecutableHelper( new TypeResolutionHelper() ),
 				new ExecutableParameterNameProvider( new DefaultParameterNameProvider() ),
 				new JavaBeanHelper( new DefaultGetterPropertySelectionStrategy(), new DefaultPropertyNodeNameProvider() ),
+				new DefaultBeanMetaDataClassNormalizer(),
 				new ValidationOrderGenerator(),
 				Collections.<MetaDataProvider>emptyList(),
 				new MethodValidationConfiguration.Builder().build()

--- a/engine/src/test/java/org/hibernate/validator/test/predefinedscope/PredefinedScopeValidatorFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/predefinedscope/PredefinedScopeValidatorFactoryTest.java
@@ -455,7 +455,7 @@ public class PredefinedScopeValidatorFactoryTest {
 	private static class MyProxyInterfaceBeanMetaDataClassNormalizer implements BeanMetaDataClassNormalizer {
 
 		@Override
-		public Class<?> normalize(Class<?> beanClass) {
+		public <T> Class<? super T> normalize(Class<T> beanClass) {
 			if ( MyProxyInterface.class.isAssignableFrom( beanClass ) ) {
 				return beanClass.getSuperclass();
 			}

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -43,6 +43,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <scope>test</scope>
@@ -88,6 +93,12 @@
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!-- For RestEasy -->
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/ejb/EjbIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/ejb/EjbIT.java
@@ -23,6 +23,11 @@ import io.restassured.filter.log.ErrorLoggingFilter;
 import io.restassured.http.ContentType;
 import org.testng.annotations.Test;
 
+/**
+ * This is a reproducer for WFL-11566, but fixing the problem requires changes in WildFly.
+ * Thus it is ignored for now.
+ * See HV-1754.
+ */
 public class EjbIT extends AbstractArquillianIT {
 	private static final String WAR_FILE_NAME = EjbIT.class.getSimpleName() + ".war";
 	private static final String APPLICATION_PATH = EjbIT.class.getSimpleName();
@@ -42,7 +47,7 @@ public class EjbIT extends AbstractArquillianIT {
 				);
 	}
 
-	@Test
+	@Test(enabled = false)
 	@RunAsClient
 	public void testRestEasyWorks() {
 		given()
@@ -55,7 +60,7 @@ public class EjbIT extends AbstractArquillianIT {
 				.body( equalTo( "Hello bars a, b, c" ) );
 	}
 
-	@Test
+	@Test(enabled = false)
 	@RunAsClient
 	public void testValidationWorks() {
 		given()

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/ejb/EjbIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/ejb/EjbIT.java
@@ -1,0 +1,70 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.integration.wildfly.ejb;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import org.hibernate.validator.integration.AbstractArquillianIT;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+
+import io.restassured.filter.log.ErrorLoggingFilter;
+import io.restassured.http.ContentType;
+import org.testng.annotations.Test;
+
+public class EjbIT extends AbstractArquillianIT {
+	private static final String WAR_FILE_NAME = EjbIT.class.getSimpleName() + ".war";
+	private static final String APPLICATION_PATH = EjbIT.class.getSimpleName();
+
+	@Deployment
+	public static WebArchive createTestArchive() throws Exception {
+		return buildTestArchive( WAR_FILE_NAME )
+				.addClass( EjbJaxRsResource.class )
+				.addClass( JaxRsApplication.class )
+				.addAsWebInfResource( EmptyAsset.INSTANCE, "beans.xml" )
+				.addAsWebInfResource(
+						new StringAsset(
+								Descriptors.create( org.jboss.shrinkwrap.descriptor.api.webapp31.WebAppDescriptor.class )
+										.exportAsString()
+						),
+						"web.xml"
+				);
+	}
+
+	@Test
+	@RunAsClient
+	public void testRestEasyWorks() {
+		given()
+				.filter( new ErrorLoggingFilter() )
+				.body( "[\"a\", \"b\", \"c\"]" )
+				.contentType( ContentType.JSON )
+				.post( APPLICATION_PATH + "/put/list/" )
+				.then()
+				.statusCode( 200 )
+				.body( equalTo( "Hello bars a, b, c" ) );
+	}
+
+	@Test
+	@RunAsClient
+	public void testValidationWorks() {
+		given()
+				.filter( new ErrorLoggingFilter() )
+				.body( "[]" )
+				.contentType( ContentType.JSON )
+				.post( APPLICATION_PATH + "/put/list/" )
+				.then()
+				.statusCode( 400 )
+				.body( containsString( "must not be empty" ) );
+	}
+}

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/ejb/EjbJaxRsResource.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/ejb/EjbJaxRsResource.java
@@ -1,0 +1,30 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.integration.wildfly.ejb;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.ejb.Stateless;
+import javax.validation.constraints.NotEmpty;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.MediaType;
+
+@Stateless
+@Path("/")
+public class EjbJaxRsResource {
+
+	@POST
+	@Path("put/list")
+	@Consumes(MediaType.APPLICATION_JSON)
+	public String putList(@NotEmpty List<String> a) {
+		return "Hello bars " + a.stream().collect( Collectors.joining( ", " ) );
+	}
+
+}
+

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/ejb/JaxRsApplication.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/ejb/JaxRsApplication.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.integration.wildfly.ejb;
+
+import java.util.Collections;
+import java.util.Set;
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("")
+public class JaxRsApplication extends Application {
+	@Override
+	public Set<Class<?>> getClasses() {
+		return Collections.emptySet();
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,7 @@
         <version.jakarta.ejb-api>3.2.5</version.jakarta.ejb-api>
         <version.jakarta.interceptor-api>1.2.4</version.jakarta.interceptor-api>
         <version.jakarta.annotation-api>1.3.5</version.jakarta.annotation-api>
+        <version.jakarta.ws.rs-api>2.1.6</version.jakarta.ws.rs-api>
 
         <!-- JavaMoney dependencies -->
         <version.javax.money>1.0.1</version.javax.money>
@@ -168,6 +169,7 @@
         <version.org.assertj.assertj-core>3.8.0</version.org.assertj.assertj-core>
         <version.junit>4.12</version.junit>
         <version.org.easymock>3.4</version.org.easymock>
+        <version.io.rest-assured>4.1.2</version.io.rest-assured>
         <version.org.codehaus.groovy>2.4.12</version.org.codehaus.groovy>
         <version.com.google.guava>27.1-jre</version.com.google.guava>
         <version.org.springframework.spring-expression>4.3.10.RELEASE</version.org.springframework.spring-expression>
@@ -431,6 +433,11 @@
                 <version>${version.org.assertj.assertj-core}</version>
             </dependency>
             <dependency>
+                <groupId>io.rest-assured</groupId>
+                <artifactId>rest-assured</artifactId>
+                <version>${version.io.rest-assured}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
                 <version>${version.org.jboss.arquillian}</version>
@@ -441,6 +448,11 @@
                 <groupId>jakarta.annotation</groupId>
                 <artifactId>jakarta.annotation-api</artifactId>
                 <version>${version.jakarta.annotation-api}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${version.jakarta.ws.rs-api}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.interceptor</groupId>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1755
https://issues.jboss.org/browse/WFLY-11566

This does not solve the problem, but adds tests and a beginning of solution.

## Problem

Essentially the problem is caused by WildFly creating proxies that extend user-constrained classes, but that override methods incorrectly (from the HV point of view). The overrides are incorrect because they change the constraints: constraint annotations are preserved, but the type of parameters is not (it is erased), and thus the constraint annotations have a different meaning, or at the very least become ambiguous.

For example `@Max(value = 2, payload = Unwrapping.Unwrap.class) List<Integer> param` would be executed differently than  `@Max(value = 2, payload = Unwrapping.Unwrap.class) List<String> param`. Thus, when WildFly generates a parameter with types erased such as `@Max(value = 2, payload = Unwrapping.Unwrap.class) List param`, we can't decide what the constraint means.

## Solutions

There are two possible solutions:

1. Change what HV considers as "incorrect method overrides".
2. Ignore proxies when processing bean metadata, and consider that their metadata is the metadata of the type they are proxying. This would involve the `BeanMetaDataClassNormalizer` introduced in 6.1.

I started some work on solution number 2 in this PR.

## Requirements

Whatever the solution, we will have to get some information from the environment:

1. For solution 1, I don't think we can change the default behavior, because it is mandated by the BV spec. We would have to alter the behavior when a specific configuration option is changed.
2. For solution 2, we need to execute Wildfly-specific code, testing whether the class is a proxy class or not. This would likely be done by checking wether the class implements a specific interface (e.g. `org.jboss.something.SomeProxyTaggingInterface`) that only proxy classes would implement. Since that class would be specific to WildFly, we'd better implement the check in WildFly and pass it to HV somehow. This would mean implementing `BeanMetaDataClassNormalizer` in WildFly.

Thus we will need changes in WF in order to pass that information.

We will also need changes in HV, because we currently don't expose any hook that WF could take advantage of. The `ValidatorFactory` is created by HV itself through the `ValidationExtension` (a CDI extension), and WF doesn't get to configure it. The only way to configure the `ValidatorFactory` seems to be by defining a `validation.xml` or a custom `ValidatorFactory` bean, but both of those options are aimed at applications, not integrators.

Since the default `ValidatorFactory` in WildFly is created through CDI, it's likely that whatever information we need to pass to the `ValidatorFactory` will need to go through CDI, be it a bean of type `BeanMetaDataClassNormalizer` or a map of properties.

Going forward, we will need to investigate how to pass this information. We will want to involve the WildFly team before we make a decision.