### PR TITLE
HV-1927 Use Executable#getAnnotatedParameterTypes() instead of Executable#getGenericParameterTypes()

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanParameter.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/properties/javabean/JavaBeanParameter.java
@@ -15,6 +15,7 @@ import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 
+import org.hibernate.validator.internal.util.TypeHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
 
@@ -35,11 +36,14 @@ public class JavaBeanParameter implements JavaBeanAnnotatedElement {
 
 	private final Type genericType;
 
-	JavaBeanParameter(int index, Parameter parameter, Class<?> type, Type genericType) {
+	private final AnnotatedType annotatedType;
+
+	JavaBeanParameter(int index, Parameter parameter, Class<?> type, AnnotatedType annotatedType) {
 		this.index = index;
 		this.parameter = parameter;
 		this.type = type;
-		this.genericType = genericType;
+		this.genericType = getErasedTypeIfTypeVariable( annotatedType.getType() );
+		this.annotatedType = annotatedType;
 	}
 
 	public int getIndex() {
@@ -53,7 +57,7 @@ public class JavaBeanParameter implements JavaBeanAnnotatedElement {
 
 	@Override
 	public AnnotatedType getAnnotatedType() {
-		return parameter.getAnnotatedType();
+		return annotatedType;
 	}
 
 	@Override
@@ -75,11 +79,19 @@ public class JavaBeanParameter implements JavaBeanAnnotatedElement {
 
 	@Override
 	public TypeVariable<?>[] getTypeParameters() {
-		return parameter.getType().getTypeParameters();
+		return type.getTypeParameters();
 	}
 
 	@Override
 	public <A extends Annotation> A getAnnotation(Class<A> annotationClass) {
 		return parameter.getAnnotation( annotationClass );
+	}
+
+	private static Type getErasedTypeIfTypeVariable(Type genericType) {
+		if ( genericType instanceof TypeVariable ) {
+			return TypeHelper.getErasedType( genericType );
+		}
+
+		return genericType;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -895,14 +895,6 @@ public interface Log extends BasicLogger {
 	@Message(id = 253, value = "Unable to instantiate property node name provider class %s.")
 	ValidationException getUnableToInstantiatePropertyNodeNameProviderClassException(String propertyNodeNameProviderClassName, @Cause Exception e);
 
-	@LogMessage(level = WARN)
-	@Message(id = 254, value = "Missing parameter metadata for %s, which declares implicit or synthetic parameters."
-			+ " Automatic resolution of generic type information for method parameters"
-			+ " may yield incorrect results if multiple parameters have the same erasure."
-			+ " To solve this, compile your code with the '-parameters' flag."
-	)
-	void missingParameterMetadataWithSyntheticOrImplicitParameters(@FormatWith(ExecutableFormatter.class) Executable executable);
-
 	@LogMessage(level = DEBUG)
 	@Message(id = 255, value = "Using %s as locale resolver.")
 	void usingLocaleResolver(@FormatWith(ClassObjectFormatter.class) Class<? extends LocaleResolver> localeResolverClass);


### PR DESCRIPTION
getGenericParameterTypes() is problematic with synthetic and implicit parameters and we used to have ugly workarounds and warnings. Using getAnnotatedParameterTypes() solves the issue.

I was extremely conservative in the changes as I want to be able to backport it.

https://hibernate.atlassian.net/browse/HV-1927