### PR TITLE
HV-1748 HV-1747 HV-1749 Improve localization support

### DIFF
--- a/documentation/src/main/asciidoc/ch12.asciidoc
+++ b/documentation/src/main/asciidoc/ch12.asciidoc
@@ -51,6 +51,9 @@ Note that when a package is part of the public API this is not necessarily true 
 `org.hibernate.validator.spi.constraintdefinition`::
 			An SPI for registering additional constraint validators programmatically, see <<section-constraint-definition-contribution>>.
 
+`org.hibernate.validator.spi.messageinterpolation`::
+			An SPI that can be used to tweak the resolution of the locale when interpolating the constraint violation messages. See <<section-locale-resolver>>.
+
 `org.hibernate.validator.spi.nodenameprovider`::
 			An SPI that can be used to alter how the names of properties will be resolved when the property path is constructed. See <<section-property-node-name-provider>>.
 
@@ -442,6 +445,55 @@ With `ResourceBundleLocator`, Hibernate Validator provides an additional SPI whi
 error messages from other resource bundles than _ValidationMessages_ while still using the actual
 interpolation algorithm as defined by the specification. Refer to
 <<section-resource-bundle-locator>> to learn how to make use of that SPI.
+
+[[section-locale-resolver]]
+=== Customizing the locale resolution
+
+[WARNING]
+====
+These contracts are marked as `@Incubating` so they might be subject to change in the future.
+====
+
+Hibernate Validator provides several extension points to build a custom locale resolution strategy.
+The resolved locale is used when interpolating the constraint violation messages.
+
+The default behavior of Hibernate Validator is to always use the system default locale (as obtained via `Locale.getDefault()`).
+This might not be the desired behavior if, for example, you usually set your system locale to `en-US` but want your application to provide messages in French.
+
+The following example shows how to set the Hibernate Validator default locale to `fr-FR`:
+
+[[example-configure-default-locale]]
+.Configure the default locale
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/localization/LocalizationTest.java[tags=default-locale]
+----
+====
+
+While this is already a nice improvement, in a fully internationalized application, this is not sufficient:
+you need Hibernate Validator to select the locale depending on the user context.
+
+Hibernate Validator provides the `org.hibernate.validator.spi.messageinterpolation.LocaleResolver` SPI
+which allows to fine-tune the resolution of the locale.
+Typically, in a JAX-RS environment, you can resolve the locale to use from the `Accept-Language` HTTP header.
+
+In the following example, we use a hardcoded value but, for instance, in the case of a RESTEasy application,
+you could extract the header from the `ResteasyContext`.
+
+[[example-locale-resolver]]
+.Fine tune the locale used to interpolate the messages via a `LocaleResolver`
+====
+[source, JAVA, indent=0]
+----
+include::{sourcedir}/org/hibernate/validator/referenceguide/chapter12/localization/LocalizationTest.java[tags=locale-resolver]
+----
+====
+
+[NOTE]
+====
+When using the `LocaleResolver`, you have to define the list of supported locales via the `locales()` method.
+====
 
 === Custom contexts
 

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/localization/LocalizationTest.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/localization/LocalizationTest.java
@@ -1,0 +1,75 @@
+package org.hibernate.validator.referenceguide.chapter12.localization;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Locale.LanguageRange;
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.constraints.AssertTrue;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolverContext;
+import org.junit.Test;
+
+public class LocalizationTest {
+
+	@Test
+	public void changeDefaultLocale() {
+		// tag::default-locale[]
+		Validator validator = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.defaultLocale( Locale.FRANCE )
+				.buildValidatorFactory()
+				.getValidator();
+
+		Set<ConstraintViolation<Bean>> violations = validator.validate( new Bean() );
+		assertEquals( "doit avoir la valeur vrai", violations.iterator().next().getMessage() );
+		// end::default-locale[]
+	}
+
+	@Test
+	public void localeResolver() {
+		// tag::locale-resolver[]
+		LocaleResolver localeResolver = new LocaleResolver() {
+
+			@Override
+			public Locale resolve(LocaleResolverContext context) {
+				// get the locales supported by the client from the Accept-Language header
+				String acceptLanguageHeader = "it-IT;q=0.9,en-US;q=0.7";
+
+				List<LanguageRange> acceptedLanguages = LanguageRange.parse( acceptLanguageHeader );
+				List<Locale> resolvedLocales = Locale.filter( acceptedLanguages, context.getSupportedLocales() );
+
+				if ( resolvedLocales.size() > 0 ) {
+					return resolvedLocales.get( 0 );
+				}
+
+				return context.getDefaultLocale();
+			}
+		};
+
+		Validator validator = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.defaultLocale( Locale.FRANCE )
+				.locales( Locale.FRANCE, Locale.ITALY, Locale.US )
+				.localeResolver( localeResolver )
+				.buildValidatorFactory()
+				.getValidator();
+
+		Set<ConstraintViolation<Bean>> violations = validator.validate( new Bean() );
+		assertEquals( "deve essere true", violations.iterator().next().getMessage() );
+		// end::locale-resolver[]
+	}
+
+	private static class Bean {
+
+		@AssertTrue
+		private boolean invalid = false;
+	}
+}

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -22,6 +22,7 @@
 
     <properties>
         <hibernate-validator-parent.path>..</hibernate-validator-parent.path>
+        <surefire.jvm.args.additional>-Duser.language=en</surefire.jvm.args.additional>
     </properties>
 
     <distributionManagement>

--- a/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
@@ -22,6 +22,7 @@ import javax.validation.valueextraction.ValueExtractor;
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.constraints.ParameterScriptAssert;
 import org.hibernate.validator.constraints.ScriptAssert;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
 import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
 import org.hibernate.validator.spi.properties.GetterPropertySelectionStrategy;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
@@ -130,6 +131,15 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 */
 	@Incubating
 	String PROPERTY_NODE_NAME_PROVIDER_CLASSNAME = "hibernate.validator.property_node_name_provider";
+
+	/**
+	 * Property for configuring the locale resolver, allowing to select an implementation of {@link LocaleResolver}
+	 * which will be used for locale resolution when interpolating a message.
+	 *
+	 * @since 6.1.1
+	 */
+	@Incubating
+	String LOCALE_RESOLVER_CLASSNAME = "hibernate.validator.locale_resolver";
 
 	/**
 	 * <p>
@@ -371,4 +381,16 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 */
 	@Incubating
 	S defaultLocale(Locale defaultLocale);
+
+	/**
+	 * Allows setting a locale resolver, defining how the locale will be resolved when interpolating the message of a constraint violation.
+	 *
+	 * @param localeResolver the {@link LocaleResolver} to be used
+	 *
+	 * @return {@code this} following the chaining method pattern
+	 *
+	 * @since 6.1.1
+	 */
+	@Incubating
+	S localeResolver(LocaleResolver localeResolver);
 }

--- a/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator;
 
 import java.time.Duration;
+import java.util.Locale;
 import java.util.Set;
 
 import javax.validation.Configuration;
@@ -360,4 +361,14 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 */
 	@Incubating
 	S propertyNodeNameProvider(PropertyNodeNameProvider propertyNodeNameProvider);
