### PR TITLE
HV-1805 + HV-1806 + HV-1807 + HV-1808 + HV-1809 Jenkinsfile + various build improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -309,6 +309,8 @@ stage('Default build') {
 							install \
 					"} \
 					-Pdist \
+					-Psigtest \
+					-Pjqassistant \
 					${enableDefaultBuildIT ? '' : '-DskipITs'} \
 					${toTestJdkArg(environments.content.jdk.default)} \
 			"""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,542 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+import groovy.transform.Field
+
+/*
+ * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
+ */
+@Library('hibernate-jenkins-pipeline-helpers@1.3')
+import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
+import org.hibernate.jenkins.pipeline.helpers.alternative.AlternativeMultiMap
+import org.hibernate.jenkins.pipeline.helpers.version.Version
+
+/*
+ * WARNING: DO NOT IMPORT LOCAL LIBRARIES HERE.
+ *
+ * By local, I mean libraries whose files are in the same Git repository.
+ *
+ * The Jenkinsfile is protected and will not be executed if modified in pull requests from external users,
+ * but other local library files are not protected.
+ * A user could potentially craft a malicious PR by modifying a local library.
+ *
+ * See https://blog.grdryn.me/blog/jenkins-pipeline-trust.html for a full explanation,
+ * and a potential solution if we really need local libraries.
+ * Alternatively we might be able to host libraries in a separate GitHub repo and configure
+ * them in the GUI: see https://ci.hibernate.org/job/hibernate-validator/configure, "Pipeline Libraries".
+ */
+
+/*
+ * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers for the documentation
+ * of the helpers library used in this Jenkinsfile,
+ * and for help writing Jenkinsfiles.
+ *
+ * ### Jenkins configuration
+ *
+ * #### Jenkins plugins
+ *
+ * This file requires the following plugins in particular:
+ *
+ * - everything required by the helpers library (see the org.hibernate.(...) imports for a link to its documentation)
+ * - https://plugins.jenkins.io/pipeline-github for the trigger on pull request comments
+ *
+ * #### Script approval
+ *
+ * If not already done, you will need to allow the following calls in <jenkinsUrl>/scriptApproval/:
+ *
+ * - everything required by the helpers library (see the org.hibernate.(...) imports for a link to its documentation)
+ *
+ * ### Integrations
+ *
+ * #### Nexus deployment
+ *
+ * This job includes two deployment modes:
+ *
+ * - A deployment of snapshot artifacts for every non-PR build on "primary" branches (master and maintenance branches).
+ * - A full release when starting the job with specific parameters.
+ *
+ * In the first case, the name of a Maven settings file must be provided in the job configuration file
+ * (see below).
+ *
+ * #### Gitter (optional)
+ *
+ * You need to enable the Jenkins integration in your Gitter room first:
+ * see https://gitlab.com/gitlab-org/gitter/webapp/blob/master/docs/integrations.md
+ *
+ * Then you will also need to configure *global* secret text credentials containing the Gitter webhook URL,
+ * and list the ID of these credentials in the job configuration file
+ * (see https://github.com/hibernate/hibernate-jenkins-pipeline-helpers#job-configuration-file).
+ *
+ * ### Job configuration
+ *
+ * This Jenkinsfile gets its configuration from four sources:
+ * branch name, environment variables, a configuration file, and credentials.
+ * All configuration is optional for the default build (and it should stay that way),
+ * but some features require some configuration.
+ *
+ * #### Branch name
+ *
+ * See the org.hibernate.(...) imports for a link to the helpers library documentation,
+ * which explains the basics.
+ *
+ * #### Environment variables
+ *
+ * No particular environment variables is necessary.
+ *
+ * #### Job configuration file
+ *
+ * See the org.hibernate.(...) imports for a link to the helpers library documentation,
+ * which explains the basic structure of this file and how to set it up.
+ *
+ * Below is the additional structure specific to this Jenkinsfile:
+ *
+ *     deployment:
+ *       maven:
+ *         # String containing the ID of a Maven settings file registered using the config-file-provider Jenkins plugin.
+ *         # The settings must provide credentials to the servers with ID
+ *         # 'jboss-releases-repository' and 'jboss-snapshots-repository'.
+ *         settingsId: ...
+ */
+
+@Field final String MAVEN_TOOL = 'Apache Maven 3.6'
+
+// Default node pattern, to be used for resource-intensive stages.
+// Should not include the master node.
+@Field final String NODE_PATTERN_BASE = 'Slave'
+// Quick-use node pattern, to be used for very light, quick, and environment-independent stages,
+// such as sending a notification. May include the master node in particular.
+@Field final String QUICK_USE_NODE_PATTERN = 'Master||Slave'
+
+@Field AlternativeMultiMap<BuildEnvironment> environments
+@Field JobHelper helper
+
+@Field boolean enableDefaultBuild = false
+@Field boolean enableDefaultBuildIT = false
+@Field boolean performRelease = false
+@Field boolean deploySnapshot = false
+
+@Field Version releaseVersion
+@Field Version afterReleaseDevelopmentVersion
+
+this.helper = new JobHelper(this)
+
+helper.runWithNotification {
+
+stage('Configure') {
+	this.environments = AlternativeMultiMap.create([
+			jdk: [
+					// This should not include every JDK; in particular let's not care too much about EOL'd JDKs like version 9
+					// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
+					new JdkBuildEnvironment(version: '8', buildJdkTool: 'OracleJDK8 Latest',
+							condition: TestCondition.BEFORE_MERGE,
+							isDefault: true),
+					new JdkBuildEnvironment(version: '11', buildJdkTool: 'OpenJDK 11 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '14', buildJdkTool: 'OpenJDK 14 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '15', buildJdkTool: 'OpenJDK 15 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '16', buildJdkTool: 'OpenJDK 16 Latest',
+							condition: TestCondition.AFTER_MERGE)
+			]
+	])
+
+	helper.configure {
+		configurationNodePattern QUICK_USE_NODE_PATTERN
+		file 'job-configuration.yaml'
+		jdk {
+			defaultTool environments.content.jdk.default.buildJdkTool
+		}
+		maven {
+			defaultTool MAVEN_TOOL
+			producedArtifactPattern "org/hibernate/validator/*"
+			// Relocation artifacts
+			producedArtifactPattern "org/hibernate/hibernate-validator*"
+		}
+	}
+
+	properties([
+			buildDiscarder(
+					logRotator(daysToKeepStr: '90')
+			),
+			pipelineTriggers(
+					// HSEARCH-3417: do not add snapshotDependencies() here, this was known to cause problems.
+					[
+							issueCommentTrigger('.*test this please.*')
+					]
+							+ helper.generateUpstreamTriggers()
+			),
+			helper.generateNotificationProperty(),
+			parameters([
+					choice(
+							name: 'ENVIRONMENT_SET',
+							choices: """AUTOMATIC
+DEFAULT
+SUPPORTED
+ALL""",
+							description: """A set of environments that must be checked.
+'AUTOMATIC' picks a different set of environments based on the branch name and whether a release is being performed.
+'DEFAULT' means a single build with the default environment expected by the Maven configuration,
+while other options will trigger multiple Maven executions in different environments."""
+					),
+					string(
+							name: 'ENVIRONMENT_FILTER',
+							defaultValue: '',
+							trim: true,
+							description: """A regex filter to apply to the environments that must be checked.
+If this parameter is non-empty, ENVIRONMENT_SET will be ignored and environments whose tag matches the given regex will be checked.
+Some useful filters: 'default', 'jdk', 'jdk-10', 'eclipse'.
+"""
+					),
+					string(
+							name: 'RELEASE_VERSION',
+							defaultValue: '',
+							description: 'The version to be released, e.g. 5.10.0.Final. Setting this triggers a release.',
+							trim: true
+					),
+					string(
+							name: 'RELEASE_DEVELOPMENT_VERSION',
+							defaultValue: '',
+							description: 'The next version to be used after the release, e.g. 5.10.0-SNAPSHOT.',
+							trim: true
+					),
+					booleanParam(
+							name: 'RELEASE_DRY_RUN',
+							defaultValue: false,
+							description: 'If true, just simulate the release, without pushing any commits or tags, and without uploading any artifacts or documentation.'
+					)
+			])
+	])
+
+	performRelease = (params.RELEASE_VERSION ? true : false)
+
+	if (!performRelease && helper.scmSource.branch.primary && !helper.scmSource.pullRequest) {
+		if (helper.configuration.file?.deployment?.maven?.settingsId) {
+			deploySnapshot = true
+		}
+		else {
+			echo "Missing deployment configuration in job configuration file - snapshot deployment will be skipped."
+		}
+	}
+
+	if (params.ENVIRONMENT_FILTER) {
+		keepOnlyEnvironmentsMatchingFilter(params.ENVIRONMENT_FILTER)
+	}
+	else {
+		keepOnlyEnvironmentsFromSet(params.ENVIRONMENT_SET)
+	}
+
+	// Determine whether ITs need to be run in the default build
+	enableDefaultBuildIT = environments.content.any { key, envSet ->
+		return envSet.enabled.contains(envSet.default)
+	}
+	// No need to re-test default environments separately, they will be tested as part of the default build if needed
+	environments.content.each { key, envSet ->
+		envSet.enabled.remove(envSet.default)
+	}
+
+	if ( enableDefaultBuildIT && params.LEGACY_IT ) {
+		echo "Enabling legacy integration tests in default environment due to explicit request"
+		enableDefaultBuildLegacyIT = true
+	}
+
+	enableDefaultBuild =
+			enableDefaultBuildIT ||
+			environments.content.any { key, envSet -> envSet.enabled.any { buildEnv -> buildEnv.requiresDefaultBuildArtifacts() } } ||
+			deploySnapshot
+
+	echo """Branch: ${helper.scmSource.branch.name}
+PR: ${helper.scmSource.pullRequest?.id}
+params.ENVIRONMENT_SET: ${params.ENVIRONMENT_SET}
+params.ENVIRONMENT_FILTER: ${params.ENVIRONMENT_FILTER}
+
+Resulting execution plan:
+    enableDefaultBuild=$enableDefaultBuild
+    enableDefaultBuildIT=$enableDefaultBuildIT
+    environments=${environments.enabledAsString}
+    performRelease=$performRelease
+    deploySnapshot=$deploySnapshot
+"""
+
+	if (performRelease) {
+		releaseVersion = Version.parseReleaseVersion(params.RELEASE_VERSION)
+		echo "Inferred version family for the release to '$releaseVersion.family'"
+
+		// Check that all the necessary parameters are set
+		if (!params.RELEASE_DEVELOPMENT_VERSION) {
+			throw new IllegalArgumentException(
+					"Missing value for parameter RELEASE_DEVELOPMENT_VERSION." +
+							" This parameter must be set when RELEASE_VERSION is set."
+			)
+		}
+		if (!params.RELEASE_DRY_RUN && !helper.configuration.file?.deployment?.maven?.settingsId) {
+			throw new IllegalArgumentException(
+					"Missing deployment configuration in job configuration file." +
+							" Cannot deploy artifacts during the release."
+			)
+		}
+	}
+
+	if (params.RELEASE_DEVELOPMENT_VERSION) {
+		afterReleaseDevelopmentVersion = Version.parseDevelopmentVersion(params.RELEASE_DEVELOPMENT_VERSION)
+	}
+}
+
+stage('Default build') {
+	if (!enableDefaultBuild) {
+		echo 'Skipping default build and integration tests in the default environment'
+		helper.markStageSkipped()
+		return
+	}
+	runBuildOnNode {
+		helper.withMavenWorkspace(mavenSettingsConfig: deploySnapshot ? helper.configuration.file.deployment.maven.settingsId : null) {
+			sh """ \
+					mvn clean \
+					--fail-at-end \
+					${deploySnapshot ? "\
+							deploy \
+					" : "\
+							install \
+					"} \
+					-Pdist \
+					${enableDefaultBuildIT ? '' : '-DskipITs'} \
+					${toTestJdkArg(environments.content.jdk.default)} \
+			"""
+
+			dir(helper.configuration.maven.localRepositoryPath) {
+				stash name:'default-build-result', includes:"org/hibernate/validator/**"
+			}
+		}
+	}
+}
+
+stage('Non-default environments') {
+	Map<String, Closure> executions = [:]
+
+	// Test with multiple JDKs
+	environments.content.jdk.enabled.each { JdkBuildEnvironment buildEnv ->
+		executions.put(buildEnv.tag, {
+			runBuildOnNode {
+				helper.withMavenWorkspace(jdk: buildEnv.buildJdkTool) {
+					mavenNonDefaultBuild buildEnv, """ \
+							clean install \
+					"""
+				}
+			}
+		})
+	}
+
+	if (executions.isEmpty()) {
+		echo 'Skipping builds in non-default environments'
+		helper.markStageSkipped()
+	}
+	else {
+		parallel(executions)
+	}
+}
+
+stage('Deploy') {
+	if (deploySnapshot) {
+		// TODO delay the release to this stage? This would require to use staging repositories for snapshots, not sure it's possible.
+		echo "Already deployed snapshot as part of the 'Default build' stage."
+	}
+	else if (performRelease) {
+		echo "Performing full release for version ${releaseVersion.toString()}"
+		runBuildOnNode {
+			helper.withMavenWorkspace(mavenSettingsConfig: params.RELEASE_DRY_RUN ? null : helper.configuration.file.deployment.maven.settingsId) {
+				sh "git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git"
+				sh "bash -xe hibernate-noorm-release-scripts/prepare-release.sh validator ${releaseVersion.toString()}"
+
+				String deployCommand = "bash -xe hibernate-noorm-release-scripts/deploy.sh validator"
+				if (!params.RELEASE_DRY_RUN) {
+					sh deployCommand
+				} else {
+					echo "WARNING: Not deploying. Would have executed:"
+					echo deployCommand
+				}
+
+				String uploadDistributionCommand = "bash -xe hibernate-noorm-release-scripts/upload-distribution.sh validator ${releaseVersion.toString()}"
+				String uploadDocumentationCommand = "bash -xe hibernate-noorm-release-scripts/upload-documentation.sh validator ${releaseVersion.toString()} ${releaseVersion.family}"
+				if (!params.RELEASE_DRY_RUN) {
+					sh uploadDistributionCommand
+					sh uploadDocumentationCommand
+				}
+				else {
+					echo "WARNING: Not uploading anything. Would have executed:"
+					echo uploadDistributionCommand
+					echo uploadDocumentationCommand
+				}
+
+				sh "bash -xe hibernate-noorm-release-scripts/update-version.sh validator ${afterReleaseDevelopmentVersion.toString()}"
+				sh "bash -xe hibernate-noorm-release-scripts/push-upstream.sh validator ${releaseVersion.toString()} ${helper.scmSource.branch.name} ${!params.RELEASE_DRY_RUN}"
+			}
+		}
+	}
+	else {
+		echo "Skipping deployment"
+		helper.markStageSkipped()
+		return
+	}
+}
+
+} // End of helper.runWithNotification
+
+// Job-specific helpers
+
+enum TestCondition {
+	// For environments that are expected to work correctly
+	// before merging into master or maintenance branches.
+	// Tested on master and maintenance branches, on feature branches, and for PRs.
+	BEFORE_MERGE,
+	// For environments that are expected to work correctly,
+	// but are considered too resource-intensive to test them on pull requests.
+	// Tested on master and maintenance branches only.
+	// Not tested on feature branches or PRs.
+	AFTER_MERGE,
+	// For environments that may not work correctly.
+	// Only tested when explicitly requested through job parameters.
+	ON_DEMAND;
+
+	// Work around JENKINS-33023
+	// See https://issues.jenkins-ci.org/browse/JENKINS-33023?focusedCommentId=325738&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-325738
+	public TestCondition() {}
+}
+
+abstract class BuildEnvironment {
+	boolean isDefault = false
+	TestCondition condition
+	String toString() { getTag() }
+	abstract String getTag()
+	boolean isDefault() { isDefault }
+	boolean requiresDefaultBuildArtifacts() { true }
+}
+
+class JdkBuildEnvironment extends BuildEnvironment {
+	String version
+	String buildJdkTool
+	String testJdkTool
+	@Override
+	String getTag() { "jdk-$version" }
+	@Override
+	boolean requiresDefaultBuildArtifacts() { false }
+}
+
+void keepOnlyEnvironmentsMatchingFilter(String regex) {
+	def pattern = /$regex/
+
+	boolean enableDefault = ('default' =~ pattern)
+
+	environments.content.each { key, envSet ->
+		envSet.enabled.removeAll { buildEnv ->
+			!(buildEnv.tag =~ pattern) && !(envSet.default == buildEnv && enableDefault)
+		}
+	}
+}
+
+void keepOnlyEnvironmentsFromSet(String environmentSetName) {
+	boolean enableDefaultEnv = false
+	boolean enableBeforeMergeEnvs = false
+	boolean enableAfterMergeEnvs = false
+	boolean enableOnDemandEnvs = false
+	switch (environmentSetName) {
+		case 'DEFAULT':
+			enableDefaultEnv = true
+			break
+		case 'SUPPORTED':
+			enableDefaultEnv = true
+			enableBeforeMergeEnvs = true
+			enableAfterMergeEnvs = true
+			break
+		case 'ALL':
+			enableDefaultEnv = true
+			enableBeforeMergeEnvs = true
+			enableAfterMergeEnvs = true
+			enableOptional = true
+			break
+		case 'AUTOMATIC':
+			if (params.RELEASE_VERSION) {
+				echo "Releasing version '$params.RELEASE_VERSION'."
+			} else if (helper.scmSource.pullRequest) {
+				echo "Building pull request '$helper.scmSource.pullRequest.id'"
+				enableDefaultEnv = true
+				enableBeforeMergeEnvs = true
+			} else if (helper.scmSource.branch.primary) {
+				echo "Building primary branch '$helper.scmSource.branch.name'"
+				enableDefaultEnv = true
+				enableBeforeMergeEnvs = true
+				enableAfterMergeEnvs = true
+				echo "Legacy integration tests are enabled for the default build environment."
+				enableDefaultBuildLegacyIT = true
+			} else {
+				echo "Building feature branch '$helper.scmSource.branch.name'"
+				enableDefaultEnv = true
+				enableBeforeMergeEnvs = true
+			}
+			break
+		default:
+			throw new IllegalArgumentException(
+					"Unknown value for param 'ENVIRONMENT_SET': '$environmentSetName'."
+			)
+	}
+
+	// Filter environments
+
+	environments.content.each { key, envSet ->
+		envSet.enabled.removeAll { buildEnv -> ! (
+				enableDefaultEnv && buildEnv.isDefault ||
+				enableBeforeMergeEnvs && buildEnv.condition == TestCondition.BEFORE_MERGE ||
+				enableAfterMergeEnvs && buildEnv.condition == TestCondition.AFTER_MERGE ||
+						enableOnDemandEnvs && buildEnv.condition == TestCondition.ON_DEMAND ) }
+	}
+}
+
+void runBuildOnNode(Closure body) {
+	runBuildOnNode( NODE_PATTERN_BASE, body )
+}
+
+void runBuildOnNode(String label, Closure body) {
+	node( label ) {
+		timeout( [time: 1, unit: 'HOURS'], body )
+	}
+}
+
+void mavenNonDefaultBuild(BuildEnvironment buildEnv, String args, String projectPath = '.') {
+	if ( buildEnv.requiresDefaultBuildArtifacts() ) {
+		dir(helper.configuration.maven.localRepositoryPath) {
+			unstash name:'default-build-result'
+		}
+	}
+
+	// Add a suffix to tests to distinguish between different executions
+	// of the same test in different environments in reports
+	def testSuffix = buildEnv.tag.replaceAll('[^a-zA-Z0-9_\\-+]+', '_')
+
+	dir(projectPath) {
+		sh """ \
+				mvn -Dsurefire.environment=$testSuffix \
+						${toTestJdkArg(buildEnv)} \
+						--fail-at-end \
+						$args \
+		"""
+	}
+}
+
+String toTestJdkArg(BuildEnvironment buildEnv) {
+	String args = ''
+
+	if ( ! (buildEnv instanceof JdkBuildEnvironment) ) {
+		return args;
+	}
+
+	String testJdkTool = buildEnv.testJdkTool
+	if ( testJdkTool ) {
+		def testJdkToolPath = tool(name: testJdkTool, type: 'jdk')
+		args += " -Dsurefire.jvm.java_executable=$testJdkToolPath/bin/java"
+	}
+
+	return args
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,10 +138,12 @@ stage('Configure') {
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '14', buildJdkTool: 'OpenJDK 14 Latest',
 							condition: TestCondition.AFTER_MERGE),
+					// Disabled because of https://bugs.openjdk.java.net/browse/JDK-8253566
 					new JdkBuildEnvironment(version: '15', buildJdkTool: 'OpenJDK 15 Latest',
-							condition: TestCondition.AFTER_MERGE),
+							condition: TestCondition.ON_DEMAND),
+					// Disabled because of https://bugs.openjdk.java.net/browse/JDK-8253566
 					new JdkBuildEnvironment(version: '16', buildJdkTool: 'OpenJDK 16 Latest',
-							condition: TestCondition.AFTER_MERGE)
+							condition: TestCondition.ON_DEMAND)
 			],
 			wildflyTck: [
 					new WildFlyTckBuildEnvironment(javaVersion: '8', buildJdkTool: 'OracleJDK8 Latest',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -315,11 +315,11 @@ stage('Default build') {
 }
 
 stage('Non-default environments') {
-	Map<String, Closure> executions = [:]
+	Map<String, Object> parameters = [:]
 
 	// Test with multiple JDKs
 	environments.content.jdk.enabled.each { JdkBuildEnvironment buildEnv ->
-		executions.put(buildEnv.tag, {
+		parameters.put(buildEnv.tag, {
 			runBuildOnNode {
 				helper.withMavenWorkspace(jdk: buildEnv.buildJdkTool) {
 					mavenNonDefaultBuild buildEnv, """ \
@@ -330,12 +330,13 @@ stage('Non-default environments') {
 		})
 	}
 
-	if (executions.isEmpty()) {
+	if (parameters.isEmpty()) {
 		echo 'Skipping builds in non-default environments'
 		helper.markStageSkipped()
 	}
 	else {
-		parallel(executions)
+		parameters.put('failFast', false)
+		parallel(parameters)
 	}
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -304,7 +304,7 @@ stage('Default build') {
 					mvn clean \
 					--fail-at-end \
 					${deploySnapshot ? "\
-							deploy \
+							deploy -DdeployAtEnd=true \
 					" : "\
 							install \
 					"} \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,9 +145,9 @@ stage('Configure') {
 			],
 			wildflyTck: [
 					new WildFlyTckBuildEnvironment(javaVersion: '8', buildJdkTool: 'OracleJDK8 Latest',
-							condition: TestCondition.AFTER_MERGE),
+							condition: TestCondition.ON_DEMAND),
 					new WildFlyTckBuildEnvironment(javaVersion: '11', buildJdkTool: 'OpenJDK 11 Latest',
-							condition: TestCondition.AFTER_MERGE)
+							condition: TestCondition.ON_DEMAND)
 			]
 	])
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractMethodValidationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AbstractMethodValidationTest.java
@@ -52,7 +52,8 @@ import org.testng.annotations.Test;
  */
 @Test
 public abstract class AbstractMethodValidationTest {
-	protected CustomerRepository customerRepository;
+	protected CustomerRepository customerRepositoryOriginalBean;
+	protected CustomerRepository customerRepositoryValidatingProxy;
 	protected RepositoryBase<Customer> repositoryBase;
 	protected Validator validator;
 
@@ -61,16 +62,17 @@ public abstract class AbstractMethodValidationTest {
 	protected abstract String messagePrefix();
 
 	protected void createProxy(Class<?>... groups) {
-		customerRepository = getValidatingProxy(
-				new CustomerRepositoryImpl(), validator, groups
+		customerRepositoryOriginalBean = new CustomerRepositoryImpl();
+		customerRepositoryValidatingProxy = getValidatingProxy(
+				customerRepositoryOriginalBean, validator, groups
 		);
-		repositoryBase = customerRepository;
+		repositoryBase = customerRepositoryValidatingProxy;
 	}
 
 	@Test
 	public void methodValidationYieldsConstraintViolation() {
 		try {
-			customerRepository.findCustomerByName( null );
+			customerRepositoryValidatingProxy.findCustomerByName( null );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -92,13 +94,13 @@ public abstract class AbstractMethodValidationTest {
 			assertMethod( constraintViolation, "findCustomerByName", String.class );
 			assertParameterIndex( constraintViolation, 0 );
 			assertMethodValidationType( constraintViolation, ElementKind.PARAMETER );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
 			assertEquals(
 					constraintViolation.getPropertyPath().toString(),
 					"findCustomerByName.name"
 			);
-			assertEquals( constraintViolation.getLeafBean(), customerRepository );
+			assertEquals( constraintViolation.getLeafBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getInvalidValue(), null );
 			assertEquals( constraintViolation.getExecutableParameters(), new Object[] { null } );
 			assertEquals( constraintViolation.getExecutableReturnValue(), null );
@@ -108,7 +110,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void validationOfMethodWithMultipleParameters() {
 		try {
-			customerRepository.findCustomerByAgeAndName( 30, null );
+			customerRepositoryValidatingProxy.findCustomerByAgeAndName( 30, null );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -141,7 +143,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void constraintViolationsAtMultipleParameters() {
 		try {
-			customerRepository.findCustomerByAgeAndName( 1, null );
+			customerRepositoryValidatingProxy.findCustomerByAgeAndName( 1, null );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -170,7 +172,7 @@ public abstract class AbstractMethodValidationTest {
 	public void methodValidationWithCascadingParameter() {
 		Customer customer = new Customer( null, null );
 		try {
-			customerRepository.persistCustomer( customer );
+			customerRepositoryValidatingProxy.persistCustomer( customer );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -195,7 +197,7 @@ public abstract class AbstractMethodValidationTest {
 					constraintViolation.getPropertyPath().toString(), "persistCustomer.customer.name"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getLeafBean(), customer );
 			assertEquals( constraintViolation.getInvalidValue(), null );
 			assertEquals( constraintViolation.getExecutableParameters(), new Object[] { customer } );
@@ -209,7 +211,7 @@ public abstract class AbstractMethodValidationTest {
 		Customer customer = new Customer( "Bob", address );
 
 		try {
-			customerRepository.persistCustomer( customer );
+			customerRepositoryValidatingProxy.persistCustomer( customer );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -236,7 +238,7 @@ public abstract class AbstractMethodValidationTest {
 					"persistCustomer.customer.address.city"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getLeafBean(), address );
 			assertEquals( constraintViolation.getInvalidValue(), null );
 			assertEquals( constraintViolation.getExecutableParameters(), new Object[] { customer } );
@@ -251,7 +253,7 @@ public abstract class AbstractMethodValidationTest {
 		customers.put( "Bob", bob );
 
 		try {
-			customerRepository.cascadingMapParameter( customers );
+			customerRepositoryValidatingProxy.cascadingMapParameter( customers );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -277,7 +279,7 @@ public abstract class AbstractMethodValidationTest {
 					"cascadingMapParameter.customer[Bob].name"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getLeafBean(), bob );
 			assertEquals( constraintViolation.getInvalidValue(), null );
 			assertEquals( constraintViolation.getExecutableParameters(), new Object[] { customers } );
@@ -291,7 +293,7 @@ public abstract class AbstractMethodValidationTest {
 		List<Customer> customers = Arrays.asList( null, customer );
 
 		try {
-			customerRepository.cascadingIterableParameter( customers );
+			customerRepositoryValidatingProxy.cascadingIterableParameter( customers );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -317,7 +319,7 @@ public abstract class AbstractMethodValidationTest {
 					"cascadingIterableParameter.customer[1].name"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getLeafBean(), customer );
 			assertEquals( constraintViolation.getInvalidValue(), null );
 			assertEquals( constraintViolation.getExecutableParameters(), new Object[] { customers } );
@@ -331,7 +333,7 @@ public abstract class AbstractMethodValidationTest {
 		Customer customer = new Customer( null );
 
 		try {
-			customerRepository.cascadingArrayParameter( null, customer );
+			customerRepositoryValidatingProxy.cascadingArrayParameter( null, customer );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -357,7 +359,7 @@ public abstract class AbstractMethodValidationTest {
 					"cascadingArrayParameter.customer[1].name"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getLeafBean(), customer );
 			assertEquals( constraintViolation.getInvalidValue(), null );
 			assertEquals(
@@ -371,7 +373,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void constraintsAtMethodFromBaseClassAreEvaluated() {
 		try {
-			customerRepository.findById( null );
+			customerRepositoryValidatingProxy.findById( null );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -398,7 +400,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void constraintsAtOverriddenMethodAreEvaluated() {
 		try {
-			customerRepository.foo( null );
+			customerRepositoryValidatingProxy.foo( null );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -425,7 +427,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void validFromOverriddenMethodIsEvaluated() {
 		try {
-			customerRepository.bar( new Customer( null, null ) );
+			customerRepositoryValidatingProxy.bar( new Customer( null, null ) );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -453,13 +455,13 @@ public abstract class AbstractMethodValidationTest {
 
 	@Test
 	public void parameterValidationOfParameterlessMethod() {
-		customerRepository.boz();
+		customerRepositoryValidatingProxy.boz();
 	}
 
 	@Test
 	public void returnValueValidationYieldsConstraintViolation() {
 		try {
-			customerRepository.baz();
+			customerRepositoryValidatingProxy.baz();
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -478,10 +480,10 @@ public abstract class AbstractMethodValidationTest {
 			assertEquals( constraintViolation.getMessage(), messagePrefix() + "must be greater than or equal to 10" );
 			assertMethod( constraintViolation, "baz" );
 			assertMethodValidationType( constraintViolation, ElementKind.RETURN_VALUE );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
 			assertEquals( constraintViolation.getPropertyPath().toString(), "baz.<return value>" );
-			assertEquals( constraintViolation.getLeafBean(), customerRepository );
+			assertEquals( constraintViolation.getLeafBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getInvalidValue(), 9 );
 			assertEquals( constraintViolation.getExecutableParameters(), null );
 			assertEquals( constraintViolation.getExecutableReturnValue(), 9 );
@@ -491,7 +493,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void cascadingReturnValue() {
 		try {
-			customerRepository.cascadingReturnValue();
+			customerRepositoryValidatingProxy.cascadingReturnValue();
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -510,7 +512,7 @@ public abstract class AbstractMethodValidationTest {
 			assertEquals( constraintViolation.getMessage(), messagePrefix() + "must not be null" );
 			assertMethod( constraintViolation, "cascadingReturnValue" );
 			assertMethodValidationType( constraintViolation, ElementKind.RETURN_VALUE );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
 			assertEquals(
 					constraintViolation.getPropertyPath().toString(),
@@ -526,7 +528,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void cascadingReturnValueFromSuperType() {
 		try {
-			customerRepository.overriddenMethodWithCascadingReturnValue();
+			customerRepositoryValidatingProxy.overriddenMethodWithCascadingReturnValue();
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -546,7 +548,7 @@ public abstract class AbstractMethodValidationTest {
 			assertMethod( constraintViolation, "overriddenMethodWithCascadingReturnValue" );
 			assertMethodValidationType( constraintViolation, ElementKind.RETURN_VALUE );
 
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
 			assertEquals(
 					constraintViolation.getPropertyPath().toString(),
@@ -562,7 +564,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void cascadingIterableReturnValue() {
 		try {
-			customerRepository.cascadingIterableReturnValue();
+			customerRepositoryValidatingProxy.cascadingIterableReturnValue();
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -587,7 +589,7 @@ public abstract class AbstractMethodValidationTest {
 					"cascadingIterableReturnValue.<return value>[1].name"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getLeafBean(), new Customer( null ) );
 			assertEquals( constraintViolation.getInvalidValue(), null );
 			assertEquals( constraintViolation.getExecutableParameters(), null );
@@ -598,7 +600,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void cascadingMapReturnValue() {
 		try {
-			customerRepository.cascadingMapReturnValue();
+			customerRepositoryValidatingProxy.cascadingMapReturnValue();
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -627,7 +629,7 @@ public abstract class AbstractMethodValidationTest {
 					"cascadingMapReturnValue.<return value>[Bob].name"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getLeafBean(), customer );
 			assertEquals( constraintViolation.getInvalidValue(), null );
 			assertEquals( constraintViolation.getExecutableParameters(), null );
@@ -638,7 +640,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void cascadingArrayReturnValue() {
 		try {
-			customerRepository.cascadingArrayReturnValue();
+			customerRepositoryValidatingProxy.cascadingArrayReturnValue();
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -663,7 +665,7 @@ public abstract class AbstractMethodValidationTest {
 					"cascadingArrayReturnValue.<return value>[1].name"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getLeafBean(), new Customer( null ) );
 			assertEquals( constraintViolation.getInvalidValue(), null );
 			assertEquals( constraintViolation.getExecutableParameters(), null );
@@ -674,7 +676,7 @@ public abstract class AbstractMethodValidationTest {
 	@Test
 	public void overridingMethodStrengthensReturnValueConstraint() {
 		try {
-			customerRepository.overriddenMethodWithReturnValueConstraint();
+			customerRepositoryValidatingProxy.overriddenMethodWithReturnValueConstraint();
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -729,13 +731,13 @@ public abstract class AbstractMethodValidationTest {
 
 	@Test
 	public void methodValidationSucceedsAsNoConstraintOfValidatedGroupAreViolated() {
-		customerRepository.parameterConstraintInGroup( null );
+		customerRepositoryValidatingProxy.parameterConstraintInGroup( null );
 	}
 
 	@Test(expectedExceptions = ConstraintViolationException.class)
 	public void methodValidationFailsAsConstraintOfValidatedGroupIsViolated() {
 		createProxy( CustomerRepository.ValidationGroup.class );
-		customerRepository.parameterConstraintInGroup( null );
+		customerRepositoryValidatingProxy.parameterConstraintInGroup( null );
 	}
 
 	@Test(expectedExceptions = ConstraintDeclarationException.class, expectedExceptionsMessageRegExp = "HV000132.*")
@@ -750,7 +752,7 @@ public abstract class AbstractMethodValidationTest {
 	@TestForIssue(jiraKey = "HV-601")
 	@Test(expectedExceptions = ConstraintViolationException.class)
 	public void shouldValidateGetterLikeNamedMethodWithParameter() {
-		customerRepository.getFoo( "" );
+		customerRepositoryValidatingProxy.getFoo( "" );
 	}
 
 	@Test
@@ -761,7 +763,7 @@ public abstract class AbstractMethodValidationTest {
 
 		try {
 			//when
-			customerRepository.methodWithCrossParameterConstraint( startDate, endDate );
+			customerRepositoryValidatingProxy.methodWithCrossParameterConstraint( startDate, endDate );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -778,8 +780,8 @@ public abstract class AbstractMethodValidationTest {
 			ConstraintViolation<?> constraintViolation = e.getConstraintViolations().iterator().next();
 			assertEquals( constraintViolation.getConstraintDescriptor().getAnnotation().annotationType(), ConsistentDateParameters.class );
 			assertEquals( constraintViolation.getInvalidValue(), new Object[] { startDate, endDate } );
-			assertEquals( constraintViolation.getLeafBean(), customerRepository );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getLeafBean(), customerRepositoryOriginalBean );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
 			assertEquals( constraintViolation.getExecutableParameters(), new Object[] { startDate, endDate } );
 			assertEquals( constraintViolation.getExecutableReturnValue(), null );
@@ -795,7 +797,7 @@ public abstract class AbstractMethodValidationTest {
 
 	@Test
 	public void methodValidationSucceeds() {
-		customerRepository.findCustomerByName( "Bob" );
+		customerRepositoryValidatingProxy.findCustomerByName( "Bob" );
 	}
 
 	protected void assertMethod(ConstraintViolation<?> constraintViolation, String methodName, Class<?>... parameterTypes) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AnnotationBasedMethodValidationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/methodvalidation/AnnotationBasedMethodValidationTest.java
@@ -46,7 +46,7 @@ public class AnnotationBasedMethodValidationTest extends AbstractMethodValidatio
 		List<Customer> customers = Arrays.asList( null, customer );
 
 		try {
-			customerRepository.iterableParameterWithCascadingTypeParameter( customers );
+			customerRepositoryValidatingProxy.iterableParameterWithCascadingTypeParameter( customers );
 			fail( "Expected ConstraintViolationException wasn't thrown." );
 		}
 		catch (ConstraintViolationException e) {
@@ -62,7 +62,7 @@ public class AnnotationBasedMethodValidationTest extends AbstractMethodValidatio
 					"iterableParameterWithCascadingTypeParameter.customer[1].name"
 			);
 			assertEquals( constraintViolation.getRootBeanClass(), CustomerRepositoryImpl.class );
-			assertEquals( constraintViolation.getRootBean(), customerRepository );
+			assertEquals( constraintViolation.getRootBean(), customerRepositoryOriginalBean );
 			assertEquals( constraintViolation.getLeafBean(), customer );
 			assertEquals( constraintViolation.getInvalidValue(), null );
 			assertEquals( constraintViolation.getExecutableParameters(), new Object[] { customers } );

--- a/osgi/felixtest/pom.xml
+++ b/osgi/felixtest/pom.xml
@@ -78,7 +78,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
-            <artifactId>arquillian-payara-server-4-managed</artifactId> 
+            <artifactId>arquillian-payara-server-managed</artifactId>
             <version>${version.fish.payara.arquillian}</version>
             <scope>test</scope>
         </dependency>

--- a/osgi/felixtest/pom.xml
+++ b/osgi/felixtest/pom.xml
@@ -72,6 +72,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
             <artifactId>arquillian-protocol-servlet</artifactId>
             <scope>test</scope>

--- a/osgi/felixtest/src/test/java/org/hibernate/validator/osgi/felix/FelixCDIIT.java
+++ b/osgi/felixtest/src/test/java/org/hibernate/validator/osgi/felix/FelixCDIIT.java
@@ -14,6 +14,8 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.PomEquippedResolveStage;
 import org.testng.annotations.Test;
 
 import com.example.cdi.MyBean;
@@ -27,11 +29,13 @@ public class FelixCDIIT extends Arquillian {
 
 	@Deployment
 	public static Archive<?> deployment() {
+		PomEquippedResolveStage pom = Maven.resolver().loadPomFromFile( "pom.xml" );
 		WebArchive war = create( WebArchive.class )
 				.addClasses(
 						MyBean.class,
 						ValidNumber.class,
-						ValidNumberValidator.class );
+						ValidNumberValidator.class )
+				.addAsLibraries( pom.resolve( "org.testng:testng" ).withTransitivity().asFile() );
 
 		return war;
 	}

--- a/osgi/integrationtest/pom.xml
+++ b/osgi/integrationtest/pom.xml
@@ -185,6 +185,7 @@
                 <configuration>
                     <reuseForks>false</reuseForks>
                     <systemPropertyVariables>
+                        <maven.settings.localRepository>${settings.localRepository}</maven.settings.localRepository>
                         <maven.mavencentral.repo.url>${mavencentral.repo.url}</maven.mavencentral.repo.url>
                     </systemPropertyVariables>
                 </configuration>

--- a/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/KarafFeaturesAreInstallableTest.java
+++ b/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/KarafFeaturesAreInstallableTest.java
@@ -67,6 +67,7 @@ public class KarafFeaturesAreInstallableTest {
 				.type( "xml" )
 				.versionAsInProject();
 
+		String mavenLocalRepository = System.getProperty( "maven.settings.localRepository" );
 		String mavenCentralRepository = System.getProperty( "maven.mavencentral.repo.url" );
 
 		return options(
@@ -93,6 +94,26 @@ public class KarafFeaturesAreInstallableTest {
 						"etc/org.apache.karaf.features.cfg",
 						"featuresBoot",
 						"system"
+				),
+				/*
+				 * Use the same local Maven repository as the build job.
+				 * This allows to retrieve the just-installed artifacts in case
+				 * the local repo was overridden from the command line.
+				 *
+				 * See https://ops4j1.jira.com/wiki/spaces/paxurl/pages/3833866/Mvn+Protocol for more information
+				 * on the configuration below.
+				 */
+				editConfigurationFilePut(
+						"etc/org.ops4j.pax.url.mvn.cfg",
+						"org.ops4j.pax.url.mvn.defaultRepositories",
+						"file://" + mavenLocalRepository
+								+ "@snapshots"
+								+ "@id=local-repo-from-maven-settings"
+				),
+				editConfigurationFilePut(
+						"etc/org.ops4j.pax.url.mvn.cfg",
+						"org.ops4j.pax.url.mvn.localRepository",
+						mavenLocalRepository
 				),
 				editConfigurationFilePut( // Erase the defaults: Maven Central uses HTTP by default...
 						"etc/org.ops4j.pax.url.mvn.cfg",

--- a/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/OsgiIntegrationTest.java
+++ b/osgi/integrationtest/src/test/java/org/hibernate/validator/osgi/integrationtest/OsgiIntegrationTest.java
@@ -90,6 +90,7 @@ public class OsgiIntegrationTest {
 				.type( "xml" )
 				.versionAsInProject();
 
+		String mavenLocalRepository = System.getProperty( "maven.settings.localRepository" );
 		String mavenCentralRepository = System.getProperty( "maven.mavencentral.repo.url" );
 
 		return options(
@@ -116,6 +117,26 @@ public class OsgiIntegrationTest {
 						"etc/org.apache.karaf.features.cfg",
 						"featuresBoot",
 						"system"
+				),
+				/*
+				 * Use the same local Maven repository as the build job.
+				 * This allows to retrieve the just-installed artifacts in case
+				 * the local repo was overridden from the command line.
+				 *
+				 * See https://ops4j1.jira.com/wiki/spaces/paxurl/pages/3833866/Mvn+Protocol for more information
+				 * on the configuration below.
+				 */
+				editConfigurationFilePut(
+						"etc/org.ops4j.pax.url.mvn.cfg",
+						"org.ops4j.pax.url.mvn.defaultRepositories",
+						"file://" + mavenLocalRepository
+								+ "@snapshots"
+								+ "@id=local-repo-from-maven-settings"
+				),
+				editConfigurationFilePut(
+						"etc/org.ops4j.pax.url.mvn.cfg",
+						"org.ops4j.pax.url.mvn.localRepository",
+						mavenLocalRepository
 				),
 				editConfigurationFilePut( // Erase the defaults: Maven Central uses HTTP by default...
 						"etc/org.ops4j.pax.url.mvn.cfg",

--- a/pom.xml
+++ b/pom.xml
@@ -1397,5 +1397,32 @@
                 </repository>
             </repositories>
         </profile>
+        <profile>
+            <id>IDEA</id>
+            <activation>
+                <!-- This is a trick to have the profile automatically activated by IDEA -->
+                <property>
+                    <name>idea.maven.embedder.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <version>${version.compiler.plugin}</version>
+                            <configuration>
+                                <compilerArgs>
+                                    <compilerArg>-Aorg.jboss.logging.tools.addGeneratedAnnotation=false</compilerArg>
+                                    <!-- Make sure IDEA uses the -parameters for all code;
+                                         IDEA ignores the "testCompilerArguments" option... -->
+                                    <compilerArg>-parameters</compilerArg>
+                                </compilerArgs>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -186,8 +186,8 @@
         <version.org.ops4j.pax.exam>4.12.0</version.org.ops4j.pax.exam>
         <version.org.ops4j.pax.url>2.5.2</version.org.ops4j.pax.url>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
-        <version.fish.payara>5.181</version.fish.payara>
-        <version.fish.payara.arquillian>1.0.Beta3</version.fish.payara.arquillian>
+        <version.fish.payara>5.2020.2</version.fish.payara>
+        <version.fish.payara.arquillian>2.3.1</version.fish.payara.arquillian>
         <!-- Used in the Karaf tests -->
         <version.javax.inject>1</version.javax.inject>
 

--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 
         <!-- Test dependencies -->
         <version.org.jboss.arquillian>1.7.0.Alpha1</version.org.jboss.arquillian>
-        <version.org.testng>6.8</version.org.testng>
+        <version.org.testng>6.14.3</version.org.testng>
         <!-- it must be the exact same version than the one used in the Bean Validation TCK -->
         <version.org.assertj.assertj-core>3.8.0</version.org.assertj.assertj-core>
         <version.junit>4.12</version.junit>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <!-- OSGi dependencies -->
         <version.org.apache.karaf>4.2.0</version.org.apache.karaf>
         <version.org.ops4j.pax.exam>4.12.0</version.org.ops4j.pax.exam>
-        <version.org.ops4j.pax.url>2.5.2</version.org.ops4j.pax.url>
+        <version.org.ops4j.pax.url>2.5.4</version.org.ops4j.pax.url>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
         <version.fish.payara>5.2020.2</version.fish.payara>
         <version.fish.payara.arquillian>2.3.1</version.fish.payara.arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         <version.org.openjfx>11.0.2</version.org.openjfx>
 
         <!-- Test dependencies -->
-        <version.org.jboss.arquillian>1.7.0.Alpha1</version.org.jboss.arquillian>
+        <version.org.jboss.arquillian>1.7.0.Alpha4</version.org.jboss.arquillian>
         <version.org.testng>6.14.3</version.org.testng>
         <!-- it must be the exact same version than the one used in the Bean Validation TCK -->
         <version.org.assertj.assertj-core>3.8.0</version.org.assertj.assertj-core>

--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,13 @@
         <surefire.jvm.args>${surefire.jvm.args.additional} ${surefire.jvm.args.add-opens} ${surefire.jvm.args.illegal-access} ${surefire.jvm.args.shrinkwrap}</surefire.jvm.args>
         <failsafe.jvm.args>${surefire.jvm.args.additional} ${surefire.jvm.args.add-opens} ${surefire.jvm.args.illegal-access} ${surefire.jvm.args.shrinkwrap}</failsafe.jvm.args>
 
+        <!--
+            Should be set from the command line.
+            Used by CI jobs that execute tests in multiple environments.
+            Allows distinguishing between multiple executions of the same test in test reports.
+         -->
+        <surefire.environment>default</surefire.environment>
+
         <arquillian.wildfly.jvm.args.add-opens></arquillian.wildfly.jvm.args.add-opens>
         <arquillian.wildfly.jvm.args.add-modules></arquillian.wildfly.jvm.args.add-modules>
         <arquillian.wildfly.jvm.args>${arquillian.wildfly.jvm.args.add-opens} ${arquillian.wildfly.jvm.args.add-modules}</arquillian.wildfly.jvm.args>
@@ -812,6 +819,7 @@
                             <include>**/*Test.java</include>
                         </includes>
                         <argLine>${surefire.jvm.args}</argLine>
+                        <reportNameSuffix>${surefire.environment}</reportNameSuffix>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -836,6 +844,7 @@
                     <version>${version.failsafe.plugin}</version>
                     <configuration>
                         <argLine>${failsafe.jvm.args}</argLine>
+                        <reportNameSuffix>${surefire.environment}</reportNameSuffix>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -284,8 +284,16 @@
         <surefire.jvm.args.additional></surefire.jvm.args.additional>
         <surefire.jvm.args.illegal-access></surefire.jvm.args.illegal-access>
         <surefire.jvm.args.add-opens></surefire.jvm.args.add-opens>
-        <surefire.jvm.args>${surefire.jvm.args.additional} ${surefire.jvm.args.add-opens} ${surefire.jvm.args.illegal-access}</surefire.jvm.args>
-        <failsafe.jvm.args>${surefire.jvm.args.additional} ${surefire.jvm.args.add-opens} ${surefire.jvm.args.illegal-access}</failsafe.jvm.args>
+        <!--
+          The arguments below are Shrinkwrap settings taken from
+          https://github.com/shrinkwrap/resolver/blob/788a3c1148af3a7ebdfdaf817393273f5f5ee17b/impl-maven/src/main/java/org/jboss/shrinkwrap/resolver/impl/maven/bootstrap/MavenSettingsBuilder.java#L80
+          - maven.repo.local: necessary for the Shrinkwrap artifact retrieval to work when using a non-default local repository
+         -->
+        <surefire.jvm.args.shrinkwrap>
+            -Dmaven.repo.local=${settings.localRepository}
+        </surefire.jvm.args.shrinkwrap>
+        <surefire.jvm.args>${surefire.jvm.args.additional} ${surefire.jvm.args.add-opens} ${surefire.jvm.args.illegal-access} ${surefire.jvm.args.shrinkwrap}</surefire.jvm.args>
+        <failsafe.jvm.args>${surefire.jvm.args.additional} ${surefire.jvm.args.add-opens} ${surefire.jvm.args.illegal-access} ${surefire.jvm.args.shrinkwrap}</failsafe.jvm.args>
 
         <arquillian.wildfly.jvm.args.add-opens></arquillian.wildfly.jvm.args.add-opens>
         <arquillian.wildfly.jvm.args.add-modules></arquillian.wildfly.jvm.args.add-modules>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -156,8 +156,6 @@
                             <value>${validation.provider}</value>
                         </property>
                     </systemProperties>
-                    <parallel>methods</parallel>
-                    <threadCount>4</threadCount>
                 </configuration>
             </plugin>
             <plugin>

--- a/tck-runner/src/test/resources/test.policy
+++ b/tck-runner/src/test/resources/test.policy
@@ -83,11 +83,13 @@ grant codeBase "file:${localRepository}/jakarta/validation/beanvalidation-standa
 
 // Ideally, this domain should have no permissions at all; Only specifically enabling some API calls done by the BV TCK
 // tests (which do not use privileged actions for these)
+// and by TestNG (which does not use privileged actions either).
 grant codeBase "file:${project.build.directory}/classes" {
     permission java.util.PropertyPermission "validation.provider", "read";
     permission java.io.FilePermission "${localRepository}/jakarta/validation/beanvalidation-tck-tests/${version.jakarta.validation.beanvalidation-tck}/beanvalidation-tck-tests-${version.jakarta.validation.beanvalidation-tck}.jar", "read";
     permission java.util.PropertyPermission "user.language", "write";
     permission org.hibernate.validator.HibernateValidatorPermission "accessPrivateMembers";
+    permission "java.lang.reflect.ReflectPermission" "suppressAccessChecks";
 };
 
 grant codeBase "file:${project.build.directory}/test-classes" {


### PR DESCRIPTION
* [HV-1809](https://hibernate.atlassian.net/browse/HV-1809): Upgrade to TestNG 6.14.3
* [HV-1808](https://hibernate.atlassian.net/browse/HV-1808): Upgrade to Arquillian 1.7.0.Alpha4
* [HV-1807](https://hibernate.atlassian.net/browse/HV-1807): Add Maven profile to improve contributor experience on Intellij IDEA
* [HV-1806](https://hibernate.atlassian.net/browse/HV-1806): Use the local repository from the Maven build in OSGi/WildFly integration tests
* [HV-1805](https://hibernate.atlassian.net/browse/HV-1805): Add a Jenkinsfile to test multiple JDKs from a single job

Once this is merged, builds for branch master and PRs to this branch will appear [here](https://ci.hibernate.org/job/hibernate-validator/). We will be able to disable all other Jenkins jobs related to this branch, and exclude this branch in the  Jenkins job dedicated to pull requests.

Other branches and PRs to these other branches will, of course, still require separate Jenkins jobs.

# Example

For my tests, I used my own repository and a separate Jenkins job. You can see the result of a full build here: https://ci.hibernate.org/blue/organizations/jenkins/hibernate-validator-personal-yoann/detail/HV-1805/22/pipeline/66

Regarding that build:

* The TCK tests on WildFly are failing. That's expected too since WildFly doesn't handle the `jakarata.*` packages yet. I added a commit to not execute these builds except on-demand, for now.
* The JDK15 and JDK16 builds are failing. That's expected and is caused by a regression in JDK15 and JDK16, which has already been reported. If you want, we can disable these builds like I did for WildFly.
* The JDK8 and JDK11 builds have a warning. This is a display bug, and it only occurs when parallel builds fail. This does not affect build execution.

## How it works

The Jenkinsfile defines what will be executed for everything related to the branch it was committed to:

* Pushes to that branch
* Pull requests to that branch

Currently, I configured the Jenkinsfile this way:

* On creation and pushes to a pull-request, or when a comment is added to the PR stating "Jenkins, retest this please", we only execute the default build (JDK8, no execution of the TCK in WildFly).
* On pushes to primary branches (`master` or anything matching `[0-9]\.[0-9]`), we only execute the default build (JDK8, no execution of the TCK in WildFly).
* On pushes to topic branches (any branch that is not a primary branch), we only execute the default build (JDK8, no execution of the TCK in WildFly). This is useful if you set up a Jenkins job for your own fork, like I did for Hibernate Search: https://ci.hibernate.org/view/Personal%20jobs/job/hibernate-search-personal-yoann/

Alternatively, it is also possible to execute a build on a particular branch (or PR) manually, from the Jenkins UI. See for example [here](https://ci.hibernate.org/job/hibernate-validator-personal-yoann/job/HV-1805/build?delay=0sec). You will have access to the following parameters:

* `ENVIRONMENT_SET`:
  * `AUTOMATIC`: Builds according to the rules above.
  * `DEFAULT`: Only performs the default build: JDK8, no execution of the TCK in WildFly.
  * `SUPPORTED`: Executes all builds that are expected to work.
  * `ALL`: Executes all builds, including those that are not expected to work.
* `ENVIRONMENT_FILTER`: Alternative to `ENVIRONMENT_SET`, to execute a particular build based on a regular expression matching the name of that build. For example, try `jdk-11`.
* `RELEASE_VERSION`: Set this to trigger a release with the given version. The version will be checked against a regex to be sure no component is missing.
* `RELEASE_DEVELOPMENT_VERSION`: The next version, for releases.
* `RELEASE_DRY_RUN`: Check to perform a dry run of the release, without any push to Github nor any upload.