### PR TITLE
HV-1812 Avoid reflection-based metadata extraction for built-in value extractors - 6.2

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/BooleanArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/BooleanArrayValueExtractor.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
@@ -13,7 +15,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class BooleanArrayValueExtractor implements ValueExtractor<boolean @ExtractedValue[]> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new BooleanArrayValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new BooleanArrayValueExtractor(), boolean[].class,
+			new ArrayElement( boolean[].class ), false, Optional.empty() );
 
 	private BooleanArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ByteArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ByteArrayValueExtractor.java
@@ -6,14 +6,17 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.internal.engine.path.NodeImpl;
 
-class ByteArrayValueExtractor implements ValueExtractor<byte @ExtractedValue[]> {
+class ByteArrayValueExtractor implements ValueExtractor<byte @ExtractedValue []> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ByteArrayValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ByteArrayValueExtractor(), byte[].class,
+			new ArrayElement( byte[].class ), false, Optional.empty() );
 
 	private ByteArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/CharArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/CharArrayValueExtractor.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
@@ -13,7 +15,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class CharArrayValueExtractor implements ValueExtractor<char @ExtractedValue[]> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new CharArrayValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new CharArrayValueExtractor(), char[].class,
+			new ArrayElement( char[].class ), false, Optional.empty() );
 
 	private CharArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/DoubleArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/DoubleArrayValueExtractor.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
@@ -13,7 +15,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class DoubleArrayValueExtractor implements ValueExtractor<double @ExtractedValue[]> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new DoubleArrayValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new DoubleArrayValueExtractor(), double[].class,
+			new ArrayElement( double[].class ), false, Optional.empty() );
 
 	private DoubleArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/FloatArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/FloatArrayValueExtractor.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
@@ -13,7 +15,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class FloatArrayValueExtractor implements ValueExtractor<float @ExtractedValue[]> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new FloatArrayValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new FloatArrayValueExtractor(), float[].class,
+			new ArrayElement( float[].class ), false, Optional.empty() );
 
 	private FloatArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/IntArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/IntArrayValueExtractor.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
@@ -13,7 +15,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class IntArrayValueExtractor implements ValueExtractor<int @ExtractedValue[]> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new IntArrayValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new IntArrayValueExtractor(), int[].class,
+			new ArrayElement( int[].class ), false, Optional.empty() );
 
 	private IntArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/IterableValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/IterableValueExtractor.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
@@ -13,7 +15,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class IterableValueExtractor implements ValueExtractor<Iterable<@ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new IterableValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new IterableValueExtractor(), Iterable.class,
+			Iterable.class.getTypeParameters()[0], false, Optional.empty() );
 
 	private IterableValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ListPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ListPropertyValueExtractor.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine.valueextraction;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
@@ -29,7 +30,8 @@ import javafx.beans.value.ObservableValue;
 @IgnoreForbiddenApisErrors(reason = "Usage of JavaFX classes")
 class ListPropertyValueExtractor implements ValueExtractor<ListProperty<@ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ListPropertyValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ListPropertyValueExtractor(), ListProperty.class,
+			ListProperty.class.getTypeParameters()[0], false, Optional.empty() );
 
 	private ListPropertyValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ListValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ListValueExtractor.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine.valueextraction;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
@@ -15,7 +16,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class ListValueExtractor implements ValueExtractor<List<@ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ListValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ListValueExtractor(), List.class, List.class.getTypeParameters()[0],
+			false, Optional.empty() );
 
 	private ListValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/LongArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/LongArrayValueExtractor.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
@@ -13,7 +15,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class LongArrayValueExtractor implements ValueExtractor<long @ExtractedValue[]> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new LongArrayValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new LongArrayValueExtractor(), long[].class,
+			new ArrayElement( long[].class ), false, Optional.empty() );
 
 	private LongArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapKeyExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapKeyExtractor.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine.valueextraction;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
@@ -15,7 +16,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class MapKeyExtractor implements ValueExtractor<Map<@ExtractedValue ?, ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapKeyExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapKeyExtractor(), Map.class, Map.class.getTypeParameters()[0],
+			false, Optional.empty() );
 
 	private MapKeyExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapPropertyKeyExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapPropertyKeyExtractor.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine.valueextraction;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
@@ -29,7 +30,8 @@ import javafx.beans.value.ObservableValue;
 @IgnoreForbiddenApisErrors(reason = "Usage of JavaFX classes")
 class MapPropertyKeyExtractor implements ValueExtractor<MapProperty<@ExtractedValue ?, ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapPropertyKeyExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapPropertyKeyExtractor(), MapProperty.class,
