### PR TITLE
Backport HV-1838 to branch 6.1 - Skip forbiddenapis on JDK17+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1346,6 +1346,16 @@
             </build>
         </profile>
         <profile>
+            <id>jdk17+</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <properties>
+                <!-- ForbiddenAPIs doesn't work with JDK17: https://github.com/policeman-tools/forbidden-apis/issues/177 -->
+                <forbiddenapis.skip>true</forbiddenapis.skip>
+            </properties>
+        </profile>
+        <profile>
             <id>jqassistant</id>
             <!--
             To run the analysis on the engine module and launch a Neo4j server accessible at http://localhost:7474/, run:


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1838

Backport of #1166

Here's a build that passed on JDK17 thanks to this change: https://ci.hibernate.org/job/hibernate-validator-personal-yoann/job/HV-1838-6.1/