### PR TITLE
HV-1795 Remove link to JavaMoney javadoc - 6.0

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -119,7 +119,7 @@
                         <link>${java.api-docs.base-url}</link>
                         <link>${javaee.api-docs.base-url}</link>
                         <link>${bv.api-docs.base-url}</link>
-                        <link>${javamoney.api-docs.base-url}</link>
+                        <!--<link>${javamoney.api-docs.base-url}</link>-->
                     </links>
                     <tags>
                         <tag>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1795