### PR TITLE
HV-1826 Reintroduce TCK Runner in container tests

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -89,15 +89,17 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>hibernate-validator-modules</artifactId>
-            <classifier>wildfly-${version.wildfly}-patch</classifier>
+            <classifier>wildfly-preview-${version.wildfly}-patch</classifier>
             <type>zip</type>
         </dependency>
+        <!--
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>hibernate-validator-modules</artifactId>
             <classifier>wildfly-${version.wildfly.secondary}-patch</classifier>
             <type>zip</type>
         </dependency>
+        -->
     </dependencies>
 
     <build>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -21,16 +21,14 @@
     <description>Hibernate Validator WildFly integration tests.</description>
 
     <properties>
-        <wildfly.target-dir>${project.build.directory}/wildfly-${version.wildfly}</wildfly.target-dir>
+        <wildfly.target-dir>${project.build.directory}/wildfly-preview-${version.wildfly}</wildfly.target-dir>
         <wildfly.modules-dir>${wildfly.target-dir}/modules/system/layers/base</wildfly.modules-dir>
-
+        <!--
         <wildfly-secondary.target-dir>${project.build.directory}/wildfly-${version.wildfly.secondary}</wildfly-secondary.target-dir>
         <wildfly-secondary.modules-dir>${wildfly-secondary.target-dir}/modules/system/layers/base</wildfly-secondary.modules-dir>
+        -->
 
         <hibernate-validator-parent.path>..</hibernate-validator-parent.path>
-
-        <!-- Temporary, should be removed as soon as we have a Jakarta EE 9 WildFly -->
-        <skipTests>true</skipTests>
     </properties>
 
     <dependencies>
@@ -158,7 +156,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>hibernate-validator-modules</artifactId>
-            <classifier>wildfly-${version.wildfly}-patch</classifier>
+            <classifier>wildfly-preview-${version.wildfly}-patch</classifier>
             <type>zip</type>
             <scope>test</scope>
         </dependency>
@@ -220,7 +218,7 @@
                                 <!-- WildFly current -->
                                 <artifactItem>
                                     <groupId>org.wildfly</groupId>
-                                    <artifactId>wildfly-dist</artifactId>
+                                    <artifactId>wildfly-preview-dist</artifactId>
                                     <version>${version.wildfly}</version>
                                     <type>tar.gz</type>
                                     <overWrite>false</overWrite>
@@ -242,7 +240,7 @@
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>hibernate-validator-modules</artifactId>
                                     <version>${project.version}</version>
-                                    <classifier>wildfly-${version.wildfly}-patch</classifier>
+                                    <classifier>wildfly-preview-${version.wildfly}-patch</classifier>
                                     <type>zip</type>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
                                 </artifactItem>
@@ -310,10 +308,10 @@
                         </goals>
                         <configuration>
                             <offline>true</offline>
-                            <jbossHome>${project.build.directory}/wildfly-${version.wildfly}/</jbossHome>
+                            <jbossHome>${project.build.directory}/wildfly-preview-${version.wildfly}/</jbossHome>
                             <fail-on-error>false</fail-on-error>
                             <commands>
-                                <command>patch apply ${project.build.directory}/hibernate-validator-modules-${project.version}-wildfly-${version.wildfly}-patch.zip</command>
+                                <command>patch apply ${project.build.directory}/hibernate-validator-modules-${project.version}-wildfly-preview-${version.wildfly}-patch.zip</command>
                             </commands>
                         </configuration>
                     </execution>
@@ -333,6 +331,7 @@
             </properties>
         </profile>
         <!-- WildFly 13 does not support JDK 11 so running the tests with WildFly 13 for JDK 10 - -->
+        <!--
         <profile>
             <id>jdk10-</id>
             <activation>
@@ -344,7 +343,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <executions>
-                            <!-- WildFly secondary version -->
                             <execution>
                                 <id>wildfly-secondary-integration-test</id>
                                 <goals>
@@ -371,7 +369,6 @@
                                 </goals>
                                 <configuration>
                                     <artifactItems>
-                                        <!-- WildFly secondary version -->
                                         <artifactItem>
                                             <groupId>org.wildfly</groupId>
                                             <artifactId>wildfly-dist</artifactId>
@@ -391,7 +388,6 @@
                                 </goals>
                                 <configuration>
                                     <artifactItems>
-                                        <!-- WildFly secondary version -->
                                         <artifactItem>
                                             <groupId>${project.groupId}</groupId>
                                             <artifactId>hibernate-validator-modules</artifactId>
@@ -411,7 +407,6 @@
                                 </goals>
                                 <configuration>
                                     <artifactItems>
