### PR TITLE
Update JDK version required for building HV and Expressly version

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Logging will delegate any log requests to that provider.
         <dependency>
            <groupId>org.glassfish.expressly</groupId>
            <artifactId>expressly</artifactId>
-           <version>5.0.0-M2</version>
+           <version>5.0.0</version>
         </dependency>
 
 * Jakarta Bean Validation defines integration points with [CDI](http://jcp.org/en/jsr/detail?id=346). If your application runs
@@ -69,7 +69,7 @@ the Apache Software License 2.0. Refer to license.txt for more information.
 ## Build from Source
 
 You can build Hibernate Validator from source by cloning the git repository `git://github.com/hibernate/hibernate-validator.git`.
-You will also need a JDK 8+ and Maven 3 (>= 3.3.1). With these prerequisites in place you can compile the source via:
+You will also need a JDK 17+ and Maven 3 (>= 3.3.1). With these prerequisites in place you can compile the source via:
 
     mvn clean install
 


### PR DESCRIPTION
Please delete this text, and add a link to the Jira issue solved by this PR;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
