### PR TITLE
HV-1840 Drop/replace deprecated CDI API usages

### DIFF
--- a/cdi/src/main/java/org/hibernate/validator/cdi/internal/DestructibleBeanInstance.java
+++ b/cdi/src/main/java/org/hibernate/validator/cdi/internal/DestructibleBeanInstance.java
@@ -41,7 +41,7 @@ public class DestructibleBeanInstance<T> {
 
 	private InjectionTarget<T> createInjectionTarget(BeanManager beanManager, Class<T> type) {
 		AnnotatedType<T> annotatedType = beanManager.createAnnotatedType( type );
-		return beanManager.createInjectionTarget( annotatedType );
+		return beanManager.getInjectionTargetFactory( annotatedType ).createInjectionTarget( null );
 	}
 
 	private static <T> T createAndInjectBeans(BeanManager beanManager, InjectionTarget<T> injectionTarget) {

--- a/cdi/src/main/java/org/hibernate/validator/cdi/internal/ValidatorBean.java
+++ b/cdi/src/main/java/org/hibernate/validator/cdi/internal/ValidatorBean.java
@@ -88,7 +88,7 @@ public class ValidatorBean implements Bean<Validator>, PassivationCapable {
 		return false;
 	}
 
-	@Override
+	// TODO to be removed once using CDI API 4.x
 	public boolean isNullable() {
 		return false;
 	}

--- a/cdi/src/main/java/org/hibernate/validator/cdi/internal/ValidatorFactoryBean.java
+++ b/cdi/src/main/java/org/hibernate/validator/cdi/internal/ValidatorFactoryBean.java
@@ -116,7 +116,7 @@ public class ValidatorFactoryBean implements Bean<ValidatorFactory>, Passivation
 		return false;
 	}
 
-	@Override
+	// TODO to be removed once using CDI API 4.x
 	public boolean isNullable() {
 		return false;
 	}

--- a/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/InjectingConstraintValidatorFactoryTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/InjectingConstraintValidatorFactoryTest.java
@@ -16,6 +16,7 @@ import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.AnnotatedType;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.InjectionTarget;
+import jakarta.enterprise.inject.spi.InjectionTargetFactory;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import jakarta.validation.constraints.Min;
@@ -32,6 +33,7 @@ public class InjectingConstraintValidatorFactoryTest {
 	private BeanManager beanManagerMock;
 	private AnnotatedType<MyValidator> annotatedTypeMock;
 	private InjectionTarget<MyValidator> injectionTargetMock;
+	private InjectionTargetFactory<MyValidator> injectionTargetFactoryMock;
 	private CreationalContext<MyValidator> creationalContextMock;
 
 	@BeforeClass
@@ -41,6 +43,7 @@ public class InjectingConstraintValidatorFactoryTest {
 		constraintValidatorFactory = new InjectingConstraintValidatorFactory( beanManagerMock );
 		annotatedTypeMock = createMock( AnnotatedType.class );
 		injectionTargetMock = createMock( InjectionTarget.class );
+		injectionTargetFactoryMock = createMock( InjectionTargetFactory.class );
 		creationalContextMock = createMock( CreationalContext.class );
 	}
 
@@ -60,7 +63,8 @@ public class InjectingConstraintValidatorFactoryTest {
 		// setup the mocks
 
 		expect( beanManagerMock.createAnnotatedType( MyValidator.class ) ).andReturn( annotatedTypeMock );
-		expect( beanManagerMock.createInjectionTarget( annotatedTypeMock ) ).andReturn( injectionTargetMock );
+		expect( beanManagerMock.getInjectionTargetFactory( annotatedTypeMock ) ).andReturn( injectionTargetFactoryMock );
+		expect( injectionTargetFactoryMock.createInjectionTarget( null ) ).andReturn( injectionTargetMock );
 		expect( (CreationalContext) beanManagerMock.createCreationalContext( null ) ).andReturn(
 				creationalContextMock
 		);
@@ -74,7 +78,7 @@ public class InjectingConstraintValidatorFactoryTest {
 		injectionTargetMock.dispose( validator );
 
 		// get the mocks into replay mode
-		replay( beanManagerMock, annotatedTypeMock, injectionTargetMock );
+		replay( beanManagerMock, annotatedTypeMock, injectionTargetFactoryMock, injectionTargetMock );
 
 		// run the tests
 		MyValidator validatorInstance = constraintValidatorFactory.getInstance( MyValidator.class );

--- a/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/beanmetadataclassnormalizer/CustomProxyBeanMetaDataClassNormalizer.java
+++ b/cdi/src/test/java/org/hibernate/validator/test/cdi/internal/beanmetadataclassnormalizer/CustomProxyBeanMetaDataClassNormalizer.java
@@ -41,7 +41,7 @@ public class CustomProxyBeanMetaDataClassNormalizer
 		return Collections.emptySet();
 	}
 
-	@Override
+	// TODO to be removed once using CDI API 4.x
 	public boolean isNullable() {
 		return false;
 	}


### PR DESCRIPTION
I was testing WFLY with latest CDI API (4.0.0.Alpha1) where there was a number of removals of long deprecated methods.
See eclipse-ee4j/cdi#472

This causes hibernate validator to crash during TCK runs so I had to create a custom artifact and replace it within WFLY - this PR a sum of changes I needed to make it work.

Since you are bound to eventually bounce into the very same issue, I thought I might as well contribute. But whether you accept it or not is OFC completely up to you :-)

Oh and I should note - the current state of this PR will work with CDI 2/3 as well as CDI 4 so there should be no harm in having it applied right away.