-                                        <!-- WildFly secondary version -->
                                         <artifactItem>
                                             <groupId>javax.money</groupId>
                                             <artifactId>money-api</artifactId>
@@ -432,7 +427,6 @@
                     <plugin>
                         <artifactId>maven-resources-plugin</artifactId>
                         <executions>
-                            <!-- WildFly secondary version -->
                             <execution>
                                 <id>copy-wildfly-secondary-resources</id>
                                 <phase>pre-integration-test</phase>
@@ -455,7 +449,6 @@
                         <groupId>org.wildfly.plugins</groupId>
                         <artifactId>wildfly-maven-plugin</artifactId>
                         <executions>
-                            <!-- WildFly secondary version -->
                             <execution>
                                 <id>apply-wildfly-secondary-patch-file</id>
                                 <phase>pre-integration-test</phase>
@@ -476,5 +469,6 @@
                 </plugins>
             </build>
         </profile>
+        -->
     </profiles>
 </project>

--- a/integration/src/test/java/org/hibernate/validator/integration/wildfly/OptionalConstraintsIT.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/wildfly/OptionalConstraintsIT.java
@@ -57,7 +57,7 @@ public class OptionalConstraintsIT extends AbstractArquillianIT {
 		assertThat( violations.iterator().next().getConstraintDescriptor().getAnnotation().annotationType() ).isEqualTo( Future.class );
 	}
 
