### PR TITLE
HV-1941 european portuguese validation messages (version 8.0)

### DIFF
--- a/engine/src/main/resources/org/hibernate/validator/ValidationMessages_pt.properties
+++ b/engine/src/main/resources/org/hibernate/validator/ValidationMessages_pt.properties
@@ -1,0 +1,53 @@
+jakarta.validation.constraints.AssertFalse.message     = deve ser falso
+jakarta.validation.constraints.AssertTrue.message      = deve ser verdadeiro
+jakarta.validation.constraints.DecimalMax.message      = deve ser menor que ${inclusive == true ? 'ou igual a ' : ''}{value}
+jakarta.validation.constraints.DecimalMin.message      = deve ser maior que ${inclusive == true ? 'ou igual a ' : ''}{value}
+jakarta.validation.constraints.Digits.message          = valor n\u00famerico fora do limite (<{integer} d\u00edgito>.<{fraction} d\u00edgitos> esperar)
+jakarta.validation.constraints.Email.message           = deve ser um endere\u00e7o de e-mail bem formado
+jakarta.validation.constraints.Future.message          = deve ser uma data futura
+jakarta.validation.constraints.FutureOrPresent.message = deve ser uma data no presente ou no futuro
+jakarta.validation.constraints.Max.message             = deve ser menor que ou igual a {value}
+jakarta.validation.constraints.Min.message             = deve ser maior que ou igual a {value}
+jakarta.validation.constraints.Negative.message        = deve ser menor que 0
+jakarta.validation.constraints.NegativeOrZero.message  = deve ser menor ou igual a 0
+jakarta.validation.constraints.NotBlank.message        = n\u00e3o deve estar em branco
+jakarta.validation.constraints.NotEmpty.message        = n\u00e3o deve estar vazio
+jakarta.validation.constraints.NotNull.message         = n\u00e3o deve ser nulo
+jakarta.validation.constraints.Null.message            = deve ser nulo
+jakarta.validation.constraints.Past.message            = deve ser uma data passada
+jakarta.validation.constraints.PastOrPresent.message   = deve ser uma data no passado ou no presente
+jakarta.validation.constraints.Pattern.message         = deve corresponder a "{regexp}"
+jakarta.validation.constraints.Positive.message        = deve ser maior que 0
+jakarta.validation.constraints.PositiveOrZero.message  = deve ser maior ou igual a 0
+jakarta.validation.constraints.Size.message            = tamanho deve ser entre {min} e {max}
+
+org.hibernate.validator.constraints.CreditCardNumber.message        = n\u00famero do cart\u00e3o de cr\u00e9dito inv\u00e1lido
+org.hibernate.validator.constraints.Currency.message                = moeda inv\u00e1lida (deve ser uma de {value})
+org.hibernate.validator.constraints.EAN.message                     = c\u00f3digo de barras {type} inv\u00e1lido
+org.hibernate.validator.constraints.Email.message                   = deve ser um endere\u00e7o de e-mail bem formado
+org.hibernate.validator.constraints.ISBN.message                    = ISBN inv\u00e1lido
+org.hibernate.validator.constraints.Length.message                  = o comprimento deve ser entre {min} e {max}
+org.hibernate.validator.constraints.CodePointLength.message         = o comprimento deve ser entre {min} e {max}
+org.hibernate.validator.constraints.LuhnCheck.message               = o d\u00edgito de verifica\u00e7\u00e3o para ${validatedValue} \u00e9 inv\u00e1lido, soma de verifica\u00e7\u00e3o Modulo 10 com falha
+org.hibernate.validator.constraints.Mod10Check.message              = o d\u00edgito de verifica\u00e7\u00e3o para ${validatedValue} \u00e9 inv\u00e1lido, soma de verifica\u00e7\u00e3o Modulo 10 com falha
+org.hibernate.validator.constraints.Mod11Check.message              = o d\u00edgito de verifica\u00e7\u00e3o para ${validatedValue} \u00e9 inv\u00e1lido, soma de verifica\u00e7\u00e3o Modulo 11 com falha
+org.hibernate.validator.constraints.ModCheck.message                = o d\u00edgito de verifica\u00e7\u00e3o para ${validatedValue} \u00e9 inv\u00e1lido, soma de verifica\u00e7\u00e3o {modType} com falha
+org.hibernate.validator.constraints.NotBlank.message                = n\u00e3o deve estar em branco
+org.hibernate.validator.constraints.NotEmpty.message                = n\u00e3o deve estar vazio
+org.hibernate.validator.constraints.ParametersScriptAssert.message  = express\u00e3o de script "{script}" n\u00e3o avaliou para true
+org.hibernate.validator.constraints.Range.message                   = deve estar entre {min} e {max}
+org.hibernate.validator.constraints.ScriptAssert.message            = express\u00e3o de script "{script}" n\u00e3o avaliou para true
+org.hibernate.validator.constraints.UniqueElements.message          = deve conter apenas elementos exclusivos
+org.hibernate.validator.constraints.URL.message                     = deve ser uma URL v\u00e1lida
+org.hibernate.validator.constraints.UUID.message                    = deve ser uma UUID v\u00e1lida
+
+org.hibernate.validator.constraints.br.CNPJ.message                 = n\u00famero do registro de contribuinte corporativo brasileiro (CNPJ) inv\u00e1lido
+org.hibernate.validator.constraints.br.CPF.message                  = n\u00famero do registro de contribuinte individual brasileiro (CPF) inv\u00e1lido
+org.hibernate.validator.constraints.br.TituloEleitoral.message      = n\u00famero do t\u00edtulo de eleitor brasileiro inv\u00e1lido
+
+org.hibernate.validator.constraints.pl.NIP.message                  = n\u00famero de identifica\u00e7\u00e3o de VAT (NIP) inv\u00e1lido
+
+org.hibernate.validator.constraints.ru.INN.message                  = n\u00famero de identifica\u00e7\u00e3o de contribuinte russo (INN) inv\u00e1lido
+
+org.hibernate.validator.constraints.time.DurationMax.message        = deve ser menor que${inclusive == true ? ' ou igual a' : ''}${days == 0 ? '' : days == 1 ? ' 1 dia' : ' ' += days += ' dias'}${hours == 0 ? '' : hours == 1 ? ' 1 hora' : ' ' += hours += ' horas'}${minutes == 0 ? '' : minutes == 1 ? ' 1 minuto' : ' ' += minutes += ' minutos'}${seconds == 0 ? '' : seconds == 1 ? ' 1 segundo' : ' ' += seconds += ' segundos'}${millis == 0 ? '' : millis == 1 ? ' 1 mili' : ' ' += millis += ' miliss'}${nanos == 0 ? '' : nanos == 1 ? ' 1 nano' : ' ' += nanos += ' nanos'}
+org.hibernate.validator.constraints.time.DurationMin.message        = deve ser maior que${inclusive == true ? ' ou igual a' : ''}${days == 0 ? '' : days == 1 ? ' 1 dia' : ' ' += days += ' dias'}${hours == 0 ? '' : hours == 1 ? ' 1 hora' : ' ' += hours += ' horas'}${minutes == 0 ? '' : minutes == 1 ? ' 1 minuto' : ' ' += minutes += ' minutos'}${seconds == 0 ? '' : seconds == 1 ? ' 1 segundo' : ' ' += seconds += ' segundos'}${millis == 0 ? '' : millis == 1 ? ' 1 mili' : ' ' += millis += ' miliss'}${nanos == 0 ? '' : nanos == 1 ? ' 1 nano' : ' ' += nanos += ' nanos'}