+
+	/**
+	 * Allows setting the default locale used to interpolate the constraint violation messages.
+	 * <p>
+	 * If not set, defaults to the system locale obtained via {@link Locale#getDefault()}.
+	 *
+	 * @since 6.1.1
+	 */
+	@Incubating
+	S defaultLocale(Locale defaultLocale);
 }

--- a/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
@@ -7,6 +7,8 @@
 package org.hibernate.validator;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
@@ -371,6 +373,34 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 */
 	@Incubating
 	S propertyNodeNameProvider(PropertyNodeNameProvider propertyNodeNameProvider);
+
+	/**
+	 * Allows setting the list of the locales supported by this ValidatorFactory.
+	 * <p>
+	 * Can be used for advanced locale resolution and/or to force the initialization of the resource bundles at
+	 * bootstrap.
+	 * <p>
+	 * If not set, defaults to a singleton containing {@link Locale#getDefault()}.
+	 *
+	 * @since 6.1.1
+	 */
+	@Incubating
+	S locales(Set<Locale> locales);
+
+	/**
+	 * Allows setting the list of the locales supported by this ValidatorFactory.
+	 * <p>
+	 * Can be used for advanced locale resolution and/or to force the initialization of the resource bundles at
+	 * bootstrap.
+	 * <p>
+	 * If not set, defaults to a singleton containing {@link Locale#getDefault()}.
+	 *
+	 * @since 6.1.1
+	 */
+	@Incubating
+	default S locales(Locale... locales) {
+		return locales( new HashSet<>( Arrays.asList( locales ) ) );
+	}
 
 	/**
 	 * Allows setting the default locale used to interpolate the constraint violation messages.

--- a/engine/src/main/java/org/hibernate/validator/PredefinedScopeHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/PredefinedScopeHibernateValidatorConfiguration.java
@@ -25,7 +25,11 @@ public interface PredefinedScopeHibernateValidatorConfiguration extends BaseHibe
 	@Incubating
 	PredefinedScopeHibernateValidatorConfiguration initializeBeanMetaData(Set<Class<?>> beanClassesToInitialize);
 
+	/**
+	 * @deprecated Planned for removal, use {@link BaseHibernateValidatorConfiguration#locales(Set)} instead.
+	 */
 	@Incubating
+	@Deprecated
 	PredefinedScopeHibernateValidatorConfiguration initializeLocales(Set<Locale> locales);
 
 	@Incubating

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/AbstractConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/AbstractConfigurationImpl.java
@@ -576,7 +576,7 @@ public abstract class AbstractConfigurationImpl<T extends BaseHibernateValidator
 	public final ResourceBundleLocator getDefaultResourceBundleLocator() {
 		if ( defaultResourceBundleLocator == null ) {
 			defaultResourceBundleLocator = new PlatformResourceBundleLocator(
-					ResourceBundleMessageInterpolator.USER_VALIDATION_MESSAGES, preloadResourceBundles(), getAllSupportedLocales() );
+					ResourceBundleMessageInterpolator.USER_VALIDATION_MESSAGES, preloadResourceBundles() ? getAllSupportedLocales() : Collections.emptySet() );
 		}
 
 		return defaultResourceBundleLocator;
