### PR TITLE
Backport HV-1835 + HV-1836 to branch 6.2 - Test Hibernate Validator against JDK17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,6 +142,8 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '15', buildJdkTool: 'OpenJDK 15 Latest',
 							condition: TestCondition.ON_DEMAND),
 					new JdkBuildEnvironment(version: '16', buildJdkTool: 'OpenJDK 16 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '17', buildJdkTool: 'OpenJDK 17 Latest',
 							condition: TestCondition.AFTER_MERGE)
 			],
 			wildflyTck: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,9 +138,8 @@ stage('Configure') {
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '14', buildJdkTool: 'OpenJDK 14 Latest',
 							condition: TestCondition.AFTER_MERGE),
-					// Disabled because of https://bugs.openjdk.java.net/browse/JDK-8253566
 					new JdkBuildEnvironment(version: '15', buildJdkTool: 'OpenJDK 15 Latest',
-							condition: TestCondition.ON_DEMAND),
+							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '16', buildJdkTool: 'OpenJDK 16 Latest',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '17', buildJdkTool: 'OpenJDK 17 Latest',

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <version.org.jboss.arquillian.container.arquillian-weld-se-embedded-1.1>1.0.0.Final</version.org.jboss.arquillian.container.arquillian-weld-se-embedded-1.1>
         <version.com.fasterxml.jackson.core.jackson-databind>2.10.3</version.com.fasterxml.jackson.core.jackson-databind>
         <version.com.fasterxml.jackson.core.jackson-annotations>2.10.3</version.com.fasterxml.jackson.core.jackson-annotations>
-        <version.net.bytebuddy.byte-buddy>1.10.16</version.net.bytebuddy.byte-buddy>
+        <version.net.bytebuddy.byte-buddy>1.10.22</version.net.bytebuddy.byte-buddy>
 
         <!-- OSGi dependencies -->
         <version.org.apache.karaf>4.2.0</version.org.apache.karaf>


### PR DESCRIPTION
* [HV-1836](https://hibernate.atlassian.net/browse/HV-1836): Restore CI for JDK 15
* [HV-1835](https://hibernate.atlassian.net/browse/HV-1835): Test Hibernate Validator against JDK17

Backport of #1160

