### PR TITLE
HV-1872 + HV-1873 Test Hibernate Validator against OpenJDK 19

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,6 +136,8 @@ stage('Configure') {
 					new JdkBuildEnvironment(version: '17', buildJdkTool: 'OpenJDK 17 Latest',
 							condition: TestCondition.AFTER_MERGE),
 					new JdkBuildEnvironment(version: '18', buildJdkTool: 'OpenJDK 18 Latest',
+							condition: TestCondition.AFTER_MERGE),
+					new JdkBuildEnvironment(version: '19', buildJdkTool: 'OpenJDK 19 Latest',
 							condition: TestCondition.AFTER_MERGE)
 			],
 			wildflyTck: [

--- a/cdi/src/main/java/org/hibernate/validator/cdi/internal/InheritedMethodsHelper.java
+++ b/cdi/src/main/java/org/hibernate/validator/cdi/internal/InheritedMethodsHelper.java
@@ -14,6 +14,7 @@ import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.List;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
 import org.hibernate.validator.internal.util.privilegedactions.GetMethods;
@@ -59,6 +60,7 @@ public class InheritedMethodsHelper {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/cdi/src/main/java/org/hibernate/validator/cdi/internal/ValidatorFactoryBean.java
+++ b/cdi/src/main/java/org/hibernate/validator/cdi/internal/ValidatorFactoryBean.java
@@ -41,6 +41,7 @@ import jakarta.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.cdi.spi.BeanNames;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.engine.valueextraction.ValueExtractorDescriptor;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.classhierarchy.ClassHierarchyHelper;
@@ -324,6 +325,7 @@ public class ValidatorFactoryBean implements Bean<ValidatorFactory>, Passivation
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConfiguredConstraint.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/ConfiguredConstraint.java
@@ -18,6 +18,7 @@ import jakarta.validation.ValidationException;
 
 import org.hibernate.validator.cfg.AnnotationDef;
 import org.hibernate.validator.cfg.ConstraintDef;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.metadata.location.ConstraintLocation;
 import org.hibernate.validator.internal.properties.Callable;
 import org.hibernate.validator.internal.properties.javabean.JavaBeanField;
@@ -113,6 +114,7 @@ class ConfiguredConstraint<A extends Annotation> {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <V> V run(PrivilegedAction<V> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/cfg/context/TypeConstraintMappingContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/cfg/context/TypeConstraintMappingContextImpl.java
@@ -23,6 +23,7 @@ import org.hibernate.validator.cfg.context.ConstructorConstraintMappingContext;
 import org.hibernate.validator.cfg.context.MethodConstraintMappingContext;
 import org.hibernate.validator.cfg.context.PropertyConstraintMappingContext;
 import org.hibernate.validator.cfg.context.TypeConstraintMappingContext;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.engine.ConstraintCreationContext;
 import org.hibernate.validator.internal.metadata.descriptor.ConstraintDescriptorImpl.ConstraintType;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
@@ -287,6 +288,7 @@ public final class TypeConstraintMappingContextImpl<C> extends ConstraintMapping
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/AbstractConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/AbstractConfigurationImpl.java
@@ -39,6 +39,7 @@ import jakarta.validation.valueextraction.ValueExtractor;
 
 import org.hibernate.validator.BaseHibernateValidatorConfiguration;
 import org.hibernate.validator.cfg.ConstraintMapping;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorFactoryImpl;
 import org.hibernate.validator.internal.engine.resolver.TraversableResolvers;
@@ -850,6 +851,7 @@ public abstract class AbstractConfigurationImpl<T extends BaseHibernateValidator
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ServiceLoaderBasedConstraintMappingContributor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ServiceLoaderBasedConstraintMappingContributor.java
@@ -20,6 +20,7 @@ import jakarta.validation.ConstraintValidator;
 
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.cfg.context.ConstraintDefinitionContext;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.TypeResolutionHelper;
 import org.hibernate.validator.internal.util.privilegedactions.GetInstancesFromServiceLoader;
 import org.hibernate.validator.spi.cfg.ConstraintMappingContributor;
@@ -104,6 +105,7 @@ public class ServiceLoaderBasedConstraintMappingContributor implements Constrain
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryConfigurationHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryConfigurationHelper.java
@@ -23,6 +23,7 @@ import jakarta.validation.spi.ConfigurationState;
 
 import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.cfg.ConstraintMapping;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
 import org.hibernate.validator.internal.engine.constraintdefinition.ConstraintDefinitionContribution;
 import org.hibernate.validator.internal.engine.messageinterpolation.DefaultLocaleResolver;
@@ -430,6 +431,7 @@ final class ValidatorFactoryConfigurationHelper {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorFactoryImpl.java
@@ -12,6 +12,7 @@ import java.security.PrivilegedAction;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorFactory;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.privilegedactions.NewInstance;
 
 /**
@@ -39,6 +40,7 @@ public class ConstraintValidatorFactoryImpl implements ConstraintValidatorFactor
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/resolver/TraversableResolvers.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/resolver/TraversableResolvers.java
@@ -14,6 +14,7 @@ import java.security.PrivilegedAction;
 import jakarta.validation.TraversableResolver;
 import jakarta.validation.ValidationException;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -152,6 +153,7 @@ public class TraversableResolvers {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/scripting/DefaultScriptEvaluatorFactory.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/scripting/DefaultScriptEvaluatorFactory.java
@@ -13,6 +13,7 @@ import java.security.PrivilegedAction;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetClassLoader;
@@ -97,6 +98,7 @@ public class DefaultScriptEvaluatorFactory extends AbstractCachingScriptEvaluato
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ValueExtractorManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valueextraction/ValueExtractorManager.java
@@ -23,6 +23,7 @@ import jakarta.validation.ConstraintDeclarationException;
 import jakarta.validation.ValidationException;
 import jakarta.validation.valueextraction.ValueExtractor;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
 import org.hibernate.validator.internal.util.stereotypes.Immutable;
 
@@ -225,6 +226,7 @@ public class ValueExtractorManager {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
@@ -103,6 +103,7 @@ import org.hibernate.validator.constraints.pl.REGON;
 import org.hibernate.validator.constraints.ru.INN;
 import org.hibernate.validator.constraints.time.DurationMax;
 import org.hibernate.validator.constraints.time.DurationMin;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.constraintvalidators.bv.AssertFalseValidator;
 import org.hibernate.validator.internal.constraintvalidators.bv.AssertTrueValidator;
 import org.hibernate.validator.internal.constraintvalidators.bv.DigitsValidatorForCharSequence;
@@ -1160,6 +1161,7 @@ public class ConstraintHelper {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ConstraintDescriptorImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/descriptor/ConstraintDescriptorImpl.java
@@ -41,6 +41,7 @@ import jakarta.validation.valueextraction.Unwrapping;
 
 import org.hibernate.validator.constraints.CompositionType;
 import org.hibernate.validator.constraints.ConstraintComposition;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorDescriptor;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.core.ConstraintOrigin;
@@ -747,6 +748,7 @@ public class ConstraintDescriptorImpl<T extends Annotation> implements Constrain
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <P> P run(PrivilegedAction<P> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
@@ -39,6 +39,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.groups.ConvertGroup;
 
 import org.hibernate.validator.group.GroupSequenceProvider;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.engine.ConstraintCreationContext;
 import org.hibernate.validator.internal.engine.valueextraction.ArrayElement;
 import org.hibernate.validator.internal.metadata.aggregated.CascadingMetaDataBuilder;
@@ -596,6 +597,7 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanField.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanField.java
@@ -18,6 +18,7 @@ import java.security.PrivilegedAction;
 
 import org.hibernate.validator.HibernateValidatorPermission;
 import org.hibernate.validator.engine.HibernateValidatorEnhancedBean;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.properties.PropertyAccessor;
 import org.hibernate.validator.internal.util.ReflectionHelper;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredField;
@@ -169,6 +170,7 @@ public class JavaBeanField implements org.hibernate.validator.internal.propertie
 	/**
 	 * Returns an accessible copy of the given member.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static Field getAccessible(Field original) {
 		SecurityManager sm = System.getSecurityManager();
 		if ( sm != null ) {
@@ -186,6 +188,7 @@ public class JavaBeanField implements org.hibernate.validator.internal.propertie
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanGetter.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanGetter.java
@@ -14,6 +14,7 @@ import java.security.PrivilegedAction;
 
 import org.hibernate.validator.HibernateValidatorPermission;
 import org.hibernate.validator.engine.HibernateValidatorEnhancedBean;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement.ConstrainedElementKind;
 import org.hibernate.validator.internal.properties.Getter;
 import org.hibernate.validator.internal.properties.PropertyAccessor;
@@ -149,6 +150,7 @@ public class JavaBeanGetter extends JavaBeanMethod implements Getter {
 	/**
 	 * Returns an accessible copy of the given method.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static Method getAccessible(Method original) {
 		SecurityManager sm = System.getSecurityManager();
 		if ( sm != null ) {
@@ -167,6 +169,7 @@ public class JavaBeanGetter extends JavaBeanMethod implements Getter {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanHelper.java
@@ -16,6 +16,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Optional;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.properties.Constrainable;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.privilegedactions.GetDeclaredConstructor;
@@ -142,6 +143,7 @@ public class JavaBeanHelper {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/ExecutableHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/ExecutableHelper.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Modifier;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.properties.Callable;
 import org.hibernate.validator.internal.properties.Signature;
 import org.hibernate.validator.internal.util.classhierarchy.Filters;
@@ -283,6 +284,7 @@ public final class ExecutableHelper {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/annotation/AnnotationDescriptor.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/annotation/AnnotationDescriptor.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.StringHelper;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -327,6 +328,7 @@ public class AnnotationDescriptor<A extends Annotation> implements Serializable 
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <V> V run(PrivilegedAction<V> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/annotation/AnnotationFactory.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/annotation/AnnotationFactory.java
@@ -10,6 +10,7 @@ import java.lang.annotation.Annotation;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.privilegedactions.GetClassLoader;
 import org.hibernate.validator.internal.util.privilegedactions.NewProxyInstance;
 
@@ -40,6 +41,7 @@ public class AnnotationFactory {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/annotation/AnnotationProxy.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/annotation/AnnotationProxy.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.privilegedactions.GetAnnotationAttributes;
 
 /**
@@ -136,6 +137,7 @@ class AnnotationProxy implements Annotation, InvocationHandler, Serializable {
 						: Arrays.equals( (Object[]) o1, (Object[]) o2 );
 	}
 
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private Map<String, Object> getAnnotationAttributes(Annotation annotation) {
 		// We only enable this optimization if the security manager is not enabled. Otherwise,
 		// we would have to add every package containing constraints to the security policy.
@@ -155,6 +157,7 @@ class AnnotationProxy implements Annotation, InvocationHandler, Serializable {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/XmlParserHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/XmlParserHelper.java
@@ -27,6 +27,7 @@ import javax.xml.stream.events.XMLEvent;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -161,10 +162,12 @@ public class XmlParserHelper {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}
 
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedExceptionAction<T> action) throws Exception {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/config/ResourceLoaderHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/config/ResourceLoaderHelper.java
@@ -12,6 +12,7 @@ import java.lang.invoke.MethodHandles;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 import org.hibernate.validator.internal.util.privilegedactions.GetClassLoader;
@@ -85,6 +86,7 @@ final class ResourceLoaderHelper {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/config/ValidationBootstrapParameters.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/config/ValidationBootstrapParameters.java
@@ -25,6 +25,7 @@ import jakarta.validation.ValidationException;
 import jakarta.validation.spi.ValidationProvider;
 import jakarta.validation.valueextraction.ValueExtractor;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.engine.valueextraction.ValueExtractorDescriptor;
 import org.hibernate.validator.internal.engine.valueextraction.ValueExtractorDescriptor.Key;
 import org.hibernate.validator.internal.util.CollectionHelper;
@@ -306,6 +307,7 @@ public class ValidationBootstrapParameters {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/config/ValidationXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/config/ValidationXmlParser.java
@@ -21,6 +21,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.Validator;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -161,6 +162,7 @@ public class ValidationXmlParser {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/mapping/ClassLoadingHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/mapping/ClassLoadingHelper.java
@@ -13,6 +13,7 @@ import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Map;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.privilegedactions.LoadClass;
 
 /**
@@ -105,6 +106,7 @@ class ClassLoadingHelper {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/mapping/ConstraintTypeStaxBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/mapping/ConstraintTypeStaxBuilder.java
@@ -29,6 +29,7 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.engine.ConstraintCreationContext;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
 import org.hibernate.validator.internal.metadata.core.MetaConstraint;
@@ -463,6 +464,7 @@ class ConstraintTypeStaxBuilder extends AbstractStaxBuilder {
 		 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 		 * privileged actions within HV's protection domain.
 		 */
+		@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 		private static <T> T run(PrivilegedAction<T> action) {
 			return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/mapping/MappingXmlParser.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/mapping/MappingXmlParser.java
@@ -26,6 +26,7 @@ import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.Validator;
 
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.engine.ConstraintCreationContext;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptions;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptionsImpl;
@@ -179,6 +180,7 @@ public class MappingXmlParser {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/ResourceBundleMessageInterpolator.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 import java.util.Set;
 
 import org.hibernate.validator.Incubating;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.engine.messageinterpolation.DefaultLocaleResolver;
 import org.hibernate.validator.internal.engine.messageinterpolation.InterpolationTerm;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -240,6 +241,7 @@ public class ResourceBundleMessageInterpolator extends AbstractMessageInterpolat
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/engine/src/main/java/org/hibernate/validator/resourceloading/PlatformResourceBundleLocator.java
+++ b/engine/src/main/java/org/hibernate/validator/resourceloading/PlatformResourceBundleLocator.java
@@ -27,6 +27,7 @@ import java.util.ResourceBundle;
 import java.util.Set;
 
 import org.hibernate.validator.Incubating;
+import org.hibernate.validator.internal.IgnoreForbiddenApisErrors;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.Contracts;
 import org.hibernate.validator.internal.util.logging.Log;
@@ -252,6 +253,7 @@ public class PlatformResourceBundleLocator implements ResourceBundleLocator {
 	 * <b>NOTE:</b> This must never be changed into a publicly available method to avoid execution of arbitrary
 	 * privileged actions within HV's protection domain.
 	 */
+	@IgnoreForbiddenApisErrors(reason = "SecurityManager is deprecated in JDK17")
 	private static <T> T run(PrivilegedAction<T> action) {
 		return System.getSecurityManager() != null ? AccessController.doPrivileged( action ) : action.run();
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -281,8 +281,6 @@
         <maven.compiler.argument.testTarget>${maven.compiler.testTarget}</maven.compiler.argument.testTarget>
         <maven.compiler.argument.testSource>${maven.compiler.testSource}</maven.compiler.argument.testSource>
 
-        <forbiddenapis.jdk.target>10</forbiddenapis.jdk.target>
-
         <!-- Set empty default values to avoid Maven leaving property references (${...}) when it doesn't find a value -->
         <surefire.jvm.args.additional></surefire.jvm.args.additional>
         <surefire.jvm.args.illegal-access></surefire.jvm.args.illegal-access>
@@ -721,9 +719,9 @@
                     <artifactId>forbiddenapis</artifactId>
                     <version>${version.forbiddenapis.plugin}</version>
                     <configuration>
-                        <targetVersion>${forbiddenapis.jdk.target}</targetVersion>
                         <!-- if the Java version used is too new, don't fail, just do nothing -->
                         <failOnUnsupportedJava>false</failOnUnsupportedJava>
+                        <ignoreSignaturesOfMissingClasses>true</ignoreSignaturesOfMissingClasses>
                         <suppressAnnotations>
                             <annotation>**.IgnoreForbiddenApisErrors</annotation>
                         </suppressAnnotations>
@@ -753,11 +751,43 @@
                             <phase>verify</phase>
                             <configuration>
                                 <bundledSignatures>
-                                    <bundledSignature>jdk-unsafe</bundledSignature>
-                                    <bundledSignature>jdk-deprecated</bundledSignature>
+                                    <!-- These signatures on the top are not specific to any JDK version -->
                                     <bundledSignature>jdk-system-out</bundledSignature>
                                     <bundledSignature>jdk-non-portable</bundledSignature>
-                                    <bundledSignature>jdk-internal</bundledSignature>
+
+                                    <!-- All following signatures should be replicated for each target JDK version we intend to support -->
+                                    <bundledSignature>jdk-unsafe-1.8</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-9</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-10</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-11</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-12</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-13</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-14</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-15</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-16</bundledSignature>
+                                    <bundledSignature>jdk-unsafe-17</bundledSignature>
+
+                                    <bundledSignature>jdk-deprecated-1.8</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-9</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-10</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-11</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-12</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-13</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-14</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-15</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-16</bundledSignature>
+                                    <bundledSignature>jdk-deprecated-17</bundledSignature>
+
+                                    <bundledSignature>jdk-internal-1.8</bundledSignature>
+                                    <bundledSignature>jdk-internal-9</bundledSignature>
+                                    <bundledSignature>jdk-internal-10</bundledSignature>
+                                    <bundledSignature>jdk-internal-11</bundledSignature>
+                                    <bundledSignature>jdk-internal-12</bundledSignature>
+                                    <bundledSignature>jdk-internal-13</bundledSignature>
+                                    <bundledSignature>jdk-internal-14</bundledSignature>
+                                    <bundledSignature>jdk-internal-15</bundledSignature>
+                                    <bundledSignature>jdk-internal-16</bundledSignature>
+                                    <bundledSignature>jdk-internal-17</bundledSignature>
                                 </bundledSignatures>
                             </configuration>
                         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <version.depends.plugin>1.4.0</version.depends.plugin>
         <version.deploy.plugin>2.8.2</version.deploy.plugin>
         <version.enforcer.plugin>3.0.0-M1</version.enforcer.plugin>
-        <version.forbiddenapis.plugin>2.5</version.forbiddenapis.plugin>
+        <version.forbiddenapis.plugin>3.2</version.forbiddenapis.plugin>
         <version.gmavenplus.plugin>1.6</version.gmavenplus.plugin>
         <version.gpg.plugin>3.0.1</version.gpg.plugin>
         <version.install.plugin>2.5.2</version.install.plugin>
@@ -1405,12 +1405,12 @@
             </build>
         </profile>
         <profile>
-            <id>jdk17+</id>
+            <id>jdk18+</id>
             <activation>
-                <jdk>[17,)</jdk>
+                <jdk>[18,)</jdk>
             </activation>
             <properties>
-                <!-- ForbiddenAPIs doesn't work with JDK17: https://github.com/policeman-tools/forbidden-apis/issues/177 -->
+                <!-- ForbiddenAPIs doesn't work with JDK18 yet -->
                 <forbiddenapis.skip>true</forbiddenapis.skip>
             </properties>
         </profile>


### PR DESCRIPTION
* [HV-1873](https://hibernate.atlassian.net/browse/HV-1873): Upgrade to forbiddenapis 3.2
* [HV-1872](https://hibernate.atlassian.net/browse/HV-1872): Test Hibernate Validator against OpenJDK 19