+			MapProperty.class.getTypeParameters()[0], false, Optional.empty() );
 
 	private MapPropertyKeyExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapPropertyValueExtractor.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine.valueextraction;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
@@ -29,7 +30,8 @@ import javafx.beans.value.ObservableValue;
 @IgnoreForbiddenApisErrors(reason = "Usage of JavaFX classes")
 class MapPropertyValueExtractor implements ValueExtractor<MapProperty<?, @ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapPropertyValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapPropertyValueExtractor(), MapProperty.class,
+			MapProperty.class.getTypeParameters()[1], false, Optional.empty() );
 
 	private MapPropertyValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/MapValueExtractor.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine.valueextraction;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
@@ -15,7 +16,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class MapValueExtractor implements ValueExtractor<Map<?, @ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new MapValueExtractor(), Map.class, Map.class.getTypeParameters()[1],
+			false, Optional.empty() );
 
 	private MapValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ObjectArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ObjectArrayValueExtractor.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
@@ -13,7 +15,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class ObjectArrayValueExtractor implements ValueExtractor<Object @ExtractedValue[]> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ObjectArrayValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ObjectArrayValueExtractor(), Object[].class,
+			new ArrayElement( Object[].class ), false, Optional.empty() );
 
 	private ObjectArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ObservableValueValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ObservableValueValueExtractor.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.UnwrapByDefault;
 import javax.validation.valueextraction.ValueExtractor;
@@ -24,7 +26,8 @@ import javafx.beans.value.ObservableValue;
 @UnwrapByDefault
 class ObservableValueValueExtractor implements ValueExtractor<ObservableValue<@ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ObservableValueValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ObservableValueValueExtractor(), ObservableValue.class,
+			ObservableValue.class.getTypeParameters()[0], true, Optional.empty() );
 
 	private ObservableValueValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalDoubleValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalDoubleValueExtractor.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
 import java.util.OptionalDouble;
 
 import javax.validation.valueextraction.ExtractedValue;
@@ -18,7 +19,8 @@ import javax.validation.valueextraction.ValueExtractor;
 @UnwrapByDefault
 class OptionalDoubleValueExtractor implements ValueExtractor<@ExtractedValue(type = Double.class) OptionalDouble> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalDoubleValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalDoubleValueExtractor(), OptionalDouble.class,
+			AnnotatedObject.INSTANCE, true, Optional.of( Double.class ) );
 
 	@Override
 	public void extractValues(OptionalDouble originalValue, ValueReceiver receiver) {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalIntValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalIntValueExtractor.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import javax.validation.valueextraction.ExtractedValue;
@@ -18,7 +19,8 @@ import javax.validation.valueextraction.ValueExtractor;
 @UnwrapByDefault
 class OptionalIntValueExtractor implements ValueExtractor<@ExtractedValue(type = Integer.class) OptionalInt> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalIntValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalIntValueExtractor(), OptionalInt.class,
+			AnnotatedObject.INSTANCE, true, Optional.of( Integer.class ) );
 
 	@Override
 	public void extractValues(OptionalInt originalValue, ValueReceiver receiver) {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalLongValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalLongValueExtractor.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
 import java.util.OptionalLong;
 
 import javax.validation.valueextraction.ExtractedValue;
@@ -18,7 +19,8 @@ import javax.validation.valueextraction.ValueExtractor;
 @UnwrapByDefault
 class OptionalLongValueExtractor implements ValueExtractor<@ExtractedValue(type = Long.class) OptionalLong> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalLongValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalLongValueExtractor(), OptionalLong.class,
+			AnnotatedObject.INSTANCE, true, Optional.of( Long.class ) );
 
 	@Override
 	public void extractValues(OptionalLong originalValue, ValueReceiver receiver) {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/OptionalValueExtractor.java
@@ -16,7 +16,8 @@ import javax.validation.valueextraction.ValueExtractor;
  */
 class OptionalValueExtractor implements ValueExtractor<Optional<@ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new OptionalValueExtractor(), Optional.class,
+			Optional.class.getTypeParameters()[0], false, Optional.empty() );
 
 	private OptionalValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyListPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyListPropertyValueExtractor.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine.valueextraction;
 
 import java.util.List;
+import java.util.Optional;
 
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
@@ -29,7 +30,8 @@ import javafx.beans.value.ObservableValue;
 @IgnoreForbiddenApisErrors(reason = "Usage of JavaFX classes")
 class ReadOnlyListPropertyValueExtractor implements ValueExtractor<ReadOnlyListProperty<@ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlyListPropertyValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlyListPropertyValueExtractor(), ReadOnlyListProperty.class,