--- a/engine/src/main/resources/org/hibernate/validator/ValidationMessages_pt_BR.properties
+++ b/engine/src/main/resources/org/hibernate/validator/ValidationMessages_pt_BR.properties
@@ -1,55 +1,6 @@
-jakarta.validation.constraints.AssertFalse.message     = deve ser falso
-jakarta.validation.constraints.AssertTrue.message      = deve ser verdadeiro
-jakarta.validation.constraints.DecimalMax.message      = deve ser menor que ${inclusive == true ? 'ou igual a ' : ''}{value}
-jakarta.validation.constraints.DecimalMin.message      = deve ser maior que ${inclusive == true ? 'ou igual a ' : ''}{value}
-jakarta.validation.constraints.Digits.message          = valor n\u00famerico fora do limite (<{integer} d\u00edgito>.<{fraction} d\u00edgitos> esperar)
-jakarta.validation.constraints.Email.message           = deve ser um endere\u00e7o de e-mail bem formado
-jakarta.validation.constraints.Future.message          = deve ser uma data futura
-jakarta.validation.constraints.FutureOrPresent.message = deve ser uma data no presente ou no futuro
+
 jakarta.validation.constraints.Max.message             = deve ser menor que ou igual \u00e0 {value}
 jakarta.validation.constraints.Min.message             = deve ser maior que ou igual \u00e0 {value}
