### PR TITLE
Enable preview features when running tests against JDK 19

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,11 @@ stage('Configure') {
 							condition: TestCondition.BEFORE_MERGE),
 					new JdkBuildEnvironment(testJavaVersion: '18', testCompilerTool: 'OpenJDK 18 Latest',
 							condition: TestCondition.AFTER_MERGE),
+					// We want to enable preview features when testing early-access builds of OpenJDK:
+					// even if we don't use these features, just enabling them can cause side effects
+					// and it's useful to test that.
 					new JdkBuildEnvironment(testJavaVersion: '19', testCompilerTool: 'OpenJDK 19 Latest',
+							testLauncherArgs: '--enable-preview',
 							condition: TestCondition.AFTER_MERGE)
 			],
 			wildflyTck: [
@@ -352,6 +356,7 @@ abstract class BuildEnvironment {
 	String testJavaVersion
 	String testCompilerTool
 	String testLauncherTool
+	String testLauncherArgs
 	String toString() { getTag() }
 	abstract String getTag()
 	boolean isDefault() { isDefault }
@@ -496,6 +501,10 @@ String toTestJdkArg(BuildEnvironment buildEnv) {
 	String version = buildEnv.testJavaVersion
 	if ( defaultVersion != version ) {
 		args += " -Djava-version.test.release=$version"
+	}
+
+	if ( buildEnv.testLauncherArgs ) {
+		args += " -Dsurefire.jvm.args.commandline=${buildEnv.testLauncherArgs}"
 	}
 
 	return args

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,8 @@
         <maven.compiler.testRelease>${java-version.test.release}</maven.compiler.testRelease>
 
         <!-- Set empty default values to avoid Maven leaving property references (${...}) when it doesn't find a value -->
+        <!-- Argument passed from the command line -->
+        <surefire.jvm.args.commandline></surefire.jvm.args.commandline>
         <surefire.jvm.args.additional></surefire.jvm.args.additional>
         <surefire.jvm.args.illegal-access></surefire.jvm.args.illegal-access>
         <surefire.jvm.args.add-opens></surefire.jvm.args.add-opens>
@@ -309,8 +311,8 @@
         <surefire.jvm.args.shrinkwrap>
             -Dmaven.repo.local=${settings.localRepository}
         </surefire.jvm.args.shrinkwrap>
-        <surefire.jvm.args>${surefire.jvm.args.additional} ${surefire.jvm.args.add-opens} ${surefire.jvm.args.illegal-access} ${surefire.jvm.args.shrinkwrap} ${surefire.jvm.args.java-version}</surefire.jvm.args>
-        <failsafe.jvm.args>${surefire.jvm.args.additional} ${surefire.jvm.args.add-opens} ${surefire.jvm.args.illegal-access} ${surefire.jvm.args.shrinkwrap} ${surefire.jvm.args.java-version}</failsafe.jvm.args>
+        <surefire.jvm.args>${surefire.jvm.args.additional} ${surefire.jvm.args.add-opens} ${surefire.jvm.args.illegal-access} ${surefire.jvm.args.shrinkwrap} ${surefire.jvm.args.java-version} ${surefire.jvm.args.commandline}</surefire.jvm.args>
+        <failsafe.jvm.args>${surefire.jvm.args.additional} ${surefire.jvm.args.add-opens} ${surefire.jvm.args.illegal-access} ${surefire.jvm.args.shrinkwrap} ${surefire.jvm.args.java-version} ${surefire.jvm.args.commandline}</failsafe.jvm.args>
 
         <!--
             Should be set from the command line.


### PR DESCRIPTION
Note the goal is not to use those preview features; just to have them and their side-effects enabled, so as to increase the chance to detect JDK bugs.

See also https://github.com/hibernate/hibernate-search/pull/3094