-	@Test
+	@Test(enabled = false)
 	public void canUseJavaMoneyBasedConstraint() {
 		Set<ConstraintViolation<Order>> violations = validator.validate( new Order( Money.of( 1200.0, "EUR" ) ) );
 

--- a/integration/src/test/resources/arquillian.xml
+++ b/integration/src/test/resources/arquillian.xml
@@ -22,9 +22,9 @@
             <property name="executionType">REMOTE</property>
         </protocol>
         <configuration>
-            <property name="jbossHome">${basedir}/target/wildfly-${version.wildfly}</property>
+            <property name="jbossHome">${wildfly.target-dir}</property>
             <property name="javaVmArguments">
-                -Dee8.preview.mode=true ${arquillian.wildfly.jvm.args}
+                ${arquillian.wildfly.jvm.args}
             </property>
             <!--
             To be injected in javaVmArguments to enable debug mode:
@@ -32,7 +32,7 @@
             -->
         </configuration>
     </container>
-
+    <!--
     <container qualifier="wildfly-secondary">
         <protocol type="jmx-wildfly">
             <property name="executionType">REMOTE</property>
@@ -40,13 +40,10 @@
         <configuration>
             <property name="jbossHome">${basedir}/target/wildfly-${version.wildfly.secondary}</property>
             <property name="javaVmArguments">
-                -Dee8.preview.mode=true ${arquillian.wildfly.jvm.args}
+                ${arquillian.wildfly.jvm.args}
             </property>
-            <!--
-            To be injected in javaVmArguments to enable debug mode:
-            -Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=y -Xmx512m -XX:MaxPermSize=128m
-            -->
         </configuration>
     </container>
+    -->
 
 </arquillian>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -25,14 +25,16 @@
         <module.xml.targetdir>${project.build.directory}/modules</module.xml.targetdir>
 
         <!-- WildFly current -->
-        <wildfly-main.original.target-dir>${project.build.directory}/wildfly-original/wildfly-${version.wildfly}</wildfly-main.original.target-dir>
-        <wildfly-main.patched.target-dir>${project.build.directory}/wildfly-patched/wildfly-${version.wildfly}</wildfly-main.patched.target-dir>
-        <wildfly-main.patch-file>${project.build.directory}/wildfly-current-hv-patch.zip</wildfly-main.patch-file>
+        <wildfly-main.original.target-dir>${project.build.directory}/wildfly-original/wildfly-preview-${version.wildfly}</wildfly-main.original.target-dir>
+        <wildfly-main.patched.target-dir>${project.build.directory}/wildfly-patched/wildfly-preview-${version.wildfly}</wildfly-main.patched.target-dir>
+        <wildfly-main.patch-file>${project.build.directory}/wildfly-preview-current-hv-patch.zip</wildfly-main.patch-file>
 
         <!-- WildFly secondary version -->
+        <!--
         <wildfly-secondary.original.target-dir>${project.build.directory}/wildfly-original/wildfly-${version.wildfly.secondary}</wildfly-secondary.original.target-dir>
         <wildfly-secondary.patched.target-dir>${project.build.directory}/wildfly-patched/wildfly-${version.wildfly.secondary}</wildfly-secondary.patched.target-dir>
         <wildfly-secondary.patch-file>${project.build.directory}/wildfly-secondary-hv-patch.zip</wildfly-secondary.patch-file>
+        -->
 
         <hibernate-validator-parent.path>..</hibernate-validator-parent.path>
     </properties>
@@ -100,14 +102,16 @@
                                 <artifact>
                                     <file>${wildfly-main.patch-file}</file>
                                     <type>zip</type>
-                                    <classifier>wildfly-${version.wildfly}-patch</classifier>
+                                    <classifier>wildfly-preview-${version.wildfly}-patch</classifier>
                                 </artifact>
                                 <!-- WildFly secondary version -->
+                                <!--
                                 <artifact>
                                     <file>${wildfly-secondary.patch-file}</file>
                                     <type>zip</type>
                                     <classifier>wildfly-${version.wildfly.secondary}-patch</classifier>
                                 </artifact>
+                                -->
                             </artifacts>
                         </configuration>
                     </execution>
@@ -135,6 +139,7 @@
                         </configuration>
                     </execution>
                     <!-- WildFly secondary version -->
+                    <!--
                     <execution>
                         <id>update-wildfly-secondary-modules</id>
                         <phase>prepare-package</phase>
@@ -150,6 +155,7 @@
                             </properties>
                         </configuration>
                     </execution>
+                    -->
                 </executions>
             </plugin>
             <plugin>
@@ -167,7 +173,7 @@
                                 <!-- WildFly current -->
                                 <artifactItem>
                                     <groupId>org.wildfly</groupId>
-                                    <artifactId>wildfly-dist</artifactId>
+                                    <artifactId>wildfly-preview-dist</artifactId>
                                     <version>${version.wildfly}</version>
                                     <type>tar.gz</type>
                                     <overWrite>false</overWrite>
@@ -175,13 +181,14 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.wildfly</groupId>
-                                    <artifactId>wildfly-dist</artifactId>
+                                    <artifactId>wildfly-preview-dist</artifactId>
                                     <version>${version.wildfly}</version>
                                     <type>tar.gz</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/wildfly-patched</outputDirectory>
                                 </artifactItem>
                                 <!-- WildFly secondary version -->
+                                <!--
                                 <artifactItem>
                                     <groupId>org.wildfly</groupId>
                                     <artifactId>wildfly-dist</artifactId>
@@ -198,6 +205,7 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/wildfly-patched</outputDirectory>
                                 </artifactItem>
+                                -->
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -216,7 +224,7 @@
                                     <artifactId>jakarta.validation-api</artifactId>
                                     <version>${version.jakarta.validation-api}</version>
                                     <overWrite>false</overWrite>
-                                    <outputDirectory>${wildfly-main.patched.target-dir}/modules/system/layers/base/javax/validation/api/main</outputDirectory>
+                                    <outputDirectory>${wildfly-main.patched.target-dir}/modules/system/layers/base/jakarta/validation/api/main</outputDirectory>
                                     <!-- Specifying name to avoid timestamp in version on CI -->
                                     <destFileName>jakarta.validation-api-${version.jakarta.validation-api}.jar</destFileName>
                                 </artifactItem>
@@ -237,13 +245,13 @@
                                     <destFileName>hibernate-validator-cdi-${project.version}.jar</destFileName>
                                 </artifactItem>
                                 <!-- WildFly secondary version -->
+                                <!--
                                 <artifactItem>
                                     <groupId>jakarta.validation</groupId>
                                     <artifactId>jakarta.validation-api</artifactId>
                                     <version>${version.jakarta.validation-api}</version>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${wildfly-secondary.patched.target-dir}/modules/system/layers/base/javax/validation/api/main</outputDirectory>
-                                    <!-- Specifying name to avoid timestamp in version on CI -->
                                     <destFileName>jakarta.validation-api-${version.jakarta.validation-api}.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
@@ -262,6 +270,7 @@
                                     <outputDirectory>${wildfly-secondary.patched.target-dir}/modules/system/layers/base/org/hibernate/validator/cdi/main</outputDirectory>
                                     <destFileName>hibernate-validator-cdi-${project.version}.jar</destFileName>
                                 </artifactItem>
+                                -->
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -271,6 +280,13 @@
             <plugin>
                 <groupId>org.jboss.as</groupId>
                 <artifactId>patch-gen-maven-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jboss.modules</groupId>
+                        <artifactId>jboss-modules</artifactId>
+                        <version>1.9.0.Final</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>create-wildfly-current-patch-file</id>
@@ -285,6 +301,7 @@
                             <outputFile>${wildfly-main.patch-file}</outputFile>
                         </configuration>
                     </execution>
+                    <!--
                     <execution>
                         <id>create-wildfly-secondary-patch-file</id>
                         <phase>prepare-package</phase>
@@ -298,6 +315,7 @@
                             <outputFile>${wildfly-secondary.patch-file}</outputFile>
                         </configuration>
                     </execution>
+                    -->
                 </executions>
             </plugin>
         </plugins>

--- a/modules/src/main/modules/wildfly-current-patch.xml
+++ b/modules/src/main/modules/wildfly-current-patch.xml
@@ -13,7 +13,7 @@
         <description>This patch upgrades Hibernate Validator to ${project.version} within a WildFly ${version.wildfly} installation</description>
         <specified-content>
             <modules>
-                <updated name="javax.validation.api" />
+                <updated name="jakarta.validation.api" />
                 <updated name="org.hibernate.validator" />
                 <updated name="org.hibernate.validator.cdi" />
             </modules>

--- a/modules/src/main/modules/wildfly-secondary-patch.xml
+++ b/modules/src/main/modules/wildfly-secondary-patch.xml
@@ -13,7 +13,7 @@
         <description>This patch upgrades Hibernate Validator to ${project.version} within a WildFly ${version.wildfly.secondary} installation</description>
         <specified-content>
             <modules>
-                <updated name="javax.validation.api" />
+                <updated name="jakarta.validation.api" />
                 <updated name="org.hibernate.validator" />
                 <updated name="org.hibernate.validator.cdi" />
             </modules>

--- a/modules/src/script/setupModules.groovy
+++ b/modules/src/script/setupModules.groovy
@@ -22,14 +22,14 @@ def removeDependency(File file, String dependencyToRemove) {
 }
 
 // Jakarta Bean Validation API
-bvModuleXml = new File( wildflyPatchedTargetDir, 'modules/system/layers/base/javax/validation/api/main/module.xml' )
+bvModuleXml = new File( wildflyPatchedTargetDir, 'modules/system/layers/base/jakarta/validation/api/main/module.xml' )
 def bvArtifactName = 'jakarta.validation-api-' + project.properties['version.jakarta.validation-api'] + '.jar';
 println "[INFO] Using Jakarta Bean Validation version " + bvArtifactName;
 processFileInplace( bvModuleXml ) { text ->
     text.replaceAll( /<resource-root path=".*validation-api.*jar/, '<resource-root path="' + bvArtifactName )
 }
 
-deleteFiles( new FileNameFinder().getFileNames( wildflyPatchedTargetDir + '/modules/system/layers/base/javax/validation/api/main', '*.jar' ) )
+deleteFiles( new FileNameFinder().getFileNames( wildflyPatchedTargetDir + '/modules/system/layers/base/jakarta/validation/api/main', '*.jar' ) )
 
 // HV
 hvModuleXml = new File( wildflyPatchedTargetDir, 'modules/system/layers/base/org/hibernate/validator/main/module.xml' )

--- a/pom.xml
+++ b/pom.xml
@@ -123,9 +123,9 @@
         <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
 
         <!-- Currently supported version of WildFly -->
-        <version.wildfly>19.0.0.Final</version.wildfly>
+        <version.wildfly>22.0.0.Final</version.wildfly>
         <!-- Used to create a patch file for the second version of WildFly we support -->
-        <version.wildfly.secondary>18.0.1.Final</version.wildfly.secondary>
+        <!--<version.wildfly.secondary>18.0.1.Final</version.wildfly.secondary>-->
         <!-- Version used to run the TCK in incontainer mode -->
         <version.wildfly.tck>${version.wildfly}</version.wildfly.tck>
 
@@ -237,8 +237,8 @@
         <version.surefire.plugin>2.21.0</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.wildfly.plugin>1.2.1.Final</version.wildfly.plugin>
-        <version.org.wildfly.core>5.0.0.Final</version.org.wildfly.core>
-        <version.wildfly-patch-gen.plugin>2.0.1.Final</version.wildfly-patch-gen.plugin>
+        <version.org.wildfly.core>14.0.0.Final</version.org.wildfly.core>
+        <version.wildfly-patch-gen.plugin>2.1.0.Final</version.wildfly-patch-gen.plugin>
         <version.wildfly-patch-gen.plugin.woodstox>5.0.3</version.wildfly-patch-gen.plugin.woodstox>
 
         <!-- Forbidden API related properties -->
@@ -337,9 +337,10 @@
                 <groupId>${project.groupId}</groupId>
                 <artifactId>hibernate-validator-modules</artifactId>
                 <version>${project.version}</version>
-                <classifier>wildfly-${version.wildfly}-patch</classifier>
+                <classifier>wildfly-preview-${version.wildfly}-patch</classifier>
                 <type>zip</type>
             </dependency>
+            <!--
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>hibernate-validator-modules</artifactId>
@@ -347,6 +348,7 @@
                 <classifier>wildfly-${version.wildfly.secondary}-patch</classifier>
                 <type>zip</type>
             </dependency>
+            -->
             <dependency>
                 <groupId>jakarta.validation</groupId>
                 <artifactId>jakarta.validation-api</artifactId>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <tck.suite.file>${project.build.directory}/dependency/beanvalidation-tck-tests-suite.xml</tck.suite.file>
-        <wildfly.target-dir>${project.build.directory}/wildfly-${version.wildfly.tck}</wildfly.target-dir>
+        <wildfly.target-dir>${project.build.directory}/wildfly-preview-${version.wildfly.tck}</wildfly.target-dir>
         <validation.provider>org.hibernate.validator.HibernateValidator</validation.provider>
         <remote.debug />
 
@@ -255,7 +255,7 @@
                     <groupId>${project.groupId}</groupId>
                     <artifactId>hibernate-validator-modules</artifactId>
                     <version>${project.version}</version>
-                    <classifier>wildfly-${version.wildfly.tck}-patch</classifier>
+                    <classifier>wildfly-preview-${version.wildfly.tck}-patch</classifier>
                     <type>zip</type>
                 </dependency>
             </dependencies>
@@ -274,7 +274,7 @@
                                     <artifactItems>
                                         <artifactItem>
                                             <groupId>org.wildfly</groupId>
-                                            <artifactId>wildfly-dist</artifactId>
+                                            <artifactId>wildfly-preview-dist</artifactId>
                                             <version>${version.wildfly.tck}</version>
                                             <type>tar.gz</type>
                                             <overWrite>false</overWrite>
@@ -295,7 +295,7 @@
                                             <groupId>${project.groupId}</groupId>
                                             <artifactId>hibernate-validator-modules</artifactId>
                                             <version>${project.version}</version>
-                                            <classifier>wildfly-${version.wildfly.tck}-patch</classifier>
+                                            <classifier>wildfly-preview-${version.wildfly.tck}-patch</classifier>
                                             <type>zip</type>
                                             <outputDirectory>${project.build.directory}</outputDirectory>
                                         </artifactItem>
@@ -318,7 +318,7 @@
                                     <offline>true</offline>
                                     <fail-on-error>false</fail-on-error>
                                     <commands>
-                                        <command>patch apply ${project.build.directory}/hibernate-validator-modules-${project.version}-wildfly-${version.wildfly.tck}-patch.zip</command>
+                                        <command>patch apply ${project.build.directory}/hibernate-validator-modules-${project.version}-wildfly-preview-${version.wildfly.tck}-patch.zip</command>
                                     </commands>
                                 </configuration>
                             </execution>

--- a/tck-runner/src/script/updateStandaloneXml.groovy
+++ b/tck-runner/src/script/updateStandaloneXml.groovy
@@ -18,7 +18,7 @@ standaloneXml = new File( getPropertyValue('wildfly.target-dir'), 'standalone/co
 println "[INFO] Add javafx.api as global module"
 
 processFileInplace( standaloneXml ) { text ->
-    text.replaceAll( /<subsystem xmlns="urn:jboss:domain:ee:4\.0">/, '<subsystem xmlns="urn:jboss:domain:ee:4.0">\n            <global-modules>\n                <module name="javafx.api" slot="main" />\n            </global-modules>' )
+    text.replaceAll( /<subsystem xmlns="urn:jboss:domain:ee:5\.0">/, '<subsystem xmlns="urn:jboss:domain:ee:5.0">\n            <global-modules>\n                <module name="javafx.api" slot="main" />\n            </global-modules>' )
 }
 
 println "[INFO] ------------------------------------------------------------------------";

--- a/tck-runner/src/test/modules/jdk11/javafx/api/main/module.xml
+++ b/tck-runner/src/test/modules/jdk11/javafx/api/main/module.xml
@@ -5,7 +5,7 @@
   ~ License: Apache License, Version 2.0
   ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
   -->
-<module xmlns="urn:jboss:module:1.3" name="javafx.api">
+<module xmlns="urn:jboss:module:1.9" name="javafx.api">
     <resources>
         <!-- we only include base as that's what we need -->
         <resource-root path="javafx-base-${version.org.openjfx}.jar" />


### PR DESCRIPTION
Also reintroduce WildFly integration tests.

To run the TCK with WildFly, run the build with `-Dincontainer`.

https://hibernate.atlassian.net/browse/HV-1826