### PR TITLE
[HV-1943] Fix french validation messages for decimals (version 6)

### DIFF
--- a/engine/src/main/resources/org/hibernate/validator/ValidationMessages_fr.properties
+++ b/engine/src/main/resources/org/hibernate/validator/ValidationMessages_fr.properties
@@ -1,7 +1,7 @@
 javax.validation.constraints.AssertFalse.message     = doit avoir la valeur faux
 javax.validation.constraints.AssertTrue.message      = doit avoir la valeur vrai
-javax.validation.constraints.DecimalMax.message      = doit \u00eatre inf\u00e9rieur ${inclusive == true ? 'ou \u00e9gal' : ''} \u00e0 {value}
-javax.validation.constraints.DecimalMin.message      = doit \u00eatre sup\u00e9rieur ${inclusive == true ? 'ou \u00e9gal' : ''} \u00e0 {value}
+javax.validation.constraints.DecimalMax.message      = doit \u00eatre inf\u00e9rieur${inclusive == true ? ' ou \u00e9gal' : ''} \u00e0 {value}
+javax.validation.constraints.DecimalMin.message      = doit \u00eatre sup\u00e9rieur${inclusive == true ? ' ou \u00e9gal' : ''} \u00e0 {value}
 javax.validation.constraints.Digits.message          = valeur num\u00e9rique hors limites (<{integer} chiffres>.<{fraction} chiffres> attendu)
 javax.validation.constraints.Email.message           = doit \u00eatre une adresse \u00e9lectronique syntaxiquement correcte
 javax.validation.constraints.Future.message          = doit \u00eatre une date dans le futur


### PR DESCRIPTION
Hi,

I reworked french validation messages for Decimals, a white space is ok but two is too much ;)

Previous ticket about validation messages issues for french locale : https://hibernate.atlassian.net/browse/HV-1943