-jakarta.validation.constraints.Negative.message        = deve ser menor que 0
-jakarta.validation.constraints.NegativeOrZero.message  = deve ser menor ou igual a 0
-jakarta.validation.constraints.NotBlank.message        = n\u00e3o deve estar em branco
-jakarta.validation.constraints.NotEmpty.message        = n\u00e3o deve estar vazio
-jakarta.validation.constraints.NotNull.message         = n\u00e3o deve ser nulo
-jakarta.validation.constraints.Null.message            = deve ser nulo
-jakarta.validation.constraints.Past.message            = deve ser uma data passada
-jakarta.validation.constraints.PastOrPresent.message   = deve ser uma data no passado ou no presente
-jakarta.validation.constraints.Pattern.message         = deve corresponder a "{regexp}"
-jakarta.validation.constraints.Positive.message        = deve ser maior que 0
-jakarta.validation.constraints.PositiveOrZero.message  = deve ser maior ou igual a 0
-jakarta.validation.constraints.Size.message            = tamanho deve ser entre {min} e {max}
 
-org.hibernate.validator.constraints.CreditCardNumber.message        = n\u00famero do cart\u00e3o de cr\u00e9dito inv\u00e1lido
-org.hibernate.validator.constraints.Currency.message                = moeda inv\u00e1lida (deve ser uma de {value})
-org.hibernate.validator.constraints.EAN.message                     = c\u00f3digo de barras {type} inv\u00e1lido
-org.hibernate.validator.constraints.Email.message                   = deve ser um endere\u00e7o de e-mail bem formado
-org.hibernate.validator.constraints.ISBN.message                    = ISBN inv\u00e1lido
-org.hibernate.validator.constraints.Length.message                  = o comprimento deve ser entre {min} e {max}
-org.hibernate.validator.constraints.CodePointLength.message         = o comprimento deve ser entre {min} e {max}
-org.hibernate.validator.constraints.LuhnCheck.message               = o d\u00edgito de verifica\u00e7\u00e3o para ${validatedValue} \u00e9 inv\u00e1lido, soma de verifica\u00e7\u00e3o Luhn Modulo 10 com falha
-org.hibernate.validator.constraints.Mod10Check.message              = o d\u00edgito de verifica\u00e7\u00e3o para ${validatedValue} \u00e9 inv\u00e1lido, soma de verifica\u00e7\u00e3o Modulo 10 com falha
-org.hibernate.validator.constraints.Mod11Check.message              = o d\u00edgito de verifica\u00e7\u00e3o para ${validatedValue} \u00e9 inv\u00e1lido, soma de verifica\u00e7\u00e3o Modulo 11 com falha
-org.hibernate.validator.constraints.ModCheck.message                = o d\u00edgito de verifica\u00e7\u00e3o para ${validatedValue} \u00e9 inv\u00e1lido, soma de verifica\u00e7\u00e3o {modType} com falha
-org.hibernate.validator.constraints.NotBlank.message                = n\u00e3o deve estar em branco
-org.hibernate.validator.constraints.NotEmpty.message                = n\u00e3o deve estar vazio
-org.hibernate.validator.constraints.ParametersScriptAssert.message  = express\u00e3o de script "{script}" n\u00e3o avaliou para true
-org.hibernate.validator.constraints.Range.message                   = deve estar entre {min} e {max}
-org.hibernate.validator.constraints.ScriptAssert.message            = express\u00e3o de script "{script}" n\u00e3o avaliou para true
-org.hibernate.validator.constraints.UniqueElements.message          = deve conter apenas elementos exclusivos
-org.hibernate.validator.constraints.URL.message                     = deve ser uma URL v\u00e1lida
-org.hibernate.validator.constraints.UUID.message                    = deve ser uma UUID v\u00e1lida
-
-org.hibernate.validator.constraints.br.CNPJ.message                 = n\u00famero do registro de contribuinte corporativo brasileiro (CNPJ) inv\u00e1lido
-org.hibernate.validator.constraints.br.CPF.message                  = n\u00famero do registro de contribuinte individual brasileiro (CPF) inv\u00e1lido
-org.hibernate.validator.constraints.br.TituloEleitoral.message      = n\u00famero do t\u00edtulo de eleitor brasileiro inv\u00e1lido
-
-org.hibernate.validator.constraints.pl.REGON.message                = n\u00famero de identifica\u00e7\u00e3o de contribuinte polon\u00eas (REGON) inv\u00e1lido
-org.hibernate.validator.constraints.pl.NIP.message                  = n\u00famero de identifica\u00e7\u00e3o de VAT (NIP) inv\u00e1lido
-org.hibernate.validator.constraints.pl.PESEL.message                = n\u00famero de identifica\u00e7\u00e3o nacional polonesa (PESEL) inv\u00e1lido
-
-org.hibernate.validator.constraints.ru.INN.message                  = n\u00famero de identifica\u00e7\u00e3o de contribuinte russo (INN) inv\u00e1lido
-
-org.hibernate.validator.constraints.time.DurationMax.message        = deve ser menor que${inclusive == true ? ' ou igual a' : ''}${days == 0 ? '' : days == 1 ? ' 1 dia' : ' ' += days += ' dias'}${hours == 0 ? '' : hours == 1 ? ' 1 hora' : ' ' += hours += ' horas'}${minutes == 0 ? '' : minutes == 1 ? ' 1 minuto' : ' ' += minutes += ' minutos'}${seconds == 0 ? '' : seconds == 1 ? ' 1 segundo' : ' ' += seconds += ' segundos'}${millis == 0 ? '' : millis == 1 ? ' 1 mili' : ' ' += millis += ' miliss'}${nanos == 0 ? '' : nanos == 1 ? ' 1 nano' : ' ' += nanos += ' nanos'}
-org.hibernate.validator.constraints.time.DurationMin.message        = deve ser maior que${inclusive == true ? ' ou igual a' : ''}${days == 0 ? '' : days == 1 ? ' 1 dia' : ' ' += days += ' dias'}${hours == 0 ? '' : hours == 1 ? ' 1 hora' : ' ' += hours += ' horas'}${minutes == 0 ? '' : minutes == 1 ? ' 1 minuto' : ' ' += minutes += ' minutos'}${seconds == 0 ? '' : seconds == 1 ? ' 1 segundo' : ' ' += seconds += ' segundos'}${millis == 0 ? '' : millis == 1 ? ' 1 mili' : ' ' += millis += ' miliss'}${nanos == 0 ? '' : nanos == 1 ? ' 1 nano' : ' ' += nanos += ' nanos'}
+org.hibernate.validator.constraints.pl.REGON.message = n\u00famero de identifica\u00e7\u00e3o de contribuinte polon\u00eas (REGON) inv\u00e1lido
+org.hibernate.validator.constraints.pl.PESEL.message = n\u00famero de identifica\u00e7\u00e3o nacional polonesa (PESEL) inv\u00e1lido

