### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -650,6 +650,10 @@
                             <compilerArg>-Aorg.jboss.logging.tools.addGeneratedAnnotation=false</compilerArg>
                         </compilerArgs>
                         <testCompilerArgument>-parameters</testCompilerArgument>
+                            	<fork>true</fork>
+                            	<useIncrementalCompilation>true</useIncrementalCompilation>
+
+
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1287,6 +1291,10 @@
                             <artifactId>maven-compiler-plugin</artifactId>
                             <configuration>
                                 <fork>true</fork>
+                            	<fork>true</fork>
+                            	<useIncrementalCompilation>true</useIncrementalCompilation>
+
+
                             </configuration>
                         </plugin>
                         <plugin>
@@ -1447,6 +1455,10 @@
                                          IDEA ignores the "testCompilerArguments" option... -->
                                     <compilerArg>-parameters</compilerArg>
                                 </compilerArgs>
+                            	<fork>true</fork>
+                            	<useIncrementalCompilation>true</useIncrementalCompilation>
+
+
                             </configuration>
                         </plugin>
                     </plugins>


### PR DESCRIPTION

Maven allows you to run the compiler as a separate process by setting `<fork>true</fork>`. This feature can lead to much less garbage collection and make Maven build faster. This project has more than 1000 source files. We can consider enabling this feature.

Maven can recompile only the classes that were affected by a change. This feature is the default. We can activate it by setting `<useIncrementalCompilation>true</useIncrementalCompilation>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