@@ -726,14 +726,12 @@ public abstract class AbstractConfigurationImpl<T extends BaseHibernateValidator
 		if ( externalClassLoader != null ) {
 			PlatformResourceBundleLocator userResourceBundleLocator = new PlatformResourceBundleLocator(
 					ResourceBundleMessageInterpolator.USER_VALIDATION_MESSAGES,
-					preloadResourceBundles(),
-					getAllSupportedLocales(),
+					preloadResourceBundles() ? getAllSupportedLocales() : Collections.emptySet(),
 					externalClassLoader
 			);
 			PlatformResourceBundleLocator contributorResourceBundleLocator = new PlatformResourceBundleLocator(
 					ResourceBundleMessageInterpolator.CONTRIBUTOR_VALIDATION_MESSAGES,
-					preloadResourceBundles(),
-					getAllSupportedLocales(),
+					preloadResourceBundles() ? getAllSupportedLocales() : Collections.emptySet(),
 					externalClassLoader,
 					true
 			);

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ConfigurationImpl.java
@@ -20,6 +20,7 @@ import org.hibernate.validator.HibernateValidatorConfiguration;
  * @author Gunnar Morling
  * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Chris Beckey &lt;cbeckey@paypal.com&gt;
+ * @author Guillaume Smet
  */
 public class ConfigurationImpl extends AbstractConfigurationImpl<HibernateValidatorConfiguration> implements HibernateValidatorConfiguration, ConfigurationState {
 
@@ -29,5 +30,10 @@ public class ConfigurationImpl extends AbstractConfigurationImpl<HibernateValida
 
 	public ConfigurationImpl(ValidationProvider<?> provider) {
 		super( provider );
+	}
+
+	@Override
+	protected boolean preloadResourceBundles() {
+		return false;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeConfigurationImpl.java
@@ -8,7 +8,6 @@ package org.hibernate.validator.internal.engine;
 
 import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
 
-import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 
@@ -31,13 +30,6 @@ public class PredefinedScopeConfigurationImpl extends AbstractConfigurationImpl<
 
 	private BeanMetaDataClassNormalizer beanMetaDataClassNormalizer;
 
-	/**
-	 * Locales to initialize eagerly.
-	 * <p>
-	 * We will always include the default locale in the final list.
-	 */
-	private Set<Locale> localesToInitialize = Collections.emptySet();
-
 	public PredefinedScopeConfigurationImpl(BootstrapState state) {
 		super( state );
 	}
@@ -59,7 +51,7 @@ public class PredefinedScopeConfigurationImpl extends AbstractConfigurationImpl<
 	@Override
 	public PredefinedScopeHibernateValidatorConfiguration initializeLocales(Set<Locale> localesToInitialize) {
 		Contracts.assertNotNull( localesToInitialize, MESSAGES.parameterMustNotBeNull( "localesToInitialize" ) );
-		this.localesToInitialize = localesToInitialize;
+		locales( localesToInitialize );
 		return thisAsT();
 	}
 
@@ -74,14 +66,7 @@ public class PredefinedScopeConfigurationImpl extends AbstractConfigurationImpl<
 	}
 
 	@Override
-	protected Set<Locale> getAllLocalesToInitialize() {
-		if ( localesToInitialize.isEmpty() ) {
-			return Collections.singleton( getDefaultLocale() );
-		}
-
-		Set<Locale> allLocales = CollectionHelper.newHashSet( localesToInitialize.size() + 1 );
-		allLocales.addAll( localesToInitialize );
-		allLocales.add( getDefaultLocale() );
-		return Collections.unmodifiableSet( allLocales );
+	protected boolean preloadResourceBundles() {
+		return true;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorContextImpl.java
@@ -34,7 +34,8 @@ public class PredefinedScopeValidatorContextImpl implements HibernateValidatorCo
 
 	@Override
 	public HibernateValidatorContext messageInterpolator(MessageInterpolator messageInterpolator) {
-		throw new IllegalStateException( "Defining a Validator-specific message interpolator is not supported by the predefined scope ValidatorFactory." );
+		validatorFactoryScopedContextBuilder.setMessageInterpolator( messageInterpolator );
+		return this;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
@@ -9,6 +9,7 @@ package org.hibernate.validator.internal.engine;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineAllowMultipleCascadedValidationOnReturnValues;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineAllowOverridingMethodAlterParameterConstraint;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineAllowParallelMethodsDefineParameterConstraints;
+import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineBeanMetaDataClassNormalizer;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintMappings;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintValidatorPayload;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineExternalClassLoader;
@@ -18,7 +19,6 @@ import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurat
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineTraversableResolverResultCacheEnabled;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.logValidatorFactoryScopedConfiguration;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.registerCustomConstraintValidators;
-import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineBeanMetaDataClassNormalizer;
 import static org.hibernate.validator.internal.util.CollectionHelper.newArrayList;
 
 import java.lang.invoke.MethodHandles;

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/DefaultLocaleResolver.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/DefaultLocaleResolver.java
@@ -1,0 +1,20 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.messageinterpolation;
+
+import java.util.Locale;
+
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolverContext;
+
+public class DefaultLocaleResolver implements LocaleResolver {
+
+	@Override
+	public Locale resolve(LocaleResolverContext context) {
+		return context.getDefaultLocale();
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/DefaultLocaleResolverContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/DefaultLocaleResolverContext.java
@@ -1,0 +1,34 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.internal.engine.messageinterpolation;
+
+import java.util.Locale;
+import java.util.Set;
+
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolverContext;
+
+public class DefaultLocaleResolverContext implements LocaleResolverContext {
+
+	private final Set<Locale> supportedLocales;
+
+	private final Locale defaultLocale;
+
+	public DefaultLocaleResolverContext(Set<Locale> supportedLocales, Locale defaultLocale) {
+		this.supportedLocales = supportedLocales;
+		this.defaultLocale = defaultLocale;
+	}
+
+	@Override
+	public Set<Locale> getSupportedLocales() {
+		return supportedLocales;
+	}
+
+	@Override
+	public Locale getDefaultLocale() {
+		return defaultLocale;
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -63,6 +63,7 @@ import org.hibernate.validator.internal.util.logging.formatter.ExecutableFormatt
 import org.hibernate.validator.internal.util.logging.formatter.ObjectArrayFormatter;
 import org.hibernate.validator.internal.util.logging.formatter.TypeFormatter;
 import org.hibernate.validator.internal.xml.mapping.ContainerElementTypePath;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
 import org.hibernate.validator.spi.nodenameprovider.PropertyNodeNameProvider;
 import org.hibernate.validator.spi.properties.GetterPropertySelectionStrategy;
 import org.hibernate.validator.spi.scripting.ScriptEvaluationException;
@@ -900,4 +901,11 @@ public interface Log extends BasicLogger {
 			+ " To solve this, compile your code with the '-parameters' flag."
 	)
 	void missingParameterMetadataWithSyntheticOrImplicitParameters(@FormatWith(ExecutableFormatter.class) Executable executable);
+
+	@LogMessage(level = DEBUG)
+	@Message(id = 255, value = "Using %s as locale resolver.")
+	void usingLocaleResolver(@FormatWith(ClassObjectFormatter.class) Class<? extends LocaleResolver> localeResolverClass);
+
+	@Message(id = 256, value = "Unable to instantiate locale resolver class %s.")
+	ValidationException getUnableToInstantiateLocaleResolverClassException(String localeResolverClassName, @Cause Exception e);
 }

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/AbstractMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/AbstractMessageInterpolator.java
@@ -280,7 +280,7 @@ public abstract class AbstractMessageInterpolator implements MessageInterpolator
 
 		if ( userResourceBundleLocator == null ) {
 			this.userResourceBundleLocator = new PlatformResourceBundleLocator( USER_VALIDATION_MESSAGES,
-					preloadResourceBundles, allLocalesToInitialize );
+					allLocalesToInitialize );
 		}
 		else {
 			this.userResourceBundleLocator = userResourceBundleLocator;
@@ -289,7 +289,6 @@ public abstract class AbstractMessageInterpolator implements MessageInterpolator
 		if ( contributorResourceBundleLocator == null ) {
 			this.contributorResourceBundleLocator = new PlatformResourceBundleLocator(
 					CONTRIBUTOR_VALIDATION_MESSAGES,
-					preloadResourceBundles,
 					allLocalesToInitialize,
 					null,
 					true
@@ -299,7 +298,7 @@ public abstract class AbstractMessageInterpolator implements MessageInterpolator
 			this.contributorResourceBundleLocator = contributorResourceBundleLocator;
 		}
 
-		this.defaultResourceBundleLocator = new PlatformResourceBundleLocator( DEFAULT_VALIDATION_MESSAGES, preloadResourceBundles, allLocalesToInitialize );
+		this.defaultResourceBundleLocator = new PlatformResourceBundleLocator( DEFAULT_VALIDATION_MESSAGES, allLocalesToInitialize );
 
 		this.cachingEnabled = cacheMessages;
 		if ( cachingEnabled ) {

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/ParameterMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/ParameterMessageInterpolator.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
 
+import org.hibernate.validator.Incubating;
 import org.hibernate.validator.internal.engine.messageinterpolation.InterpolationTerm;
 import org.hibernate.validator.internal.engine.messageinterpolation.ParameterTermResolver;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -28,11 +29,15 @@ public class ParameterMessageInterpolator extends AbstractMessageInterpolator {
 	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
 
 	public ParameterMessageInterpolator() {
-		this( Collections.emptySet() );
+		this( Collections.emptySet(), Locale.getDefault() );
 	}
 
-	public ParameterMessageInterpolator(Set<Locale> localesToInitialize) {
-		super( localesToInitialize );
+	/**
+	 * @since 6.1.1
+	 */
+	@Incubating
+	public ParameterMessageInterpolator(Set<Locale> localesToInitialize, Locale defaultLocale) {
+		super( localesToInitialize, defaultLocale );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/ParameterMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/ParameterMessageInterpolator.java
@@ -32,23 +32,23 @@ public class ParameterMessageInterpolator extends AbstractMessageInterpolator {
 	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
 
 	public ParameterMessageInterpolator() {
-		this( Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver() );
+		this( Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(), false );
 	}
 
 	/**
 	 * @since 6.1.1
 	 */
 	@Incubating
-	public ParameterMessageInterpolator(Set<Locale> localesToInitialize, Locale defaultLocale) {
-		this( localesToInitialize, defaultLocale, new DefaultLocaleResolver() );
+	public ParameterMessageInterpolator(Set<Locale> locales, Locale defaultLocale, boolean preloadResourceBundles) {
+		this( locales, defaultLocale, new DefaultLocaleResolver(), preloadResourceBundles );
 	}
 
 	/**
 	 * @since 6.1.1
 	 */
 	@Incubating
-	public ParameterMessageInterpolator(Set<Locale> localesToInitialize, Locale defaultLocale, LocaleResolver localeResolver) {
-		super( localesToInitialize, defaultLocale, localeResolver );
+	public ParameterMessageInterpolator(Set<Locale> locales, Locale defaultLocale, LocaleResolver localeResolver, boolean preloadResourceBundles) {
+		super( locales, defaultLocale, localeResolver, preloadResourceBundles );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/ParameterMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/ParameterMessageInterpolator.java
@@ -12,16 +12,19 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.hibernate.validator.Incubating;
+import org.hibernate.validator.internal.engine.messageinterpolation.DefaultLocaleResolver;
 import org.hibernate.validator.internal.engine.messageinterpolation.InterpolationTerm;
 import org.hibernate.validator.internal.engine.messageinterpolation.ParameterTermResolver;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
 
 /**
  * Resource bundle message interpolator, it does not support EL expression
  * and does support parameter value expression
  *
  * @author Adam Stawicki
+ * @author Guillaume Smet
  * @since 5.2
  */
 public class ParameterMessageInterpolator extends AbstractMessageInterpolator {
@@ -29,7 +32,7 @@ public class ParameterMessageInterpolator extends AbstractMessageInterpolator {
 	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
 
 	public ParameterMessageInterpolator() {
-		this( Collections.emptySet(), Locale.getDefault() );
+		this( Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver() );
 	}
 
 	/**
@@ -37,7 +40,15 @@ public class ParameterMessageInterpolator extends AbstractMessageInterpolator {
 	 */
 	@Incubating
 	public ParameterMessageInterpolator(Set<Locale> localesToInitialize, Locale defaultLocale) {
-		super( localesToInitialize, defaultLocale );
+		this( localesToInitialize, defaultLocale, new DefaultLocaleResolver() );
+	}
+
+	/**
+	 * @since 6.1.1
+	 */
+	@Incubating
+	public ParameterMessageInterpolator(Set<Locale> localesToInitialize, Locale defaultLocale, LocaleResolver localeResolver) {
+		super( localesToInitialize, defaultLocale, localeResolver );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import javax.el.ELManager;
 import javax.el.ExpressionFactory;
 
+import org.hibernate.validator.Incubating;
 import org.hibernate.validator.internal.engine.messageinterpolation.InterpolationTerm;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -40,69 +41,99 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	private final ExpressionFactory expressionFactory;
 
 	public ResourceBundleMessageInterpolator() {
-		this( Collections.emptySet() );
+		this( Collections.emptySet(), Locale.getDefault() );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator) {
-		this( userResourceBundleLocator, Collections.emptySet() );
+		this( userResourceBundleLocator, Collections.emptySet(), Locale.getDefault() );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator) {
-		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet() );
+		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet(), Locale.getDefault() );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator,
 			boolean cachingEnabled) {
-		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet(), cachingEnabled );
+		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet(), Locale.getDefault(), cachingEnabled );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator, boolean cachingEnabled) {
-		this( userResourceBundleLocator, null, Collections.emptySet(), cachingEnabled );
+		this( userResourceBundleLocator, null, Collections.emptySet(), Locale.getDefault(), cachingEnabled );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			boolean cachingEnabled,
 			ExpressionFactory expressionFactory) {
-		this( userResourceBundleLocator, null, Collections.emptySet(), cachingEnabled );
+		this( userResourceBundleLocator, null, Collections.emptySet(), Locale.getDefault(), cachingEnabled );
 	}
 
-	public ResourceBundleMessageInterpolator(Set<Locale> localesToInitialize) {
-		super( localesToInitialize );
+	/**
+	 * @since 6.1.1
+	 */
+	@Incubating
+	public ResourceBundleMessageInterpolator(Set<Locale> localesToInitialize, Locale defaultLocale) {
+		super( localesToInitialize, defaultLocale );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
-	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator, Set<Locale> localesToInitialize) {
-		super( userResourceBundleLocator, localesToInitialize );
+	/**
+	 * @since 6.1.1
+	 */
+	@Incubating
+	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator, Set<Locale> localesToInitialize, Locale defaultLocale) {
+		super( userResourceBundleLocator, localesToInitialize, defaultLocale );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
-	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
-			ResourceBundleLocator contributorResourceBundleLocator,
-			Set<Locale> localesToInitialize) {
-		super( userResourceBundleLocator, contributorResourceBundleLocator, localesToInitialize );
-		this.expressionFactory = buildExpressionFactory();
-	}
-
+	/**
+	 * @since 6.1.1
+	 */
+	@Incubating
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator,
 			Set<Locale> localesToInitialize,
+			Locale defaultLocale) {
+		super( userResourceBundleLocator, contributorResourceBundleLocator, localesToInitialize, defaultLocale );
+		this.expressionFactory = buildExpressionFactory();
+	}
+
+	/**
+	 * @since 6.1.1
+	 */
+	@Incubating
+	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
+			ResourceBundleLocator contributorResourceBundleLocator,
+			Set<Locale> localesToInitialize,
+			Locale defaultLocale,
 			boolean cachingEnabled) {
-		super( userResourceBundleLocator, contributorResourceBundleLocator, localesToInitialize, cachingEnabled );
+		super( userResourceBundleLocator, contributorResourceBundleLocator, localesToInitialize, defaultLocale, cachingEnabled );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
-	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator, Set<Locale> localesToInitialize, boolean cachingEnabled) {
-		super( userResourceBundleLocator, null, localesToInitialize, cachingEnabled );
-		this.expressionFactory = buildExpressionFactory();
-	}
-
+	/**
+	 * @since 6.1.1
+	 */
+	@Incubating
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			Set<Locale> localesToInitialize,
+			Locale defaultLocale,
+			boolean cachingEnabled) {
+		super( userResourceBundleLocator, null, localesToInitialize, defaultLocale, cachingEnabled );
+		this.expressionFactory = buildExpressionFactory();
+	}
+
+	/**
+	 * @since 6.1.1
+	 */
+	@Incubating
+	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
+			Set<Locale> localesToInitialize,
+			Locale defaultLocale,
 			boolean cachingEnabled,
 			ExpressionFactory expressionFactory) {
-		super( userResourceBundleLocator, null, localesToInitialize, cachingEnabled );
+		super( userResourceBundleLocator, null, localesToInitialize, defaultLocale, cachingEnabled );
 		this.expressionFactory = expressionFactory;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
@@ -17,11 +17,13 @@ import javax.el.ELManager;
 import javax.el.ExpressionFactory;
 
 import org.hibernate.validator.Incubating;
+import org.hibernate.validator.internal.engine.messageinterpolation.DefaultLocaleResolver;
 import org.hibernate.validator.internal.engine.messageinterpolation.InterpolationTerm;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetClassLoader;
 import org.hibernate.validator.internal.util.privilegedactions.SetContextClassLoader;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
 
 /**
@@ -41,49 +43,41 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	private final ExpressionFactory expressionFactory;
 
 	public ResourceBundleMessageInterpolator() {
-		this( Collections.emptySet(), Locale.getDefault() );
+		this( Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver() );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator) {
-		this( userResourceBundleLocator, Collections.emptySet(), Locale.getDefault() );
+		this( userResourceBundleLocator, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver() );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator) {
-		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet(), Locale.getDefault() );
+		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver() );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator,
 			boolean cachingEnabled) {
-		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet(), Locale.getDefault(), cachingEnabled );
+		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(),
+				cachingEnabled );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator, boolean cachingEnabled) {
-		this( userResourceBundleLocator, null, Collections.emptySet(), Locale.getDefault(), cachingEnabled );
+		this( userResourceBundleLocator, null, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(), cachingEnabled );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			boolean cachingEnabled,
 			ExpressionFactory expressionFactory) {
-		this( userResourceBundleLocator, null, Collections.emptySet(), Locale.getDefault(), cachingEnabled );
+		this( userResourceBundleLocator, null, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(), cachingEnabled );
 	}
 
 	/**
 	 * @since 6.1.1
 	 */
 	@Incubating
-	public ResourceBundleMessageInterpolator(Set<Locale> localesToInitialize, Locale defaultLocale) {
-		super( localesToInitialize, defaultLocale );
-		this.expressionFactory = buildExpressionFactory();
-	}
-
-	/**
-	 * @since 6.1.1
-	 */
-	@Incubating
-	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator, Set<Locale> localesToInitialize, Locale defaultLocale) {
-		super( userResourceBundleLocator, localesToInitialize, defaultLocale );
+	public ResourceBundleMessageInterpolator(Set<Locale> localesToInitialize, Locale defaultLocale, LocaleResolver localeResolver) {
+		super( localesToInitialize, defaultLocale, localeResolver );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
@@ -92,10 +86,10 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	 */
 	@Incubating
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
-			ResourceBundleLocator contributorResourceBundleLocator,
 			Set<Locale> localesToInitialize,
-			Locale defaultLocale) {
-		super( userResourceBundleLocator, contributorResourceBundleLocator, localesToInitialize, defaultLocale );
+			Locale defaultLocale,
+			LocaleResolver localeResolver) {
+		super( userResourceBundleLocator, localesToInitialize, defaultLocale, localeResolver );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
@@ -107,8 +101,22 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 			ResourceBundleLocator contributorResourceBundleLocator,
 			Set<Locale> localesToInitialize,
 			Locale defaultLocale,
+			LocaleResolver localeResolver) {
+		super( userResourceBundleLocator, contributorResourceBundleLocator, localesToInitialize, defaultLocale, localeResolver );
+		this.expressionFactory = buildExpressionFactory();
+	}
+
+	/**
+	 * @since 6.1.1
+	 */
+	@Incubating
+	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
+			ResourceBundleLocator contributorResourceBundleLocator,
+			Set<Locale> localesToInitialize,
+			Locale defaultLocale,
+			LocaleResolver localeResolver,
 			boolean cachingEnabled) {
-		super( userResourceBundleLocator, contributorResourceBundleLocator, localesToInitialize, defaultLocale, cachingEnabled );
+		super( userResourceBundleLocator, contributorResourceBundleLocator, localesToInitialize, defaultLocale, localeResolver, cachingEnabled );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
@@ -119,8 +127,9 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			Set<Locale> localesToInitialize,
 			Locale defaultLocale,
+			LocaleResolver localeResolver,
 			boolean cachingEnabled) {
-		super( userResourceBundleLocator, null, localesToInitialize, defaultLocale, cachingEnabled );
+		super( userResourceBundleLocator, null, localesToInitialize, defaultLocale, localeResolver, cachingEnabled );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
@@ -131,9 +140,10 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			Set<Locale> localesToInitialize,
 			Locale defaultLocale,
+			LocaleResolver localeResolver,
 			boolean cachingEnabled,
 			ExpressionFactory expressionFactory) {
-		super( userResourceBundleLocator, null, localesToInitialize, defaultLocale, cachingEnabled );
+		super( userResourceBundleLocator, null, localesToInitialize, defaultLocale, localeResolver, cachingEnabled );
 		this.expressionFactory = expressionFactory;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
@@ -43,41 +43,41 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	private final ExpressionFactory expressionFactory;
 
 	public ResourceBundleMessageInterpolator() {
-		this( Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver() );
+		this( Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(), false );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator) {
-		this( userResourceBundleLocator, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver() );
+		this( userResourceBundleLocator, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(), false );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator) {
-		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver() );
+		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(), false );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator,
 			boolean cachingEnabled) {
 		this( userResourceBundleLocator, contributorResourceBundleLocator, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(),
-				cachingEnabled );
+				false, cachingEnabled );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator, boolean cachingEnabled) {
-		this( userResourceBundleLocator, null, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(), cachingEnabled );
+		this( userResourceBundleLocator, null, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(), false, cachingEnabled );
 	}
 
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			boolean cachingEnabled,
 			ExpressionFactory expressionFactory) {
-		this( userResourceBundleLocator, null, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(), cachingEnabled );
+		this( userResourceBundleLocator, null, Collections.emptySet(), Locale.getDefault(), new DefaultLocaleResolver(), false, cachingEnabled );
 	}
 
 	/**
 	 * @since 6.1.1
 	 */
 	@Incubating
-	public ResourceBundleMessageInterpolator(Set<Locale> localesToInitialize, Locale defaultLocale, LocaleResolver localeResolver) {
-		super( localesToInitialize, defaultLocale, localeResolver );
+	public ResourceBundleMessageInterpolator(Set<Locale> locales, Locale defaultLocale, LocaleResolver localeResolver, boolean preloadResourceBundles) {
+		super( locales, defaultLocale, localeResolver, preloadResourceBundles );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
@@ -86,10 +86,11 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	 */
 	@Incubating
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
-			Set<Locale> localesToInitialize,
+			Set<Locale> locales,
 			Locale defaultLocale,
-			LocaleResolver localeResolver) {
-		super( userResourceBundleLocator, localesToInitialize, defaultLocale, localeResolver );
+			LocaleResolver localeResolver,
+			boolean preloadResourceBundles) {
+		super( userResourceBundleLocator, locales, defaultLocale, localeResolver, preloadResourceBundles );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
@@ -99,10 +100,11 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	@Incubating
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator,
-			Set<Locale> localesToInitialize,
+			Set<Locale> locales,
 			Locale defaultLocale,
-			LocaleResolver localeResolver) {
-		super( userResourceBundleLocator, contributorResourceBundleLocator, localesToInitialize, defaultLocale, localeResolver );
+			LocaleResolver localeResolver,
+			boolean preloadResourceBundles) {
+		super( userResourceBundleLocator, contributorResourceBundleLocator, locales, defaultLocale, localeResolver, preloadResourceBundles );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
@@ -112,11 +114,13 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	@Incubating
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
 			ResourceBundleLocator contributorResourceBundleLocator,
-			Set<Locale> localesToInitialize,
+			Set<Locale> locales,
 			Locale defaultLocale,
 			LocaleResolver localeResolver,
+			boolean preloadResourceBundles,
 			boolean cachingEnabled) {
-		super( userResourceBundleLocator, contributorResourceBundleLocator, localesToInitialize, defaultLocale, localeResolver, cachingEnabled );
+		super( userResourceBundleLocator, contributorResourceBundleLocator, locales, defaultLocale, localeResolver, preloadResourceBundles,
+				cachingEnabled );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
@@ -125,11 +129,12 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	 */
 	@Incubating
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
-			Set<Locale> localesToInitialize,
+			Set<Locale> locales,
 			Locale defaultLocale,
 			LocaleResolver localeResolver,
+			boolean preloadResourceBundles,
 			boolean cachingEnabled) {
-		super( userResourceBundleLocator, null, localesToInitialize, defaultLocale, localeResolver, cachingEnabled );
+		super( userResourceBundleLocator, null, locales, defaultLocale, localeResolver, preloadResourceBundles, cachingEnabled );
 		this.expressionFactory = buildExpressionFactory();
 	}
 
@@ -138,12 +143,13 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	 */
 	@Incubating
 	public ResourceBundleMessageInterpolator(ResourceBundleLocator userResourceBundleLocator,
-			Set<Locale> localesToInitialize,
+			Set<Locale> locales,
 			Locale defaultLocale,
 			LocaleResolver localeResolver,
+			boolean preloadResourceBundles,
 			boolean cachingEnabled,
 			ExpressionFactory expressionFactory) {
-		super( userResourceBundleLocator, null, localesToInitialize, defaultLocale, localeResolver, cachingEnabled );
+		super( userResourceBundleLocator, null, locales, defaultLocale, localeResolver, preloadResourceBundles, cachingEnabled );
 		this.expressionFactory = expressionFactory;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/resourceloading/AggregateResourceBundleLocator.java
+++ b/engine/src/main/java/org/hibernate/validator/resourceloading/AggregateResourceBundleLocator.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
 
+import org.hibernate.validator.Incubating;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.spi.resourceloading.ResourceBundleLocator;
@@ -42,7 +43,7 @@ public class AggregateResourceBundleLocator extends DelegatingResourceBundleLoca
 	 * first bundle containing the key.
 	 */
 	public AggregateResourceBundleLocator(List<String> bundleNames) {
-		this( bundleNames, Collections.emptySet(), null );
+		this( bundleNames, false, Collections.emptySet(), null );
 	}
 
 	/**
@@ -58,7 +59,7 @@ public class AggregateResourceBundleLocator extends DelegatingResourceBundleLoca
 	 * source bundles.
 	 */
 	public AggregateResourceBundleLocator(List<String> bundleNames, ResourceBundleLocator delegate) {
-		this( bundleNames, Collections.emptySet(), delegate, null );
+		this( bundleNames, false, Collections.emptySet(), delegate, null );
 	}
 
 	/**
@@ -77,7 +78,7 @@ public class AggregateResourceBundleLocator extends DelegatingResourceBundleLoca
 	 */
 	public AggregateResourceBundleLocator(List<String> bundleNames, ResourceBundleLocator delegate,
 			ClassLoader classLoader) {
-		this( bundleNames, Collections.emptySet(), delegate, classLoader );
+		this( bundleNames, false, Collections.emptySet(), delegate, classLoader );
 	}
 
 	/**
@@ -88,12 +89,14 @@ public class AggregateResourceBundleLocator extends DelegatingResourceBundleLoca
 	 * contain all entries from all source bundles. In case a key occurs
 	 * in multiple source bundles, the value will be taken from the
 	 * first bundle containing the key.
-	 * @param localesToInitialize The set of locales to initialize at bootstrap.
+	 * @param preloadResourceBundles if resource bundles should be initialized when initializing the locator
+	 * @param localesToInitialize The set of locales to initialize at bootstrap
 	 *
-	 * @since 6.1
+	 * @since 6.1.1
 	 */
-	public AggregateResourceBundleLocator(List<String> bundleNames, Set<Locale> localesToInitialize) {
-		this( bundleNames, localesToInitialize, null );
+	@Incubating
+	public AggregateResourceBundleLocator(List<String> bundleNames, boolean preloadResourceBundles, Set<Locale> localesToInitialize) {
+		this( bundleNames, preloadResourceBundles, localesToInitialize, null );
 	}
 
 	/**
@@ -104,15 +107,20 @@ public class AggregateResourceBundleLocator extends DelegatingResourceBundleLoca
 	 * contain all keys from all source bundles. In case a key occurs
 	 * in multiple source bundles, the value will be taken from the
 	 * first bundle containing the key.
-	 * @param localesToInitialize The set of locales to initialize at bootstrap.
+	 * @param preloadResourceBundles if resource bundles should be initialized when initializing the locator
+	 * @param localesToInitialize The set of locales to initialize at bootstrap
 	 * @param delegate A delegate resource bundle locator. The bundle returned by
 	 * this locator will be added to the aggregate bundle after all
 	 * source bundles.
 	 *
-	 * @since 6.1
+	 * @since 6.1.1
 	 */
-	public AggregateResourceBundleLocator(List<String> bundleNames, Set<Locale> localesToInitialize, ResourceBundleLocator delegate) {
-		this( bundleNames, localesToInitialize, delegate, null );
+	@Incubating
+	public AggregateResourceBundleLocator(List<String> bundleNames,
+			boolean preloadResourceBundles,
+			Set<Locale> localesToInitialize,
+			ResourceBundleLocator delegate) {
+		this( bundleNames, preloadResourceBundles, localesToInitialize, delegate, null );
 	}
 
 	/**
@@ -123,22 +131,27 @@ public class AggregateResourceBundleLocator extends DelegatingResourceBundleLoca
 	 * contain all keys from all source bundles. In case a key occurs
 	 * in multiple source bundles, the value will be taken from the
 	 * first bundle containing the key.
-	 * @param localesToInitialize The set of locales to initialize at bootstrap.
+	 * @param preloadResourceBundles if resource bundles should be initialized when initializing the locator
+	 * @param localesToInitialize The set of locales to initialize at bootstrap
 	 * @param delegate A delegate resource bundle locator. The bundle returned by
 	 * this locator will be added to the aggregate bundle after all
 	 * source bundles.
 	 * @param classLoader The classloader to use for loading the bundle.
 	 *
-	 * @since 6.1
+	 * @since 6.1.1
 	 */
-	public AggregateResourceBundleLocator(List<String> bundleNames, Set<Locale> localesToInitialize, ResourceBundleLocator delegate,
+	@Incubating
+	public AggregateResourceBundleLocator(List<String> bundleNames,
+			boolean preloadResourceBundles,
+			Set<Locale> localesToInitialize,
+			ResourceBundleLocator delegate,
 			ClassLoader classLoader) {
 		super( delegate );
 		Contracts.assertValueNotNull( bundleNames, "bundleNames" );
 
 		List<PlatformResourceBundleLocator> tmpBundleLocators = new ArrayList<>( bundleNames.size() );
 		for ( String bundleName : bundleNames ) {
-			tmpBundleLocators.add( new PlatformResourceBundleLocator( bundleName, localesToInitialize, classLoader ) );
+			tmpBundleLocators.add( new PlatformResourceBundleLocator( bundleName, preloadResourceBundles, localesToInitialize, classLoader ) );
 		}
 		this.resourceBundleLocators = CollectionHelper.toImmutableList( tmpBundleLocators );
 	}

--- a/engine/src/main/java/org/hibernate/validator/resourceloading/AggregateResourceBundleLocator.java
+++ b/engine/src/main/java/org/hibernate/validator/resourceloading/AggregateResourceBundleLocator.java
@@ -151,7 +151,8 @@ public class AggregateResourceBundleLocator extends DelegatingResourceBundleLoca
 
 		List<PlatformResourceBundleLocator> tmpBundleLocators = new ArrayList<>( bundleNames.size() );
 		for ( String bundleName : bundleNames ) {
-			tmpBundleLocators.add( new PlatformResourceBundleLocator( bundleName, preloadResourceBundles, localesToInitialize, classLoader ) );
+			tmpBundleLocators
+					.add( new PlatformResourceBundleLocator( bundleName, preloadResourceBundles ? localesToInitialize : Collections.emptySet(), classLoader ) );
 		}
 		this.resourceBundleLocators = CollectionHelper.toImmutableList( tmpBundleLocators );
 	}

--- a/engine/src/main/java/org/hibernate/validator/spi/messageinterpolation/LocaleResolver.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/messageinterpolation/LocaleResolver.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.spi.messageinterpolation;
+
+import java.util.Locale;
+
+import org.hibernate.validator.Incubating;
+
+/**
+ * Define the strategy used to resolve the locale user for message interpolation when no locale is defined from the list
+ * of supported locales.
+ *
+ * @author Guillaume Smet
+ * @since 6.1.1
+ */
+@Incubating
+public interface LocaleResolver {
+
+	/**
+	 * Returns the locale used for message interpolation when no locale is defined.
+	 *
+	 * @param context the context
+	 *
+	 * @return the locale to use for message interpolation, never null
+	 */
+	Locale resolve(LocaleResolverContext context);
+}

--- a/engine/src/main/java/org/hibernate/validator/spi/messageinterpolation/LocaleResolverContext.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/messageinterpolation/LocaleResolverContext.java
@@ -1,0 +1,26 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.spi.messageinterpolation;
+
+import java.util.Locale;
+import java.util.Set;
+
+import org.hibernate.validator.Incubating;
+
+/**
+ * Context used for locale resolution.
+ *
+ * @author Guillaume Smet
+ * @since 6.1.1
+ */
+@Incubating
+public interface LocaleResolverContext {
+
+	Set<Locale> getSupportedLocales();
+
+	Locale getDefaultLocale();
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/DefaultLocaleMessageInterpolationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/DefaultLocaleMessageInterpolationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.messageinterpolation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+
+import javax.validation.MessageInterpolator;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+import javax.validation.metadata.ConstraintDescriptor;
+
+import org.hibernate.validator.HibernateValidator;
+import org.testng.annotations.Test;
+
+public class DefaultLocaleMessageInterpolationTest {
+
+	@Test
+	public void testNoDefaultLocaleDefinedStillWorking() {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.buildValidatorFactory();
+
+		MessageInterpolator messageInterpolator = validatorFactory.getMessageInterpolator();
+
+		assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+						.isEqualTo( "must be false" );
+	}
+
+	@Test
+	public void testDefaultLocaleHonored() {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.defaultLocale( Locale.FRANCE )
+				.buildValidatorFactory();
+
+		MessageInterpolator messageInterpolator = validatorFactory.getMessageInterpolator();
+
+		assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+						.isEqualTo( "doit avoir la valeur faux" );
+
+		validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.defaultLocale( Locale.ITALY )
+				.buildValidatorFactory();
+
+		messageInterpolator = validatorFactory.getMessageInterpolator();
+
+		assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+						.isEqualTo( "deve essere false" );
+	}
+
+	private static class TestContext implements MessageInterpolator.Context {
+
+		@Override
+		public ConstraintDescriptor<?> getConstraintDescriptor() {
+			return null;
+		}
+
+		@Override
+		public Object getValidatedValue() {
+			return null;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T unwrap(Class<T> type) {
+			return (T) this;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/LocaleResolverTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/LocaleResolverTest.java
@@ -1,0 +1,100 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.messageinterpolation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+
+import javax.validation.MessageInterpolator;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+import javax.validation.metadata.ConstraintDescriptor;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolverContext;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutil.ValidationXmlTestHelper;
+import org.testng.annotations.Test;
+
+@TestForIssue(jiraKey = "HV-1749")
+public class LocaleResolverTest {
+
+	@Test
+	public void testLocaleResolver() {
+		ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+				.configure()
+				.localeResolver( new StaticFieldLocaleResolver() )
+				.buildValidatorFactory();
+		MessageInterpolator messageInterpolator = validatorFactory.getMessageInterpolator();
+
+		StaticFieldLocaleResolver.resolvedLocale = Locale.FRANCE;
+		assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+				.isEqualTo( "doit avoir la valeur faux" );
+
+		StaticFieldLocaleResolver.resolvedLocale = Locale.ITALY;
+		assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+				.isEqualTo( "deve essere false" );
+	}
+
+	@Test
+	public void shouldApplyLocaleResolverConfiguredInValidationXml() {
+		runWithCustomValidationXml( "locale-resolver-validation.xml", new Runnable() {
+
+			@Override
+			public void run() {
+				ValidatorFactory validatorFactory = Validation.byProvider( HibernateValidator.class )
+						.configure()
+						.buildValidatorFactory();
+				MessageInterpolator messageInterpolator = validatorFactory.getMessageInterpolator();
+
+				StaticFieldLocaleResolver.resolvedLocale = Locale.FRANCE;
+				assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+						.isEqualTo( "doit avoir la valeur faux" );
+
+				StaticFieldLocaleResolver.resolvedLocale = Locale.ITALY;
+				assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+						.isEqualTo( "deve essere false" );
+			}
+		} );
+	}
+
+	private void runWithCustomValidationXml(String validationXmlName, Runnable runnable) {
+		new ValidationXmlTestHelper( LocaleResolverTest.class ).
+			runWithCustomValidationXml( validationXmlName, runnable );
+	}
+
+	public static class StaticFieldLocaleResolver implements LocaleResolver {
+
+		private static Locale resolvedLocale = Locale.FRANCE;
+
+		@Override
+		public Locale resolve(LocaleResolverContext context) {
+			return resolvedLocale;
+		}
+	}
+
+	private static class TestContext implements MessageInterpolator.Context {
+
+		@Override
+		public ConstraintDescriptor<?> getConstraintDescriptor() {
+			return null;
+		}
+
+		@Override
+		public Object getValidatedValue() {
+			return null;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T unwrap(Class<T> type) {
+			return (T) this;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/predefinedscope/LocaleResolverTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/predefinedscope/LocaleResolverTest.java
@@ -1,0 +1,136 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.predefinedscope;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Locale.LanguageRange;
+
+import javax.validation.MessageInterpolator;
+import javax.validation.Validation;
+import javax.validation.ValidatorFactory;
+import javax.validation.metadata.ConstraintDescriptor;
+
+import org.hibernate.validator.PredefinedScopeHibernateValidator;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolver;
+import org.hibernate.validator.spi.messageinterpolation.LocaleResolverContext;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.testng.annotations.Test;
+
+@TestForIssue(jiraKey = "HV-1749")
+public class LocaleResolverTest {
+
+	@Test
+	public void testLanguageRangeSupport() throws NoSuchMethodException, SecurityException {
+		ValidatorFactory validatorFactory = getValidatorFactoryWithInitializedLocales( Locale.FRANCE, new Locale( "es", "ES" ) );
+		MessageInterpolator messageInterpolator = validatorFactory.getMessageInterpolator();
+
+		StaticFieldLocaleResolver.acceptLanguage = "fr-FR,fr;q=0.9";
+
+		assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+				.isEqualTo( "doit avoir la valeur faux" );
+	}
+
+	@Test
+	public void testCascadePriorities() {
+		ValidatorFactory validatorFactory = getValidatorFactoryWithInitializedLocales( Locale.FRANCE, Locale.forLanguageTag( "es" ) );
+		MessageInterpolator messageInterpolator = validatorFactory.getMessageInterpolator();
+
+		StaticFieldLocaleResolver.acceptLanguage = "hr-HR,hr;q=0.9,es;q=0.7";
+
+		assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+				.isEqualTo( "debe ser falso" );
+	}
+
+	@Test
+	public void testFallbackToDefault() throws NoSuchMethodException, SecurityException {
+		// Defaults to en when we don't define a default as we launch Surefire with the en locale
+		ValidatorFactory validatorFactory = getValidatorFactoryWithInitializedLocales( new Locale( "es", "ES" ) );
+		MessageInterpolator messageInterpolator = validatorFactory.getMessageInterpolator();
+
+		StaticFieldLocaleResolver.acceptLanguage = "hr-HR,hr;q=0.9";
+
+		assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+				.isEqualTo( "must be false" );
+
+		// Defaults to fr_FR if we define it as the default locale
+		validatorFactory = getValidatorFactoryWithDefaultLocaleAndInitializedLocales( Locale.FRANCE, Locale.forLanguageTag( "es_ES" ) );
+		messageInterpolator = validatorFactory.getMessageInterpolator();
+
+		assertThat( messageInterpolator.interpolate( "{javax.validation.constraints.AssertFalse.message}", new TestContext() ) )
+				.isEqualTo( "doit avoir la valeur faux" );
+	}
+
+	private static ValidatorFactory getValidatorFactoryWithInitializedLocales(Locale... locales) {
+		ValidatorFactory validatorFactory = Validation.byProvider( PredefinedScopeHibernateValidator.class )
+				.configure()
+				.localeResolver( new StaticFieldLocaleResolver() )
+				.initializeLocales( new HashSet<>( Arrays.asList( locales ) ) )
+				.initializeBeanMetaData( new HashSet<>( Arrays.asList( Bean.class ) ) )
+				.buildValidatorFactory();
+
+		return validatorFactory;
+	}
+
+	private static ValidatorFactory getValidatorFactoryWithDefaultLocaleAndInitializedLocales(Locale defaultLocale, Locale... locales) {
+		ValidatorFactory validatorFactory = Validation.byProvider( PredefinedScopeHibernateValidator.class )
+				.configure()
+				.localeResolver( new StaticFieldLocaleResolver() )
+				.initializeLocales( new HashSet<>( Arrays.asList( locales ) ) )
+				.defaultLocale( defaultLocale )
+				.initializeBeanMetaData( new HashSet<>( Arrays.asList( Bean.class ) ) )
+				.buildValidatorFactory();
+
+		return validatorFactory;
+	}
+
+	private static class Bean {
+	}
+
+	private static class StaticFieldLocaleResolver implements LocaleResolver {
+
+		private static String acceptLanguage;
+
+		@Override
+		public Locale resolve(LocaleResolverContext context) {
+			List<LanguageRange> localePriorities = LanguageRange.parse( acceptLanguage );
+			if ( localePriorities.isEmpty() ) {
+				return context.getDefaultLocale();
+			}
+
+			List<Locale> resolvedLocales = Locale.filter( localePriorities, context.getSupportedLocales() );
+			if ( resolvedLocales.size() > 0 ) {
+				return resolvedLocales.get( 0 );
+			}
+
+			return context.getDefaultLocale();
+		}
+	}
+
+	private static class TestContext implements MessageInterpolator.Context {
+
+		@Override
+		public ConstraintDescriptor<?> getConstraintDescriptor() {
+			return null;
+		}
+
+		@Override
+		public Object getValidatedValue() {
+			return null;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public <T> T unwrap(Class<T> type) {
+			return (T) this;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/predefinedscope/PredefinedScopeValidatorFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/predefinedscope/PredefinedScopeValidatorFactoryTest.java
@@ -230,7 +230,7 @@ public class PredefinedScopeValidatorFactoryTest {
 		ValidatorFactory validatorFactory = Validation.byProvider( PredefinedScopeHibernateValidator.class )
 				.configure()
 				.initializeBeanMetaData( beanMetaDataToInitialize )
-				.initializeLocales( Collections.singleton( Locale.getDefault() ) )
+				.locales( Collections.singleton( Locale.getDefault() ) )
 				.buildValidatorFactory();
 
 		// As we don't have any metadata for BeanProxy, we consider it is not constrained at all.
@@ -246,7 +246,7 @@ public class PredefinedScopeValidatorFactoryTest {
 		ValidatorFactory validatorFactory = Validation.byProvider( PredefinedScopeHibernateValidator.class )
 				.configure()
 				.initializeBeanMetaData( beanMetaDataToInitialize )
-				.initializeLocales( Collections.singleton( Locale.getDefault() ) )
+				.locales( Collections.singleton( Locale.getDefault() ) )
 				.beanMetaDataClassNormalizer( new MyProxyInterfaceBeanMetaDataClassNormalizer() )
 				.buildValidatorFactory();
 
@@ -345,7 +345,7 @@ public class PredefinedScopeValidatorFactoryTest {
 		return Validation.byProvider( PredefinedScopeHibernateValidator.class )
 				.configure()
 				.initializeBeanMetaData( beanMetaDataToInitialize )
-				.initializeLocales( Collections.singleton( locale ) )
+				.locales( Collections.singleton( locale ) )
 				.buildValidatorFactory();
 	}
 

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/engine/messageinterpolation/locale-resolver-validation.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/engine/messageinterpolation/locale-resolver-validation.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<validation-config
+    xmlns="http://xmlns.jcp.org/xml/ns/validation/configuration"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/validation/configuration
+        http://xmlns.jcp.org/xml/ns/validation/configuration/validation-configuration-2.0.xsd"
+    version="2.0">
+
+    <property name="hibernate.validator.locale_resolver">org.hibernate.validator.test.internal.engine.messageinterpolation.LocaleResolverTest$StaticFieldLocaleResolver</property>
+</validation-config>


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HV-1747
 * https://hibernate.atlassian.net/browse/HV-1748
 * https://hibernate.atlassian.net/browse/HV-1749

@marko-bekhta if you're still with us (hi :) ), I'm interested in your feedback: the idea of this patch is to allow some more localization greatness for the `PredefinedScopeValidatorFactory`.

For now, the improvements are targeting this one as it's the only one with a proper list of locale. I have allowed to override the default locale for the good old `ValidatorFactory` too.

@irenakezic you can use this branch to finish your localization work on Quarkus. You now have a method to pass the ``LanguageRange``s to. Note that you need to check if the message interpolator is an `HibernateMessageInterpolator`, otherwise you need to default to the message using the default locale as you do right now if you don't have any header. I also incorporated your commit in the PR and added a test.