### PR TITLE
HV-1942 Update DefaultGroupSequenceProvider add default method provide the class of instance

### DIFF
--- a/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
@@ -1,3 +1,9 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
 package org.hibernate.validator.spi.group;
 
 import jakarta.validation.Validation;

--- a/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
@@ -26,108 +26,108 @@ import java.util.Objects;
  */
 public class DefaultGroupSequenceProviderTest {
 
-    @Test
-    public void withoutClassParam () {
-        Assert.assertThrows (() -> {
-            final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory ();
-            final Validator validator = validatorFactory.getValidator ();
-            validator.validate (new A1 ());
-        });
-    }
+	@Test
+	public void withoutClassParam () {
+		Assert.assertThrows (() -> {
+			final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory ();
+			final Validator validator = validatorFactory.getValidator ();
+			validator.validate (new A1 ());
+		});
+	}
 
-    @Test
-    public void withClassParam () {
-        final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory ();
-        final Validator validator = validatorFactory.getValidator ();
-        validator.validate (new A2 ());
-    }
-
-
-    public static class DefaultGroupSequenceProvider1 implements DefaultGroupSequenceProvider<Object> {
-
-        @Override
-        public List<Class<?>> getValidationGroups (Object object) {
-            List<Class<?>> groups = new ArrayList<> ();
-            if (Objects.nonNull (object)) {
-                groups.add (object.getClass ());
-            }
-            return groups;
-        }
-    }
+	@Test
+	public void withClassParam () {
+		final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory ();
+		final Validator validator = validatorFactory.getValidator ();
+		validator.validate (new A2 ());
+	}
 
 
-    public static class DefaultGroupSequenceProvider2 implements DefaultGroupSequenceProvider<Object> {
+	public static class DefaultGroupSequenceProvider1 implements DefaultGroupSequenceProvider<Object> {
 
-        @Override
-        public List<Class<?>> getValidationGroups (Class<?> clazz, Object object) {
-            List<Class<?>> groups = new ArrayList<> ();
-            if (Objects.nonNull (clazz)) {
-                groups.add (clazz);
-            }
-            return groups;
-        }
-
-        @Override
-        public List<Class<?>> getValidationGroups (Object object) {
-            throw new IllegalArgumentException ("");
-        }
-    }
+		@Override
+		public List<Class<?>> getValidationGroups (Object object) {
+			List<Class<?>> groups = new ArrayList<> ();
+			if (Objects.nonNull (object)) {
+				groups.add (object.getClass ());
+			}
+			return groups;
+		}
+	}
 
 
-    @GroupSequenceProvider(DefaultGroupSequenceProvider1.class)
-    public static class A1 {
-        @NotNull
-        private String name;
+	public static class DefaultGroupSequenceProvider2 implements DefaultGroupSequenceProvider<Object> {
 
-        public String getName () {
-            return name;
-        }
+		@Override
+		public List<Class<?>> getValidationGroups (Class<?> clazz, Object object) {
+			List<Class<?>> groups = new ArrayList<> ();
+			if (Objects.nonNull (clazz)) {
+				groups.add (clazz);
+			}
+			return groups;
+		}
 
-        public void setName (String name) {
-            this.name = name;
-        }
-    }
+		@Override
+		public List<Class<?>> getValidationGroups (Object object) {
+			throw new IllegalArgumentException ("");
+		}
+	}
 
-    @GroupSequenceProvider(DefaultGroupSequenceProvider1.class)
-    public static class B1 {
-        @NotNull
-        private String name;
 
-        public String getName () {
-            return name;
-        }
+	@GroupSequenceProvider(DefaultGroupSequenceProvider1.class)
+	public static class A1 {
+		@NotNull
+		private String name;
 
-        public void setName (String name) {
-            this.name = name;
-        }
-    }
+		public String getName () {
+			return name;
+		}
 
-    @GroupSequenceProvider(DefaultGroupSequenceProvider2.class)
-    public static class A2 {
-        @NotNull
-        private String name;
+		public void setName (String name) {
+			this.name = name;
+		}
+	}
 
-        public String getName () {
-            return name;
-        }
+	@GroupSequenceProvider(DefaultGroupSequenceProvider1.class)
+	public static class B1 {
+		@NotNull
+		private String name;
 
-        public void setName (String name) {
-            this.name = name;
-        }
-    }
+		public String getName () {
+			return name;
+		}
 
-    @GroupSequenceProvider(DefaultGroupSequenceProvider2.class)
-    public static class B2 {
-        @NotNull
-        private String name;
+		public void setName (String name) {
+			this.name = name;
+		}
+	}
 
-        public String getName () {
-            return name;
-        }
+	@GroupSequenceProvider(DefaultGroupSequenceProvider2.class)
+	public static class A2 {
+		@NotNull
+		private String name;
 
-        public void setName (String name) {
-            this.name = name;
-        }
-    }
+		public String getName () {
+			return name;
+		}
+
+		public void setName (String name) {
+			this.name = name;
+		}
+	}
+
+	@GroupSequenceProvider(DefaultGroupSequenceProvider2.class)
+	public static class B2 {
+		@NotNull
+		private String name;
+
+		public String getName () {
+			return name;
+		}
+
+		public void setName (String name) {
+			this.name = name;
+		}
+	}
 
 }

