### PR TITLE
Backport HV-1744 + HV-1934 to branch 6.0 - Move documentation to Google Analytics 4

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -195,6 +195,21 @@
                         </configuration>
                     </execution>
                     <execution>
+                        <id>copy-script-to-html-output</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${asciidoctor.aggregated-resources-dir}/script/</directory>
+                                </resource>
+                            </resources>
+                            <outputDirectory>${asciidoctor.base-output-dir}/html_single/script/</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>copy-images-to-html-output</id>
                         <phase>generate-resources</phase>
                         <goals>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -33,9 +33,7 @@
         <html.meta.description>Hibernate Validator, Annotation based constraints for your domain model - Reference Documentation</html.meta.description>
         <html.meta.keywords>hibernate, validator, hibernate validator, validation, bean validation</html.meta.keywords>
         <html.meta.project-key>validator</html.meta.project-key>
-        <html.google-analytics.id>UA-45270411-3</html.google-analytics.id>
-        <html.google-analytics.tag-manager.id>GTM-NJWS5L</html.google-analytics.tag-manager.id>
-        <html.google-analytics.tag-manager.channel>Hibernate</html.google-analytics.tag-manager.channel>
+        <html.google-analytics.id>G-282CVRCQHZ</html.google-analytics.id>
         <html.outdated-content.project-key>${html.meta.project-key}</html.outdated-content.project-key>
 
         <!-- Skip artifact deployment -->

--- a/documentation/src/main/asciidoc/index.asciidoc
+++ b/documentation/src/main/asciidoc/index.asciidoc
@@ -6,10 +6,10 @@ Hardy Ferentschik; Gunnar Morling; Guillaume Smet
 :xrefstyle: full
 :anchor:
 :toc: left
-:toclevels: 3
+:toclevels: 4
 :sectnumlevels: 5
 :docinfodir: {docinfodir}
-:docinfo:
+:docinfo: shared,private
 :title-logo-image: image:hibernate_logo_a.png[align=left,pdfwidth=33%]
 
 include::pr01.asciidoc[]

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <spring-expression.version>4.3.10.RELEASE</spring-expression.version>
 
         <!-- Asciidoctor -->
-        <hibernate-asciidoctor-theme.version>1.0.1.Final</hibernate-asciidoctor-theme.version>
+        <hibernate-asciidoctor-theme.version>1.0.3.Final</hibernate-asciidoctor-theme.version>
         <hibernate-asciidoctor-extensions.version>1.0.3.Final</hibernate-asciidoctor-extensions.version>
         <asciidoctor-maven-plugin.version>1.5.5</asciidoctor-maven-plugin.version>
         <jruby.version>9.1.8.0</jruby.version>

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
         <spring-expression.version>4.3.10.RELEASE</spring-expression.version>
 
         <!-- Asciidoctor -->
-        <hibernate-asciidoctor-theme.version>1.0.3.Final</hibernate-asciidoctor-theme.version>
+        <hibernate-asciidoctor-theme.version>1.0.6.Final</hibernate-asciidoctor-theme.version>
         <hibernate-asciidoctor-extensions.version>1.0.3.Final</hibernate-asciidoctor-extensions.version>
         <asciidoctor-maven-plugin.version>1.5.5</asciidoctor-maven-plugin.version>
         <jruby.version>9.1.8.0</jruby.version>


### PR DESCRIPTION
* [HV-1934](https://hibernate.atlassian.net/browse/HV-1934): Upgrade to hibernate-asciidoctor-theme 1.0.6
* [HV-1744](https://hibernate.atlassian.net/browse/HV-1744): Use auto-expanding entries in the documentation TOC

Backport of #1296

I had to backport HV-1744 as well, otherwise tocbot (introduced in hibernate-asciidoctor-theme 1.0.3) wouldn't work correctly.



[HV-1934]: https://hibernate.atlassian.net/browse/HV-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HV-1744]: https://hibernate.atlassian.net/browse/HV-1744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