### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
   - mvn -N io.takari:maven:wrapper
   - ./mvnw -v
   # first run to download all the Maven dependencies without logging
-  - travis_wait ./mvnw $BUILD_OPTIONS -U -B -q -Dcheckstyle.skip -DskipTests=true install
+  - ./mvnw $BUILD_OPTIONS -U -B -q -Dcheckstyle.skip -DskipTests=true install
 before_script:
 script:
   - ./mvnw $BUILD_OPTIONS -DskipDistro=true checkstyle:check


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