+			ReadOnlyListProperty.class.getTypeParameters()[0], false, Optional.empty() );
 
 	private ReadOnlyListPropertyValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyMapPropertyKeyExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyMapPropertyKeyExtractor.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine.valueextraction;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
@@ -29,7 +30,8 @@ import javafx.beans.value.ObservableValue;
 @IgnoreForbiddenApisErrors(reason = "Usage of JavaFX classes")
 class ReadOnlyMapPropertyKeyExtractor implements ValueExtractor<ReadOnlyMapProperty<@ExtractedValue ?, ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlyMapPropertyKeyExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlyMapPropertyKeyExtractor(), ReadOnlyMapProperty.class,
+			ReadOnlyMapProperty.class.getTypeParameters()[0], false, Optional.empty() );
 
 	private ReadOnlyMapPropertyKeyExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyMapPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlyMapPropertyValueExtractor.java
@@ -7,6 +7,7 @@
 package org.hibernate.validator.internal.engine.valueextraction;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
@@ -29,7 +30,8 @@ import javafx.beans.value.ObservableValue;
 @IgnoreForbiddenApisErrors(reason = "Usage of JavaFX classes")
 class ReadOnlyMapPropertyValueExtractor implements ValueExtractor<ReadOnlyMapProperty<?, @ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlyMapPropertyValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlyMapPropertyValueExtractor(), ReadOnlyMapProperty.class,
+			ReadOnlyMapProperty.class.getTypeParameters()[1], false, Optional.empty() );
 
 	private ReadOnlyMapPropertyValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlySetPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ReadOnlySetPropertyValueExtractor.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.valueextraction.ExtractedValue;
@@ -29,7 +30,8 @@ import javafx.beans.value.ObservableValue;
 @IgnoreForbiddenApisErrors(reason = "Usage of JavaFX classes")
 class ReadOnlySetPropertyValueExtractor implements ValueExtractor<ReadOnlySetProperty<@ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlySetPropertyValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ReadOnlySetPropertyValueExtractor(), ReadOnlySetProperty.class,
+			ReadOnlySetProperty.class.getTypeParameters()[0], false, Optional.empty() );
 
 	private ReadOnlySetPropertyValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/SetPropertyValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/SetPropertyValueExtractor.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
 import java.util.Set;
 
 import javax.validation.valueextraction.ExtractedValue;
@@ -29,7 +30,8 @@ import javafx.beans.value.ObservableValue;
 @IgnoreForbiddenApisErrors(reason = "Usage of JavaFX classes")
 class SetPropertyValueExtractor implements ValueExtractor<SetProperty<@ExtractedValue ?>> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new SetPropertyValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new SetPropertyValueExtractor(), SetProperty.class,
+			SetProperty.class.getTypeParameters()[0], false, Optional.empty() );
 
 	private SetPropertyValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ShortArrayValueExtractor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ShortArrayValueExtractor.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.engine.valueextraction;
 
+import java.util.Optional;
+
 import javax.validation.valueextraction.ExtractedValue;
 import javax.validation.valueextraction.ValueExtractor;
 
@@ -13,7 +15,8 @@ import org.hibernate.validator.internal.engine.path.NodeImpl;
 
 class ShortArrayValueExtractor implements ValueExtractor<short @ExtractedValue[]> {
 
-	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ShortArrayValueExtractor() );
+	static final ValueExtractorDescriptor DESCRIPTOR = new ValueExtractorDescriptor( new ShortArrayValueExtractor(), short[].class,
+			new ArrayElement( short[].class ), false, Optional.empty() );
 
 	private ShortArrayValueExtractor() {
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ValueExtractorDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ValueExtractorDescriptor.java
@@ -53,6 +53,19 @@ public class ValueExtractorDescriptor {
 		this.extractedType = getExtractedType( valueExtractorDefinition );
 	}
 
+	ValueExtractorDescriptor(ValueExtractor<?> valueExtractor,
+			Class<?> containerType,
+			TypeVariable<?> extractedTypeParameter,
+			boolean unwrapByDefault,
+			Optional<Class<?>> extractedType) {
+		this.key = new Key(
+				containerType,
+				extractedTypeParameter );
+		this.valueExtractor = valueExtractor;
+		this.unwrapByDefault = unwrapByDefault;
+		this.extractedType = extractedType;
+	}
+
 	@SuppressWarnings("rawtypes")
 	private static TypeVariable<?> getExtractedTypeParameter(AnnotatedParameterizedType valueExtractorDefinition,
 			Class<? extends ValueExtractor> extractorImplementationType) {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1812

@yrodiere not the most exciting PR but I would appreciate a second pair of eyes.

The idea is to avoid calling a method not present in the Android JDK for the built-in value extractors.