### PR TITLE
HV-1761 fix interpolation of primitive arrays

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/ParameterTermResolver.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/messageinterpolation/ParameterTermResolver.java
@@ -18,6 +18,7 @@ import org.hibernate.validator.messageinterpolation.HibernateMessageInterpolator
  * @author Hardy Ferentschik
  * @author Adam Stawicki
  * @author Guillaume Smet
+ * @author Alexander Gatsenko
  */
 public class ParameterTermResolver implements TermResolver {
 
@@ -26,12 +27,7 @@ public class ParameterTermResolver implements TermResolver {
 		String resolvedExpression;
 		Object variable = getVariable( context, removeCurlyBraces( expression ) );
 		if ( variable != null ) {
-			if ( variable.getClass().isArray() ) {
-				resolvedExpression = Arrays.toString( (Object[]) variable );
-			}
-			else {
-				resolvedExpression = variable.toString();
-			}
+			resolvedExpression = resolveExpression( variable );
 		}
 		else {
 			resolvedExpression = expression;
@@ -51,5 +47,42 @@ public class ParameterTermResolver implements TermResolver {
 
 	private String removeCurlyBraces(String parameter) {
 		return parameter.substring( 1, parameter.length() - 1 );
+	}
+
+	private String resolveExpression(Object variable) {
+		final String resolvedExpression;
+		if ( variable.getClass().isArray() ) {
+			if ( variable.getClass() == boolean[].class ) {
+				resolvedExpression = Arrays.toString( (boolean[]) variable );
+			}
+			else if ( variable.getClass() == char[].class ) {
+				resolvedExpression = Arrays.toString( (char[]) variable );
+			}
+			else if ( variable.getClass() == byte[].class ) {
+				resolvedExpression = Arrays.toString( (byte[]) variable );
+			}
+			else if ( variable.getClass() == short[].class ) {
+				resolvedExpression = Arrays.toString( (short[]) variable );
+			}
+			else if ( variable.getClass() == int[].class ) {
+				resolvedExpression = Arrays.toString( (int[]) variable );
+			}
+			else if ( variable.getClass() == long[].class ) {
+				resolvedExpression = Arrays.toString( (long[]) variable );
+			}
+			else if ( variable.getClass() == float[].class ) {
+				resolvedExpression = Arrays.toString( (float[]) variable );
+			}
+			else if ( variable.getClass() == double[].class ) {
+				resolvedExpression = Arrays.toString( (double[]) variable );
+			}
+			else {
+				resolvedExpression = Arrays.toString( (Object[]) variable );
+			}
+		}
+		else {
+			resolvedExpression = variable.toString();
+		}
+		return resolvedExpression;
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/ParameterTermResolverTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/ParameterTermResolverTest.java
@@ -1,0 +1,160 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.messageinterpolation;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import javax.validation.MessageInterpolator;
+import javax.validation.metadata.ConstraintDescriptor;
+
+import org.hibernate.validator.internal.engine.messageinterpolation.ParameterTermResolver;
+import org.hibernate.validator.messageinterpolation.HibernateMessageInterpolatorContext;
+import org.hibernate.validator.testutil.TestForIssue;
+
+import org.easymock.EasyMock;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test for {@link org.hibernate.validator.internal.engine.messageinterpolation.ParameterTermResolver}
+ *
+ * @author Alexander Gatsenko
+ */
+public class ParameterTermResolverTest {
+
+	private final ParameterTermResolver resolver = new ParameterTermResolver();
+
+	@DataProvider(name = "interpolateByNotArrayValueArgs")
+	public static Object[][] interpolateByNotArrayValueArgs() {
+		// lines of (String variableName, Object variableValue, String expectedResolvedExpression)
+		return new Object[][] {
+				{ "value", null, "{value}" },
+				{ "value", true, "true" },
+				{ "value", false, "false" },
+				{ "value", 'a', "a" },
+				{ "value", (byte) 10, "10" },
+				{ "value", (short) 10, "10" },
+				{ "value", 10, "10" },
+				{ "value", 10L, "10" },
+				{ "value", 10.1, "10.1" },
+				{ "value", 10.1f, "10.1" },
+				{ "value", "string value", "string value" },
+		};
+	}
+
+	@DataProvider(name = "interpolateByArrayValueArgs")
+	public static Object[][] interpolateByArrayValueArgs() {
+		// lines of (String variableName, <Array as Object> variableValueArray, String expectedResolvedExpression)
+		return new Object[][] {
+				{ "value", new boolean[] { true, false }, Arrays.toString( new boolean[] { true, false } ) },
+				{ "value", new char[] { 'a', 'b' }, Arrays.toString( new char[] { 'a', 'b' } ) },
+				{ "value", new byte[] { 1, 2 }, Arrays.toString( new byte[] { 1, 2 } ) },
+				{ "value", new short[] { 1, 2 }, Arrays.toString( new short[] { 1, 2 } ) },
+				{ "value", new int[] { 1, 2 }, Arrays.toString( new int[] { 1, 2 } ) },
+				{ "value", new long[] { 1, 2 }, Arrays.toString( new long[] { 1, 2 } ) },
+				{ "value", new double[] { 1.2, 3.4 }, Arrays.toString( new double[] { 1.2, 3.4 } ) },
+				{ "value", new float[] { 1.2F, 3.4F }, Arrays.toString( new float[] { 1.2F, 3.4F } ) },
+				{ "value", new String[] { "one", "two" }, Arrays.toString( new String[] { "one", "two" } ) },
+		};
+	}
+
+	@Test(dataProvider = "interpolateByNotArrayValueArgs")
+	public void testInterpolateShouldResolveExpressionByNotArrayValue(
+			String variableName,
+			Object variableValue,
+			String expectedResolvedExpression) {
+		final MessageInterpolator.Context context = createHibernateContextWithConstraintDescriptorAttr(
+				variableName,
+				variableValue
+		);
+		final String srcExpression = createVariableExpression( variableName );
+
+		final String actualResolvedExpression = resolver.interpolate( context, srcExpression );
+		assertEquals( actualResolvedExpression, expectedResolvedExpression );
+	}
+
+	@Test(dataProvider = "interpolateByArrayValueArgs")
+	@TestForIssue(jiraKey = "HV-1761")
+	public void testInterpolateShouldResolveExpressionByArrayValue(
+			String variableName,
+			Object variableValueArray,
+			String expectedResolvedExpression) {
+		final MessageInterpolator.Context context = createHibernateContextWithConstraintDescriptorAttr(
+				variableName,
+				variableValueArray
+		);
+		final String srcExpression = createVariableExpression( variableName );
+
+		final String actualResolvedExpression = resolver.interpolate( context, srcExpression );
+		assertEquals( actualResolvedExpression, expectedResolvedExpression );
+	}
+
+	@Test(dataProvider = "interpolateByNotArrayValueArgs")
+	public void testInterpolateShouldAllowUseNotHibernateContext(
+			String variableName,
+			Object variableValue,
+			String expectedResolvedExpression) {
+		final MessageInterpolator.Context context = createNotHibernateContextWithConstraintDescriptorAttr(
+				variableName,
+				variableValue
+		);
+		final String srcExpression = createVariableExpression( variableName );
+
+		final String actualResolvedExpression = resolver.interpolate( context, srcExpression );
+		assertEquals( actualResolvedExpression, expectedResolvedExpression );
+	}
+
+	private static String createVariableExpression(String variableName) {
+		return String.format( "{%s}", variableName );
+	}
+
+	private static Map<String, Object> createConstraintDescriptorAttr(String attrName, Object attrValue) {
+		Map<String, Object> map = new HashMap<>( 1 );
+		map.put( attrName, attrValue );
+		return map;
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private static MessageInterpolator.Context createNotHibernateContextWithConstraintDescriptorAttr(
+			String attrName,
+			Object attrValue) {
+		final Map<String, Object> attrs = createConstraintDescriptorAttr( attrName, attrValue );
+
+		final MessageInterpolator.Context context = EasyMock.mock( MessageInterpolator.Context.class );
+		final ConstraintDescriptor constraintDescriptor = EasyMock.mock( ConstraintDescriptor.class );
+
+		EasyMock.expect( context.getConstraintDescriptor() ).andStubReturn( constraintDescriptor );
+		EasyMock.expect( constraintDescriptor.getAttributes() ).andStubReturn( attrs );
+
+		EasyMock.replay( context );
+		EasyMock.replay( constraintDescriptor );
+
+		return context;
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private static MessageInterpolator.Context createHibernateContextWithConstraintDescriptorAttr(
+			String attrName,
+			Object attrValue) {
+		final Map<String, Object> attrs = createConstraintDescriptorAttr( attrName, attrValue );
+
+		final HibernateMessageInterpolatorContext context = EasyMock.mock( HibernateMessageInterpolatorContext.class );
+		final ConstraintDescriptor constraintDescriptor = EasyMock.mock( ConstraintDescriptor.class );
+
+		EasyMock.expect( context.getMessageParameters() ).andStubReturn( attrs );
+		EasyMock.expect( context.getConstraintDescriptor() ).andStubReturn( constraintDescriptor );
+		EasyMock.expect( constraintDescriptor.getAttributes() ).andStubReturn( attrs );
+
+		EasyMock.replay( context );
+		EasyMock.replay( constraintDescriptor );
+
+		return context;
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1761

This is a fix for the 'HV-1328' bugs. The issue is that invoking `ParameterTermResolver.interpolate (context, expression)` throws the exception `java.lang.ClassCastException` if the value of the expression is a primitive array.

I can merge these changes into `6.1`, `6.2`, `master` brunches if needed.