--- a/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
@@ -48,7 +48,7 @@ public class DefaultGroupSequenceProviderTest {
 		@Override
 		public List<Class<?>> getValidationGroups (Object object) {
 			List<Class<?>> groups = new ArrayList<> ();
-			if (Objects.nonNull (object)) {
+			if ( Objects.nonNull (object) ) {
 				groups.add (object.getClass ());
 			}
 			return groups;
@@ -61,7 +61,7 @@ public class DefaultGroupSequenceProviderTest {
 		@Override
 		public List<Class<?>> getValidationGroups (Class<?> clazz, Object object) {
 			List<Class<?>> groups = new ArrayList<> ();
-			if (Objects.nonNull (clazz)) {
+			if ( Objects.nonNull (clazz) ) {
 				groups.add (clazz);
 			}
 			return groups;

--- a/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
@@ -27,29 +27,29 @@ import java.util.Objects;
 public class DefaultGroupSequenceProviderTest {
 
     @Test
-    public void withoutClassParam() {
-        Assert.assertThrows(() -> {
-            final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
-            final Validator validator = validatorFactory.getValidator();
-            validator.validate(new A1());
+    public void withoutClassParam () {
+        Assert.assertThrows (() -> {
+            final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory ();
+            final Validator validator = validatorFactory.getValidator ();
+            validator.validate (new A1 ());
         });
     }
 
     @Test
-    public void withClassParam() {
-        final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
-        final Validator validator = validatorFactory.getValidator();
-        validator.validate(new A2());
+    public void withClassParam () {
+        final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory ();
+        final Validator validator = validatorFactory.getValidator ();
+        validator.validate (new A2 ());
     }
 
 
     public static class DefaultGroupSequenceProvider1 implements DefaultGroupSequenceProvider<Object> {
 
         @Override
-        public List<Class<?>> getValidationGroups(Object object) {
-            List<Class<?>> groups = new ArrayList<>();
-            if (Objects.nonNull(object)) {
-                groups.add(object.getClass());
+        public List<Class<?>> getValidationGroups (Object object) {
+            List<Class<?>> groups = new ArrayList<> ();
+            if (Objects.nonNull (object)) {
+                groups.add (object.getClass ());
             }
             return groups;
         }
@@ -59,17 +59,17 @@ public class DefaultGroupSequenceProviderTest {
     public static class DefaultGroupSequenceProvider2 implements DefaultGroupSequenceProvider<Object> {
 
         @Override
-        public List<Class<?>> getValidationGroups(Class<?> clazz, Object object) {
-            List<Class<?>> groups = new ArrayList<>();
-            if (Objects.nonNull(clazz)) {
-                groups.add(clazz);
+        public List<Class<?>> getValidationGroups (Class<?> clazz, Object object) {
+            List<Class<?>> groups = new ArrayList<> ();
+            if (Objects.nonNull (clazz)) {
+                groups.add (clazz);
             }
             return groups;
         }
 
         @Override
-        public List<Class<?>> getValidationGroups(Object object) {
-            throw new IllegalArgumentException("");
+        public List<Class<?>> getValidationGroups (Object object) {
+            throw new IllegalArgumentException ("");
         }
     }
 
@@ -79,11 +79,11 @@ public class DefaultGroupSequenceProviderTest {
         @NotNull
         private String name;
 
-        public String getName() {
+        public String getName () {
             return name;
         }
 
-        public void setName(String name) {
+        public void setName (String name) {
             this.name = name;
         }
     }
@@ -93,11 +93,11 @@ public class DefaultGroupSequenceProviderTest {
         @NotNull
         private String name;
 
-        public String getName() {
+        public String getName () {
             return name;
         }
 
-        public void setName(String name) {
+        public void setName (String name) {
             this.name = name;
         }
     }
@@ -107,11 +107,11 @@ public class DefaultGroupSequenceProviderTest {
         @NotNull
         private String name;
 
-        public String getName() {
+        public String getName () {
             return name;
         }
 
-        public void setName(String name) {
+        public void setName (String name) {
             this.name = name;
         }
     }
@@ -121,11 +121,11 @@ public class DefaultGroupSequenceProviderTest {
         @NotNull
         private String name;
 
-        public String getName() {
+        public String getName () {
             return name;
         }
 
-        public void setName(String name) {
+        public void setName (String name) {
             this.name = name;
         }
     }

--- a/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
@@ -28,7 +28,7 @@ public class DefaultGroupSequenceProviderTest {
 
 	@Test
 	public void withoutClassParam() {
-		Assert.assertThrows(() -> {
+		Assert.assertThrows(()->{
 			final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
 			final Validator validator = validatorFactory.getValidator();
 			validator.validate(new A1());

--- a/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
@@ -1,0 +1,127 @@
+package org.hibernate.validator.spi.group;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import jakarta.validation.constraints.NotNull;
+import org.hibernate.validator.group.GroupSequenceProvider;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+
+/**
+ * DefaultGroupSequenceProviderTest.
+ *
+ * @author ilikly
+ */
+public class DefaultGroupSequenceProviderTest {
+
+    @Test
+    public void withoutClassParam() {
+        Assert.assertThrows(() -> {
+            final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+            final Validator validator = validatorFactory.getValidator();
+            validator.validate(new A1());
+        });
+    }
+
+    @Test
+    public void withClassParam() {
+        final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        final Validator validator = validatorFactory.getValidator();
+        validator.validate(new A2());
+    }
+
+
+    public static class DefaultGroupSequenceProvider1 implements DefaultGroupSequenceProvider<Object> {
+
+        @Override
+        public List<Class<?>> getValidationGroups(Object object) {
+            List<Class<?>> groups = new ArrayList<>();
+            if (Objects.nonNull(object)) {
+                groups.add(object.getClass());
+            }
+            return groups;
+        }
+    }
+
+
+    public static class DefaultGroupSequenceProvider2 implements DefaultGroupSequenceProvider<Object> {
+
+        @Override
+        public List<Class<?>> getValidationGroups(Class<?> clazz, Object object) {
+            List<Class<?>> groups = new ArrayList<>();
+            if (Objects.nonNull(clazz)) {
+                groups.add(clazz);
+            }
+            return groups;
+        }
+
+        @Override
+        public List<Class<?>> getValidationGroups(Object object) {
+            throw new IllegalArgumentException("");
+        }
+    }
+
+
+    @GroupSequenceProvider(DefaultGroupSequenceProvider1.class)
+    public static class A1 {
+        @NotNull
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @GroupSequenceProvider(DefaultGroupSequenceProvider1.class)
+    public static class B1 {
+        @NotNull
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @GroupSequenceProvider(DefaultGroupSequenceProvider2.class)
+    public static class A2 {
+        @NotNull
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    @GroupSequenceProvider(DefaultGroupSequenceProvider2.class)
+    public static class B2 {
+        @NotNull
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+}

--- a/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
@@ -28,28 +28,28 @@ public class DefaultGroupSequenceProviderTest {
 
 	@Test
 	public void withoutClassParam() {
-		Assert.assertThrows(()->{
+		Assert.assertThrows( () -> {
 			final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
 			final Validator validator = validatorFactory.getValidator();
-			validator.validate(new A1());
-		});
+			validator.validate( new A1() );
+		} );
 	}
 
 	@Test
 	public void withClassParam() {
 		final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
 		final Validator validator = validatorFactory.getValidator();
-		validator.validate(new A2());
+		validator.validate( new A2() );
 	}
 
 
 	public static class DefaultGroupSequenceProvider1 implements DefaultGroupSequenceProvider<Object> {
 
 		@Override
-		public List<Class<?>> getValidationGroups(Object object) {
+		public List<Class<?>> getValidationGroups( Object object ) {
 			List<Class<?>> groups = new ArrayList<>();
-			if ( Objects.nonNull(object) ) {
-				groups.add(object.getClass());
+			if ( Objects.nonNull( object ) ) {
+				groups.add( object.getClass() );
 			}
 			return groups;
 		}
@@ -59,17 +59,17 @@ public class DefaultGroupSequenceProviderTest {
 	public static class DefaultGroupSequenceProvider2 implements DefaultGroupSequenceProvider<Object> {
 
 		@Override
-		public List<Class<?>> getValidationGroups(Class<?> clazz, Object object) {
+		public List<Class<?>> getValidationGroups( Class<?> clazz, Object object ) {
 			List<Class<?>> groups = new ArrayList<>();
-			if ( Objects.nonNull(clazz) ) {
-				groups.add(clazz);
+			if ( Objects.nonNull( clazz ) ) {
+				groups.add( clazz );
 			}
 			return groups;
 		}
 
 		@Override
-		public List<Class<?>> getValidationGroups(Object object) {
-			throw new IllegalArgumentException("");
+		public List<Class<?>> getValidationGroups( Object object ) {
+			throw new IllegalArgumentException( "" );
 		}
 	}
 
@@ -83,7 +83,7 @@ public class DefaultGroupSequenceProviderTest {
 			return name;
 		}
 
-		public void setName(String name) {
+		public void setName( String name ) {
 			this.name = name;
 		}
 	}
@@ -97,7 +97,7 @@ public class DefaultGroupSequenceProviderTest {
 			return name;
 		}
 
-		public void setName(String name) {
+		public void setName( String name ) {
 			this.name = name;
 		}
 	}
@@ -111,7 +111,7 @@ public class DefaultGroupSequenceProviderTest {
 			return name;
 		}
 
-		public void setName(String name) {
+		public void setName( String name ) {
 			this.name = name;
 		}
 	}
@@ -125,7 +125,7 @@ public class DefaultGroupSequenceProviderTest {
 			return name;
 		}
 
-		public void setName(String name) {
+		public void setName( String name ) {
 			this.name = name;
 		}
 	}

--- a/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 public class DefaultGroupSequenceProviderTest {
 
 	@Test
-	public void withoutClassParam () {
+	public void withoutClassParam() {
 		Assert.assertThrows (() -> {
 			final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory ();
 			final Validator validator = validatorFactory.getValidator ();
@@ -36,7 +36,7 @@ public class DefaultGroupSequenceProviderTest {
 	}
 
 	@Test
-	public void withClassParam () {
+	public void withClassParam() {
 		final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory ();
 		final Validator validator = validatorFactory.getValidator ();
 		validator.validate (new A2 ());
@@ -46,7 +46,7 @@ public class DefaultGroupSequenceProviderTest {
 	public static class DefaultGroupSequenceProvider1 implements DefaultGroupSequenceProvider<Object> {
 
 		@Override
-		public List<Class<?>> getValidationGroups (Object object) {
+		public List<Class<?>> getValidationGroups(Object object) {
 			List<Class<?>> groups = new ArrayList<> ();
 			if ( Objects.nonNull (object) ) {
 				groups.add (object.getClass ());
@@ -59,7 +59,7 @@ public class DefaultGroupSequenceProviderTest {
 	public static class DefaultGroupSequenceProvider2 implements DefaultGroupSequenceProvider<Object> {
 
 		@Override
-		public List<Class<?>> getValidationGroups (Class<?> clazz, Object object) {
+		public List<Class<?>> getValidationGroups(Class<?> clazz, Object object) {
 			List<Class<?>> groups = new ArrayList<> ();
 			if ( Objects.nonNull (clazz) ) {
 				groups.add (clazz);
@@ -68,7 +68,7 @@ public class DefaultGroupSequenceProviderTest {
 		}
 
 		@Override
-		public List<Class<?>> getValidationGroups (Object object) {
+		public List<Class<?>> getValidationGroups(Object object) {
 			throw new IllegalArgumentException ("");
 		}
 	}
@@ -79,11 +79,11 @@ public class DefaultGroupSequenceProviderTest {
 		@NotNull
 		private String name;
 
-		public String getName () {
+		public String getName() {
 			return name;
 		}
 
-		public void setName (String name) {
+		public void setName(String name) {
 			this.name = name;
 		}
 	}
@@ -93,11 +93,11 @@ public class DefaultGroupSequenceProviderTest {
 		@NotNull
 		private String name;
 
-		public String getName () {
+		public String getName() {
 			return name;
 		}
 
-		public void setName (String name) {
+		public void setName(String name) {
 			this.name = name;
 		}
 	}
@@ -107,11 +107,11 @@ public class DefaultGroupSequenceProviderTest {
 		@NotNull
 		private String name;
 
-		public String getName () {
+		public String getName() {
 			return name;
 		}
 
-		public void setName (String name) {
+		public void setName(String name) {
 			this.name = name;
 		}
 	}
@@ -121,11 +121,11 @@ public class DefaultGroupSequenceProviderTest {
 		@NotNull
 		private String name;
 
-		public String getName () {
+		public String getName() {
 			return name;
 		}
 
-		public void setName (String name) {
+		public void setName(String name) {
 			this.name = name;
 		}
 	}

--- a/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
+++ b/cdi/src/test/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProviderTest.java
@@ -28,18 +28,18 @@ public class DefaultGroupSequenceProviderTest {
 
 	@Test
 	public void withoutClassParam() {
-		Assert.assertThrows (() -> {
-			final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory ();
-			final Validator validator = validatorFactory.getValidator ();
-			validator.validate (new A1 ());
+		Assert.assertThrows(() -> {
+			final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+			final Validator validator = validatorFactory.getValidator();
+			validator.validate(new A1());
 		});
 	}
 
 	@Test
 	public void withClassParam() {
-		final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory ();
-		final Validator validator = validatorFactory.getValidator ();
-		validator.validate (new A2 ());
+		final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+		final Validator validator = validatorFactory.getValidator();
+		validator.validate(new A2());
 	}
 
 
@@ -47,9 +47,9 @@ public class DefaultGroupSequenceProviderTest {
 
 		@Override
 		public List<Class<?>> getValidationGroups(Object object) {
-			List<Class<?>> groups = new ArrayList<> ();
-			if ( Objects.nonNull (object) ) {
-				groups.add (object.getClass ());
+			List<Class<?>> groups = new ArrayList<>();
+			if ( Objects.nonNull(object) ) {
+				groups.add(object.getClass());
 			}
 			return groups;
 		}
@@ -60,16 +60,16 @@ public class DefaultGroupSequenceProviderTest {
 
 		@Override
 		public List<Class<?>> getValidationGroups(Class<?> clazz, Object object) {
-			List<Class<?>> groups = new ArrayList<> ();
-			if ( Objects.nonNull (clazz) ) {
-				groups.add (clazz);
+			List<Class<?>> groups = new ArrayList<>();
+			if ( Objects.nonNull(clazz) ) {
+				groups.add(clazz);
 			}
 			return groups;
 		}
 
 		@Override
 		public List<Class<?>> getValidationGroups(Object object) {
-			throw new IllegalArgumentException ("");
+			throw new IllegalArgumentException("");
 		}
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -325,7 +325,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	@Override
 	public List<Class<?>> getDefaultGroupSequence(T beanState) {
 		if ( hasDefaultGroupSequenceProvider() ) {
-			List<Class<?>> providerDefaultGroupSequence = defaultGroupSequenceProvider.getValidationGroups( beanState );
+			List<Class<?>> providerDefaultGroupSequence = defaultGroupSequenceProvider.getValidationGroups( beanClass, beanState );
 			return getValidDefaultGroupSequence( beanClass, providerDefaultGroupSequence );
 		}
 
@@ -335,7 +335,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	@Override
 	public Iterator<Sequence> getDefaultValidationSequence(T beanState) {
 		if ( hasDefaultGroupSequenceProvider() ) {
-			List<Class<?>> providerDefaultGroupSequence = defaultGroupSequenceProvider.getValidationGroups( beanState );
+			List<Class<?>> providerDefaultGroupSequence = defaultGroupSequenceProvider.getValidationGroups( beanClass, beanState );
 			return validationOrderGenerator.getDefaultValidationOrder(
 					beanClass,
 					getValidDefaultGroupSequence( beanClass, providerDefaultGroupSequence )

--- a/engine/src/main/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProvider.java
@@ -39,7 +39,7 @@ public interface DefaultGroupSequenceProvider<T> {
 	 * The object parameter allows to dynamically compose the default group sequence in function of the validated value state.
 	 * </p>
 	 *
-     * @param clazz the instance class being validated.
+     	 * @param clazz the instance class being validated.
 	 * @param object the instance being validated. This value can be {@code null} in case this method was called as part of
 	 * {@linkplain jakarta.validation.Validator#validateValue(Class, String, Object, Class[]) Validator#validateValue}.
 	 *

--- a/engine/src/main/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProvider.java
@@ -46,9 +46,10 @@ public interface DefaultGroupSequenceProvider<T> {
 	 * @return a list of classes specifying the default group sequence. The same constraints to the redefined group list
 	 *         apply as for lists defined via {@code GroupSequence}. In particular the list has to contain the type T.
 	 */
-	default List<Class<?>> getValidationGroups(Class<?> clazz, T object){
-        return getValidationGroups(object);
-    }
+	default List<Class<?>> getValidationGroups(Class<?> clazz, T object) {
+    	return getValidationGroups( object );
+	}
+
 	/**
 	 * This method returns the default group sequence for the given instance.
 	 * <p>

--- a/engine/src/main/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProvider.java
@@ -39,6 +39,22 @@ public interface DefaultGroupSequenceProvider<T> {
 	 * The object parameter allows to dynamically compose the default group sequence in function of the validated value state.
 	 * </p>
 	 *
+     * @param clazz the instance class being validated.
+	 * @param object the instance being validated. This value can be {@code null} in case this method was called as part of
+	 * {@linkplain jakarta.validation.Validator#validateValue(Class, String, Object, Class[]) Validator#validateValue}.
+	 *
+	 * @return a list of classes specifying the default group sequence. The same constraints to the redefined group list
+	 *         apply as for lists defined via {@code GroupSequence}. In particular the list has to contain the type T.
+	 */
+	default List<Class<?>> getValidationGroups(Class<?> clazz, T object){
+        return getValidationGroups(object);
+    }
+	/**
+	 * This method returns the default group sequence for the given instance.
+	 * <p>
+	 * The object parameter allows to dynamically compose the default group sequence in function of the validated value state.
+	 * </p>
+	 *
 	 * @param object the instance being validated. This value can be {@code null} in case this method was called as part of
 	 * {@linkplain jakarta.validation.Validator#validateValue(Class, String, Object, Class[]) Validator#validateValue}.
 	 *

--- a/engine/src/main/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProvider.java
@@ -47,7 +47,7 @@ public interface DefaultGroupSequenceProvider<T> {
 	 *         apply as for lists defined via {@code GroupSequence}. In particular the list has to contain the type T.
 	 */
 	default List<Class<?>> getValidationGroups(Class<?> clazz, T object) {
-    	return getValidationGroups( object );
+		return getValidationGroups( object );
 	}
 
 	/**


### PR DESCRIPTION
The provider can not get current class of instance when the instance is null When use a common DefaultGroupSequenceProvider for multi class. And the method of `BeanMetaDataImpl#getValidDefaultGroupSequence` checked must have the special group of `beanClass.getName()` and also can not return the default group of `Default.class`.


