### PR TITLE
HV-1854 Improve PESEL validator conditions

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/pl/PESELValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/pl/PESELValidator.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.constraintvalidators.hv.pl;
 
+import java.time.DateTimeException;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 
@@ -36,12 +38,28 @@ public class PESELValidator extends ModCheckBase implements ConstraintValidator<
 
 	@Override
 	public boolean isCheckDigitValid(List<Integer> digits, char checkDigit) {
-		Collections.reverse( digits );
-
 		// if the length of the number is incorrect we can return fast
-		if ( digits.size() != WEIGHTS_PESEL.length  ) {
+		if ( digits.size() != WEIGHTS_PESEL.length ) {
 			return false;
 		}
+
+		int monthCode = doubleDigitNumberFromSubList( digits, 2 );
+		try {
+			// PESEL format is YYMMDD*****, where MM is coded month (depending on the century
+			// 0/20/40/60/80 can be added to the month value) see javadoc on `year()`.
+			// Need to make sure that these first 6 digits represent a valid date
+			LocalDate.of(
+					year( doubleDigitNumberFromSubList( digits, 0 ), monthCode / 20 ),
+					monthCode % 20,
+					doubleDigitNumberFromSubList( digits, 4 )
+			);
+		}
+		catch (DateTimeException e) {
+			return false;
+		}
+
+		// now that we are done with custom logic we can proceeed with regular mod check of the checkdigit:
+		Collections.reverse( digits );
 
 		int modResult = ModUtil.calculateModXCheckWithWeights( digits, 10, Integer.MAX_VALUE, WEIGHTS_PESEL );
 		switch ( modResult ) {
@@ -51,4 +69,29 @@ public class PESELValidator extends ModCheckBase implements ConstraintValidator<
 				return Character.isDigit( checkDigit ) && modResult == extractDigit( checkDigit );
 		}
 	}
+
+	private int doubleDigitNumberFromSubList(List<Integer> digits, int start) {
+		// index access is ok here as we use ArrayLists.
+		return digits.get( start ) * 10 + digits.get( start + 1 );
+	}
+
+	/**
+	 * 1800–1899 - 80
+	 * 1900–1999 - 00
+	 * 2000–2099 - 20
+	 * 2100–2199 - 40
+	 * 2200–2299 - 60
+	 */
+	private int year(int year, int centuryCode) {
+		switch ( centuryCode ) {
+			case 4: return 1800 + year;
+			case 0: return 1900 + year;
+			case 1: return 2000 + year;
+			case 2: return 2100 + year;
+			case 3: return 2200 + year;
+			default:
+				throw new IllegalStateException( "Invalid century code." );
+		}
+	}
+
 }

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/PESELValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/pl/PESELValidatorTest.java
@@ -12,6 +12,7 @@ import static org.hibernate.validator.testutil.ConstraintViolationAssert.violati
 
 import org.hibernate.validator.constraints.pl.PESEL;
 import org.hibernate.validator.test.constraints.annotations.AbstractConstrainedTest;
+import org.hibernate.validator.testutil.TestForIssue;
 
 import org.testng.annotations.Test;
 
@@ -58,7 +59,6 @@ public class PESELValidatorTest extends AbstractConstrainedTest {
 		assertNoViolations( validator.validate( new Person( "12241301417" ) ) );
 		assertNoViolations( validator.validate( new Person( "12252918020" ) ) );
 		assertNoViolations( validator.validate( new Person( "12262911406" ) ) );
-
 	}
 
 	@Test
@@ -96,6 +96,31 @@ public class PESELValidatorTest extends AbstractConstrainedTest {
 						violationOf( PESEL.class ).withProperty( "pesel" )
 				);
 		assertThat( validator.validate( new Person( "12262911402" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+	}
+
+	@Test
+	@TestForIssue( jiraKey = "HV-1854")
+	public void testMeaningfulPESELNumber() {
+		assertThat( validator.validate( new Person( "00000000000" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+		assertThat( validator.validate( new Person( "00130000006" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+		assertThat( validator.validate( new Person( "00013300009" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+		assertThat( validator.validate( new Person( "21022900008" ) ) )
+				.containsOnlyViolations(
+						violationOf( PESEL.class ).withProperty( "pesel" )
+				);
+		assertThat( validator.validate( new Person( "21034000004" ) ) )
 				.containsOnlyViolations(
 						violationOf( PESEL.class ).withProperty( "pesel" )
 				);


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1854

With PESEL structure being YYMMDDZZZXQ only MM and DD parts make sense to have some additional checks applied. Year can be 00-99, ZZZ just "random digits", X - sex part is even/odd but ultimately 0-9 as well. 
Check digits in the new testcases would've allowed these numbers to be considered as valid without this additional date/month logic.

I'm actually glad that someone is using these specific validators and reported a problem with that more simple approach. 
But not as glad as being able to finally do some work here 😉 


