### PR TITLE
HV-1862 Update Log4j 2 test dependency to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <version.com.fasterxml.classmate>1.5.1</version.com.fasterxml.classmate>
         <version.joda-time>2.9.7</version.joda-time>
         <version.org.slf4j>1.7.22</version.org.slf4j>
-        <version.org.apache.logging.log4j>2.15.0</version.org.apache.logging.log4j>
+        <version.org.apache.logging.log4j>2.16.0</version.org.apache.logging.log4j>
 
         <!--
             These dependencies are used for integration tests with WildFly.


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1862