### PR TITLE
Backport HV-1882 follow-up to branch 6.2: Make sure to copy javafx.api modules to WildFly when running the TCK with JDK8

### DIFF
--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -401,6 +401,41 @@
             </build>
         </profile>
         <profile>
+            <id>testWithJdk8</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>8</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- Copy additional modules -->
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-resources</id>
+                                <phase>generate-test-resources</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${wildfly.target-dir}/modules/system/layers/base/</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>src/test/modules/jdk8</directory>
+                                            <filtering>true</filtering>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>testWithJdk11+</id>
             <activation>
                 <property>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1882

Backport of #1230