### PR TITLE
Use arquillian-protocol-servlet-jakarta artifact instead of arquillian-protocol-servlet for testing with WildFly 27 (upgrade to org.wildfly.arquillian=5.0.0.Alpha3, upgrade to Servlet 5.0, switch to arquillian-protocol-servlet-jakarta)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         -->
         <version.jakarta.enterprise.cdi-api>4.0.1</version.jakarta.enterprise.cdi-api>
         <version.org.jboss.weld.weld>5.0.1.Final</version.org.jboss.weld.weld>
-        <version.org.wildfly.arquillian>2.2.0.Final</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>5.0.0.Alpha3</version.org.wildfly.arquillian>
         <version.jakarta.ejb-api>4.0.1</version.jakarta.ejb-api>
         <version.jakarta.interceptor-api>2.1.0</version.jakarta.interceptor-api>
         <version.jakarta.annotation-api>2.1.1</version.jakarta.annotation-api>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -75,7 +75,7 @@
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.protocol</groupId>
-            <artifactId>arquillian-protocol-servlet</artifactId>
+            <artifactId>arquillian-protocol-servlet-jakarta</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -255,7 +255,7 @@
             </activation>
             <properties>
                 <surefire.jvm.args.additional>-DincludeJavaFXTests=true -Xmx1024m -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Duser.language=en</surefire.jvm.args.additional>
-                <arquillian.protocol>Servlet 3.0</arquillian.protocol>
+                <arquillian.protocol>Servlet 5.0</arquillian.protocol>
             </properties>
             <dependencies>
                 <dependency>
@@ -383,7 +383,7 @@
             </activation>
             <properties>
                 <surefire.jvm.args.additional>-Xmx1024m -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Duser.language=en</surefire.jvm.args.additional>
-                <arquillian.protocol>Servlet 3.0</arquillian.protocol>
+                <arquillian.protocol>Servlet 5.0</arquillian.protocol>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

https://hibernate.atlassian.net/browse/HV-1922

The inspiration for this PR is we noticed Bean Validation TCK failures without these changes when running against the newly updated WildFly `main` branch build (based on wildfly/dist/target instead of wildfly/ee-9/dist/target).  

Following advice from @jamezp we were able to hack our Bean Validation TCK run by using the following additional command line options.

When building Hibernate Validator:
- -Dversion.org.wildfly.arquillian=5.0.0.Alpha3 

When running the Hibernate Validator TCK Runner for WildFly:
-     -Dversion.org.wildfly.arquillian=5.0.0.Alpha3 
-     -Dmaven.test.dependency.excludes=org.jboss.arquillian.protocol:arquillian-protocol-servlet 
-     -Darquillian.protocol="Servlet 5.0" 

Instead of excluding `arquillian-protocol-servlet` this pr switches to `arquillian-protocol-servlet-jakarta`
   