### PR TITLE
HV-0000 PESEL validator didn't check if coded date is proper value

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/pl/PESELValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/pl/PESELValidator.java
@@ -6,49 +6,107 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.hv.pl;
 
-import java.util.Collections;
-import java.util.List;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
 
 import org.hibernate.validator.constraints.pl.PESEL;
-import org.hibernate.validator.internal.constraintvalidators.hv.ModCheckBase;
-import org.hibernate.validator.internal.util.ModUtil;
+
+import static java.lang.Character.getNumericValue;
+import static java.lang.Integer.parseInt;
 
 /**
  * Validator for {@link PESEL}.
  *
  * @author Marko Bekhta
  */
-public class PESELValidator extends ModCheckBase implements ConstraintValidator<PESEL, CharSequence> {
+public class PESELValidator implements ConstraintValidator<PESEL, CharSequence> {
 
-	private static final int[] WEIGHTS_PESEL = { 1, 3, 7, 9, 1, 3, 7, 9, 1, 3 };
+	private static final int PESEL_LENGTH = 11;
 
-	@Override
-	public void initialize(PESEL constraintAnnotation) {
-		super.initialize(
-				0,
-				Integer.MAX_VALUE,
-				-1,
-				false
-		);
+	private static final int[] WEIGHTS_PESEL = { 1, 3, 7, 9, 1, 3, 7, 9, 1, 3, 1 };
+	private static final Pattern VALID_PESEL_REGEX = Pattern.compile("[0-9]{11}");
+	private static final Map<Integer, Integer> YEAR_CODES = new HashMap<>();
+
+	static {
+		YEAR_CODES.put(0, 1900);
+		YEAR_CODES.put(20, 2000);
+		YEAR_CODES.put(40, 2100);
+		YEAR_CODES.put(60, 2200);
+		YEAR_CODES.put(80, 1800);
 	}
 
 	@Override
-	public boolean isCheckDigitValid(List<Integer> digits, char checkDigit) {
-		Collections.reverse( digits );
+	public boolean isValid(CharSequence value, ConstraintValidatorContext context) {
+		if (value == null) {
+			return true;
+		}
 
-		// if the length of the number is incorrect we can return fast
-		if ( digits.size() != WEIGHTS_PESEL.length  ) {
+		final String pesel = value.toString();
+
+		return containsValidCharacters(pesel)
+				&& isCheckSumValid(pesel)
+				&& isDateValid(pesel);
+
+	}
+
+	private boolean isDateValid(String pesel) {
+		int year = parseInt(pesel.substring(0, 2));
+		int monthWithCenturyCode = parseInt(pesel.substring(2, 4));
+		int month = monthWithCenturyCode % 20;
+		int dayOfMonth = parseInt(pesel.substring(4, 6));
+
+		year = extractCenturyFirstYear(month, monthWithCenturyCode) + year;
+
+		try {
+			LocalDate.of(year, month, dayOfMonth);
+		} catch (DateTimeException e) {
 			return false;
 		}
-
-		int modResult = ModUtil.calculateModXCheckWithWeights( digits, 10, Integer.MAX_VALUE, WEIGHTS_PESEL );
-		switch ( modResult ) {
-			case 10:
-				return checkDigit == '0';
-			default:
-				return Character.isDigit( checkDigit ) && modResult == extractDigit( checkDigit );
-		}
+		return true;
 	}
+
+	private int extractCenturyFirstYear(int month, int monthWithYearCode) {
+		final int yearCode = monthWithYearCode - month;
+		return YEAR_CODES.get(yearCode);
+	}
+
+	private boolean containsValidCharacters(String pesel) {
+		return VALID_PESEL_REGEX.matcher(pesel).matches();
+	}
+
+	private boolean isCheckSumValid(String pesel) {
+		final int[] digitsOfPesel = peselToDigitsArray(pesel);
+		return (calculateWeightedSum(digitsOfPesel) % 10) == 0;
+	}
+
+	private int[] peselToDigitsArray(String pesel) {
+		int[] digits = new int[PESEL_LENGTH];
+		final char[] peselCharacters = pesel.toCharArray();
+
+		for (int i = 0; i < PESEL_LENGTH; i++) {
+			digits[i] = getNumericValue(peselCharacters[i]);
+		}
+		return digits;
+	}
+
+	private int calculateWeightedSum(int[] digitsOfPesel) {
+		return (digitsOfPesel[0] * WEIGHTS_PESEL[0])
+				+ (digitsOfPesel[1] * WEIGHTS_PESEL[1])
+				+ (digitsOfPesel[2] * WEIGHTS_PESEL[2])
+				+ (digitsOfPesel[3] * WEIGHTS_PESEL[3])
+				+ (digitsOfPesel[4] * WEIGHTS_PESEL[4])
+				+ (digitsOfPesel[5] * WEIGHTS_PESEL[5])
+				+ (digitsOfPesel[6] * WEIGHTS_PESEL[6])
+				+ (digitsOfPesel[7] * WEIGHTS_PESEL[7])
+				+ (digitsOfPesel[8] * WEIGHTS_PESEL[8])
+				+ (digitsOfPesel[9] * WEIGHTS_PESEL[9])
+				+ (digitsOfPesel[10] * WEIGHTS_PESEL[10]);
+	}
+
 }

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/PESELValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/PESELValidatorTest.java
@@ -101,12 +101,81 @@ public class PESELValidatorTest extends AbstractConstrainedTest {
 				);
 	}
 
-	public static class Person {
+	@Test
+	public void testIncorrectDateInPESELNumber() {
+
+		assertThat( validator.validate( new Person("20223003433" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person("19222903431" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person("75123203434" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person("25273203437" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person("25370203433" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person("13443101230" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person("14551204561" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person("15613201234" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person("15771001231" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person("15874201235" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person("15951001235" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person( "85023003436" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+
+		assertThat( validator.validate( new Person( "85023003436" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+	}
+
+	static class Person {
 
 		@PESEL
-		private String pesel;
+		final private String pesel;
 
-		public Person(String pesel) {
+		Person(String pesel) {
 			this.pesel = pesel;
 		}
 	}


### PR DESCRIPTION
PESEL validator did not checked if the data coded in PESEL number represents proper, existing date from calendar. E.g. it was possible to mark as proper PESEL with date of 30 February encoded.

There is no issue reported in Hibernate Valirator Jira