### PR TITLE
HV-1882 Follow-up: Ensure Java programs launched in tests (Payara, WildFly) use the test Java home, not the Maven Java home

### DIFF
--- a/integration/src/test/resources/arquillian.xml
+++ b/integration/src/test/resources/arquillian.xml
@@ -23,7 +23,7 @@
         </protocol>
         <configuration>
             <property name="jbossHome">${wildfly.target-dir}</property>
-            <property name="javaHome">${arquillian.wildfly.jvm.java_home}</property>
+            <!-- Java home is defined through an environment variable (see maven-failsafe-plugin config) -->
             <property name="javaVmArguments">
                 ${arquillian.wildfly.jvm.args}
             </property>

--- a/osgi/felixtest/src/test/resources/arquillian.xml
+++ b/osgi/felixtest/src/test/resources/arquillian.xml
@@ -20,7 +20,7 @@
     <container qualifier="paraya" default="true">
         <configuration>
             <property name="glassFishHome">${basedir}/target/payara5</property>
-            <property name="javaHome">${arquillian.payara.jvm.java_home}</property>
+            <!-- Java home is defined through an environment variable (see maven-failsafe-plugin config) -->
             <!--
             Uncomment to enable debug mode (debug port is 9009, suspend is disabled):
             <property name="debug">true</property>

--- a/pom.xml
+++ b/pom.xml
@@ -317,12 +317,9 @@
          -->
         <surefire.environment>default</surefire.environment>
 
-        <arquillian.wildfly.jvm.java_home>${java-version.test.launcher.java_home}</arquillian.wildfly.jvm.java_home>
         <arquillian.wildfly.jvm.args.add-opens></arquillian.wildfly.jvm.args.add-opens>
         <arquillian.wildfly.jvm.args.add-modules></arquillian.wildfly.jvm.args.add-modules>
         <arquillian.wildfly.jvm.args>${arquillian.wildfly.jvm.args.add-opens} ${arquillian.wildfly.jvm.args.add-modules}</arquillian.wildfly.jvm.args>
-
-        <arquillian.payara.jvm.java_home>${java-version.test.launcher.java_home}</arquillian.payara.jvm.java_home>
 
         <!-- JDK version required for the build -->
         <jdk.min.version>17</jdk.min.version>
@@ -890,6 +887,11 @@
                         <jvm>${java-version.test.launcher}</jvm>
                         <argLine>${surefire.jvm.args}</argLine>
                         <reportNameSuffix>${surefire.environment}</reportNameSuffix>
+                        <environmentVariables>
+                            <!-- Ensure Java programs launched in tests (Payara, WildFly)
+                                 use the test Java home, not the Maven Java home -->
+                            <JAVA_HOME>${java-version.test.launcher.java_home}</JAVA_HOME>
+                        </environmentVariables>
                     </configuration>
                     <dependencies>
                         <!--
@@ -929,6 +931,11 @@
                         <jvm>${java-version.test.launcher}</jvm>
                         <argLine>${failsafe.jvm.args}</argLine>
                         <reportNameSuffix>${surefire.environment}</reportNameSuffix>
+                        <environmentVariables>
+                            <!-- Ensure Java programs launched in tests (Payara, WildFly)
+                                 use the test Java home, not the Maven Java home -->
+                            <JAVA_HOME>${java-version.test.launcher.java_home}</JAVA_HOME>
+                        </environmentVariables>
                     </configuration>
                     <dependencies>
                         <!--

--- a/tck-runner/src/test/resources/arquillian.xml
+++ b/tck-runner/src/test/resources/arquillian.xml
@@ -26,7 +26,7 @@
         <!-- Takes no effect - ARQ-579 -->
         <configuration>
             <property name="jbossHome">${wildfly.target-dir}</property>
-            <property name="javaHome">${arquillian.wildfly.jvm.java_home}</property>
+            <!-- Java home is defined through an environment variable (see maven-failsafe-plugin config) -->
             <property name="javaVmArguments">${arquillian.wildfly.jvm.args}
                 -Xmx1024m -XX:MaxPermSize=512m ${remote.debug}
                 -Dvalidation.provider=${validation.provider}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1882

Follows up on #1219

We already had a solution for WildFly (setting a property in `arquillian.xml`), but this one is more generic and will also work for Payara, once we re-enable those integration tests on the main branch (see #1227, where Payara tests run successfully on branch 6.2) .