### PR TITLE
HV-1949 Delay building constraint bean info from XML until all sources contributed to available constraint validators

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryConfigurationHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryConfigurationHelper.java
@@ -72,13 +72,6 @@ final class ValidatorFactoryConfigurationHelper {
 			 * these programmatically defined mappings into account when checking for constraint definition uniqueness
 			 */
 			constraintMappings.addAll( hibernateConfiguration.getProgrammaticMappings() );
-
-			// service loader based config
-			ConstraintMappingContributor serviceLoaderBasedContributor = new ServiceLoaderBasedConstraintMappingContributor(
-					typeResolutionHelper,
-					externalClassLoader != null ? externalClassLoader : run( GetClassLoader.fromContext() ) );
-			DefaultConstraintMappingBuilder builder = new DefaultConstraintMappingBuilder( javaBeanHelper, constraintMappings );
-			serviceLoaderBasedContributor.createConstraintMappings( builder );
 		}
 
 		// XML-defined constraint mapping contributors
@@ -90,6 +83,22 @@ final class ValidatorFactoryConfigurationHelper {
 			contributor.createConstraintMappings( builder );
 		}
 
+		return constraintMappings;
+	}
+
+	static Set<DefaultConstraintMapping> determineServiceLoadedConstraintMappings(
+			TypeResolutionHelper typeResolutionHelper,
+			JavaBeanHelper javaBeanHelper, ClassLoader externalClassLoader) {
+		Set<DefaultConstraintMapping> constraintMappings = newHashSet();
+
+		// service loader based config
+		ConstraintMappingContributor serviceLoaderBasedContributor = new ServiceLoaderBasedConstraintMappingContributor(
+				typeResolutionHelper,
+				externalClassLoader != null ? externalClassLoader : run( GetClassLoader.fromContext() )
+		);
+		DefaultConstraintMappingBuilder builder = new DefaultConstraintMappingBuilder(
+				javaBeanHelper, constraintMappings );
+		serviceLoaderBasedContributor.createConstraintMappings( builder );
 		return constraintMappings;
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/XmlMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/XmlMetaDataProvider.java
@@ -6,17 +6,14 @@
  */
 package org.hibernate.validator.internal.metadata.provider;
 
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import org.hibernate.validator.internal.engine.ConstraintCreationContext;
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptions;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
 import org.hibernate.validator.internal.metadata.raw.ConfigurationSource;
 import org.hibernate.validator.internal.metadata.raw.ConstrainedElement;
-import org.hibernate.validator.internal.properties.javabean.JavaBeanHelper;
 import org.hibernate.validator.internal.util.CollectionHelper;
 import org.hibernate.validator.internal.util.stereotypes.Immutable;
 import org.hibernate.validator.internal.xml.mapping.MappingXmlParser;
@@ -36,15 +33,7 @@ public class XmlMetaDataProvider implements MetaDataProvider {
 
 	private final AnnotationProcessingOptions annotationProcessingOptions;
 
-	public XmlMetaDataProvider(ConstraintCreationContext constraintCreationContext,
-			JavaBeanHelper javaBeanHelper,
-			Set<InputStream> mappingStreams,
-			ClassLoader externalClassLoader) {
-
-		MappingXmlParser mappingParser = new MappingXmlParser( constraintCreationContext,
-				javaBeanHelper, externalClassLoader );
-		mappingParser.parse( mappingStreams );
-
+	public XmlMetaDataProvider(MappingXmlParser mappingParser) {
 		configuredBeans = CollectionHelper.toImmutableMap( createBeanConfigurations( mappingParser ) );
 		annotationProcessingOptions = mappingParser.getAnnotationProcessingOptions();
 	}

--- a/engine/src/main/java/org/hibernate/validator/internal/xml/mapping/ConstraintMappingsStaxBuilder.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/mapping/ConstraintMappingsStaxBuilder.java
@@ -87,8 +87,16 @@ class ConstraintMappingsStaxBuilder extends AbstractStaxBuilder {
 		return new ConstraintDefinitionStaxBuilder( classLoadingHelper, constraintCreationContext.getConstraintHelper(), defaultPackageStaxBuilder );
 	}
 
-	public void build(Set<Class<?>> processedClasses, Map<Class<?>, Set<ConstrainedElement>> constrainedElementsByType, Set<String> alreadyProcessedConstraintDefinitions) {
+	public void buildConstraintDefinitions(Set<String> alreadyProcessedConstraintDefinitions) {
 		constraintDefinitionStaxBuilders.forEach( builder -> builder.build( alreadyProcessedConstraintDefinitions ) );
+	}
+
+	public void buildConstrainedElements(Set<Class<?>> processedClasses, Map<Class<?>, Set<ConstrainedElement>> constrainedElementsByType) {
 		beanStaxBuilders.forEach( builder -> builder.build( javaBeanHelper, processedClasses, constrainedElementsByType ) );
 	}
+
+	public boolean hasBeanBuilders() {
+		return !beanStaxBuilders.isEmpty();
+	}
+
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest.java
@@ -123,6 +123,25 @@ public class XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest {
 		);
 	}
 
+	@Test
+	public void constraintValidatorLoadedByServiceLoaderOverriddenByProgrammaticDefinition() {
+		final HibernateValidatorConfiguration configuration = ValidatorUtil.getConfiguration();
+		configuration.externalClassLoader( new ServiceLoaderTestingClassLoader() );
+
+		ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+		configuration.addMapping( constraintMapping );
+
+		constraintMapping.constraintDefinition( MyOtherConstraint.class )
+				.includeExistingValidators( false )
+				.validatedBy( MyOtherConstraint.MyOtherOtherConstraintValidator.class );
+
+		final ValidatorFactory validatorFactory = configuration.buildValidatorFactory();
+		final Validator validator = validatorFactory.getValidator();
+
+		assertNoViolations( validator.validate( new Foo() ) );
+		assertNoViolations( validator.validate( new Bar() ) );
+	}
+
 	public static class Foo {
 		public String string;
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest.java
@@ -1,0 +1,223 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.xml;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureClassLoader;
+import java.util.Enumeration;
+
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.cfg.ConstraintDef;
+import org.hibernate.validator.cfg.ConstraintMapping;
+import org.hibernate.validator.testutils.ValidatorUtil;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.testng.annotations.Test;
+
+public class XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest {
+
+	@Test
+	public void constraintAppliedInXmlDefinitionIsAppliedThroughProgrammaticMapping() {
+		final HibernateValidatorConfiguration configuration = ValidatorUtil.getConfiguration();
+		configuration.addMapping( XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest.class.getResourceAsStream( "hv-1949-mapping.xml" ) );
+		ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+		configuration.addMapping( constraintMapping );
+
+		constraintMapping.constraintDefinition( MyOtherConstraint.class )
+				.includeExistingValidators( true )
+				.validatedBy( MyOtherConstraint.MyOtherConstraintValidator.class );
+
+		final ValidatorFactory validatorFactory = configuration.buildValidatorFactory();
+		final Validator validator = validatorFactory.getValidator();
+
+		assertThat( validator.validate( new Foo() ) ).containsOnlyViolations(
+				violationOf( MyOtherConstraint.class ).withProperty( "string" )
+		);
+		assertThat( validator.validate( new Bar() ) ).containsOnlyViolations(
+				violationOf( MyOtherConstraint.class ).withProperty( "string" )
+		);
+	}
+
+	@Test
+	public void constraintAppliedInXmlDefinitionIsAppliedThroughServiceLoading() {
+		final HibernateValidatorConfiguration configuration = ValidatorUtil.getConfiguration();
+		configuration.addMapping( XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest.class.getResourceAsStream( "hv-1949-mapping.xml" ) );
+		configuration.externalClassLoader( new ServiceLoaderTestingClassLoader() );
+
+		final ValidatorFactory validatorFactory = configuration.buildValidatorFactory();
+		final Validator validator = validatorFactory.getValidator();
+
+		assertThat( validator.validate( new Foo() ) ).containsOnlyViolations(
+				violationOf( MyOtherConstraint.class ).withProperty( "string" )
+		);
+		assertThat( validator.validate( new Bar() ) ).containsOnlyViolations(
+				violationOf( MyOtherConstraint.class ).withProperty( "string" )
+		);
+	}
+
+	@Test
+	public void constraintAppliedInXmlDefinitionIsAppliedThroughXmlOverriddenWithProgrammatic() {
+		final HibernateValidatorConfiguration configuration = ValidatorUtil.getConfiguration();
+		configuration.addMapping( XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest.class.getResourceAsStream( "hv-1949-mapping.xml" ) );
+		configuration.addMapping( XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest.class.getResourceAsStream( "hv-1949-constraint.xml" ) );
+
+		ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+		configuration.addMapping( constraintMapping );
+
+		constraintMapping.constraintDefinition( MyOtherConstraint.class )
+				.includeExistingValidators( false )
+				.validatedBy( MyOtherConstraint.MyOtherOtherConstraintValidator.class );
+
+		final ValidatorFactory validatorFactory = configuration.buildValidatorFactory();
+		final Validator validator = validatorFactory.getValidator();
+
+		assertNoViolations( validator.validate( new Foo() ) );
+		assertNoViolations( validator.validate( new Bar() ) );
+	}
+
+	@Test
+	public void constraintAppliedProgrammaticallyDefinitionIsAppliedThroughXml() {
+		final HibernateValidatorConfiguration configuration = ValidatorUtil.getConfiguration();
+		configuration.addMapping( XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest.class.getResourceAsStream( "hv-1949-constraint.xml" ) );
+		ConstraintMapping constraintMapping = configuration.createConstraintMapping();
+		configuration.addMapping( constraintMapping );
+
+		constraintMapping.type( Foo.class )
+				.field( "string" )
+				.constraint( new MyOtherConstraintDef() );
+
+		final ValidatorFactory validatorFactory = configuration.buildValidatorFactory();
+		final Validator validator = validatorFactory.getValidator();
+
+		assertThat( validator.validate( new Foo() ) ).containsOnlyViolations(
+				violationOf( MyOtherConstraint.class ).withProperty( "string" )
+		);
+		assertThat( validator.validate( new Bar() ) ).containsOnlyViolations(
+				violationOf( MyOtherConstraint.class ).withProperty( "string" )
+		);
+	}
+
+	public static class Foo {
+		public String string;
+	}
+
+	public static class Bar {
+		@MyOtherConstraint
+		public String string;
+	}
+
+	public static class MyOtherConstraintDef extends ConstraintDef<MyOtherConstraintDef, MyOtherConstraint> {
+
+		protected MyOtherConstraintDef() {
+			super( MyOtherConstraint.class );
+		}
+	}
+
+	@Documented
+	@Constraint(validatedBy = {})
+	@Target({ TYPE, METHOD, FIELD })
+	@Retention(RUNTIME)
+	public @interface MyOtherConstraint {
+
+		String message() default "MyOtherConstraint is not valid";
+
+		Class<?>[] groups() default {};
+
+		Class<? extends Payload>[] payload() default {};
+
+		class MyOtherConstraintValidator implements ConstraintValidator<MyOtherConstraint, Object> {
+
+			@Override
+			public boolean isValid(Object value, ConstraintValidatorContext context) {
+				return false;
+			}
+		}
+
+		class MyOtherOtherConstraintValidator implements ConstraintValidator<MyOtherConstraint, Object> {
+
+			@Override
+			public boolean isValid(Object value, ConstraintValidatorContext context) {
+				return true;
+			}
+		}
+	}
+
+	/*
+	 * A classloader that allows to use a `META-INF/services/jakarta.validation.ConstraintValidator`
+	 * defined in the tests rather than reading it from an actual file.
+	 */
+	private static class ServiceLoaderTestingClassLoader extends SecureClassLoader {
+
+		private static final String SERVICE_FILE = "META-INF/services/" + ConstraintValidator.class.getName();
+
+		public ServiceLoaderTestingClassLoader() {
+			super( ServiceLoaderTestingClassLoader.class.getClassLoader() );
+		}
+
+		@Override
+		public Enumeration<URL> getResources(String name) throws IOException {
+			if ( SERVICE_FILE.equals( name ) ) {
+				URL url = new URL( "protocol", "host", -1, "file", new URLStreamHandler() {
+					@Override
+					protected URLConnection openConnection(URL u) {
+						return new URLConnection( u ) {
+							@Override
+							public void connect() {
+							}
+
+							@Override
+							public InputStream getInputStream() {
+								return new ByteArrayInputStream(
+										MyOtherConstraint.MyOtherConstraintValidator.class.getName()
+												.getBytes( StandardCharsets.UTF_8 )
+								);
+							}
+						};
+					}
+				} );
+				return new Enumeration<>() {
+					private boolean hasMore = true;
+
+					@Override
+					public boolean hasMoreElements() {
+						return hasMore;
+					}
+
+					@Override
+					public URL nextElement() {
+						hasMore = false;
+						return url;
+					}
+				};
+			}
+			return super.getResources( name );
+		}
+	}
+
+}

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/hv-1949-constraint.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/hv-1949-constraint.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<constraint-mappings
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
+        version="3.0">
+
+    <constraint-definition
+            annotation="org.hibernate.validator.test.internal.xml.XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest$MyOtherConstraint">
+        <validated-by>
+            <value>
+                org.hibernate.validator.test.internal.xml.XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest$MyOtherConstraint$MyOtherConstraintValidator
+            </value>
+        </validated-by>
+    </constraint-definition>
+</constraint-mappings>

--- a/engine/src/test/resources/org/hibernate/validator/test/internal/xml/hv-1949-mapping.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/internal/xml/hv-1949-mapping.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<constraint-mappings
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping
+            https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
+        version="3.0">
+
+    <bean class="org.hibernate.validator.test.internal.xml.XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest$Foo">
+        <field name="string">
+            <constraint
+                    annotation="org.hibernate.validator.test.internal.xml.XmlMappingMixedWithServiceLoaderAndProgrammaticDefinitionTest$MyOtherConstraint">
+            </constraint>
+        </field>
+    </bean>
+</constraint-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1949

The problem was that we were building constrained elements for the XML provider only based on the info collected from XML itself + whatever was already a part of constraint helper. This was ignoring any info set by ServiceLoading or coming from programmatic definitions. As a result, constrained elements created from XML data were missing the validators. 

The idea for the fix is to process all constraint definitions from all sources, as those can override whatever was set by previous providers and only then start building the bean metadata.

If this makes sense and there's no suggestions for better names for new methods 🙈 🥲  I'll prepare a backport to 6.2 (assuming we'd want the fix to be included there too)