--- a/engine/src/main/resources/org/hibernate/validator/ValidationMessages_pt_PT.properties
+++ b/engine/src/main/resources/org/hibernate/validator/ValidationMessages_pt_PT.properties
@@ -1,0 +1,11 @@
+jakarta.validation.constraints.Past.message = deve ser uma data no passado
+jakarta.validation.constraints.Size.message = tamanho deve estar entre {min} e {max}
+
+org.hibernate.validator.constraints.Length.message          = o comprimento deve estar entre {min} e {max}
+org.hibernate.validator.constraints.CodePointLength.message = o comprimento deve estar entre {min} e {max}
+
+org.hibernate.validator.constraints.br.CNPJ.message         = n\u00famero de registo de contribuinte corporativo brasileiro (CNPJ) inv\u00e1lido
+org.hibernate.validator.constraints.br.CPF.message          = n\u00famero de registo de contribuinte individual brasileiro (CPF) inv\u00e1lido
+
+org.hibernate.validator.constraints.pl.REGON.message        = n\u00famero de identifica\u00e7\u00e3o de contribuinte polaco (REGON) inv\u00e1lido
+org.hibernate.validator.constraints.pl.PESEL.message        = n\u00famero de identifica\u00e7\u00e3o nacional poloca (PESEL) inv\u00e1lido


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1941

Added European Portuguese validation messages; I moved the existing Brazilian Portuguese messages to the common Portuguese locale where applicable. 
