### PR TITLE
HV-1961 Upgrade maven-surefire-plugin/maven-failsafe-plugin version to 3.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,8 +237,7 @@
         <version.shade.plugin>3.1.0</version.shade.plugin>
         <version.sigtest.plugin>1.6</version.sigtest.plugin>
         <version.source.plugin>3.0.1</version.source.plugin>
-        <version.surefire.plugin>2.21.0</version.surefire.plugin>
-        <version.surefire.plugin.java-version.asm>9.2</version.surefire.plugin.java-version.asm>
+        <version.surefire.plugin>3.1.2</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.wildfly.plugin>1.2.1.Final</version.wildfly.plugin>
         <version.org.wildfly.core>14.0.0.Final</version.org.wildfly.core>
@@ -882,11 +881,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${version.surefire.plugin}</version>
                     <configuration>
-                        <forkMode>once</forkMode>
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
-                        <includes>
-                            <include>**/*Test.java</include>
-                        </includes>
                         <jvm>${java-version.test.launcher}</jvm>
                         <argLine>${surefire.jvm.args}</argLine>
                         <reportNameSuffix>${surefire.environment}</reportNameSuffix>
@@ -896,19 +891,6 @@
                             <JAVA_HOME>${java-version.test.launcher.java_home}</JAVA_HOME>
                         </environmentVariables>
                     </configuration>
-                    <dependencies>
-                        <!--
-                             maven-surefire-plugin and maven-failsafe-plugin use an older version of ASM
-                             that cannot handle Java 15+ bytecode.
-                             Let's upgrade that dependency and hope for the best;
-                             if it doesn't work, the build is very likely to fail and we'll know about it.
-                         -->
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>${version.surefire.plugin.java-version.asm}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-report-plugin</artifactId>
@@ -923,7 +905,6 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <outputDirectory>${project.build.directory}/surefire-reports</outputDirectory>
                         <outputName>test-report</outputName>
                     </configuration>
                 </plugin>
@@ -940,19 +921,6 @@
                             <JAVA_HOME>${java-version.test.launcher.java_home}</JAVA_HOME>
                         </environmentVariables>
                     </configuration>
-                    <dependencies>
-                        <!--
-                             maven-surefire-plugin and maven-failsafe-plugin use an older version of ASM
-                             that cannot handle Java 15+ bytecode.
-                             Let's upgrade that dependency and hope for the best;
-                             if it doesn't work, the build is very likely to fail and we'll know about it.
-                         -->
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>${version.surefire.plugin.java-version.asm}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
@@ -984,21 +952,6 @@
                     <artifactId>asciidoctor-maven-plugin</artifactId>
                     <version>${version.asciidoctor.plugin}</version>
                     <dependencies>
-                        <dependency>
-                            <groupId>org.jruby</groupId>
-                            <artifactId>jruby-complete</artifactId>
-                            <version>${version.org.jruby}</version>
-                        </dependency>
-                         <dependency>
-                            <groupId>org.asciidoctor</groupId>
-                            <artifactId>asciidoctorj</artifactId>
-                            <version>${version.org.asciidoctor.asciidoctorj}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.asciidoctor</groupId>
-                            <artifactId>asciidoctorj-pdf</artifactId>
-                            <version>${version.org.asciidoctor.asciidoctorj-pdf}</version>
-                        </dependency>
                         <dependency>
                             <groupId>org.hibernate.infra</groupId>
                             <artifactId>hibernate-asciidoctor-extensions</artifactId>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -162,12 +162,9 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${tck.suite.file}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <systemProperties>
-                        <property>
-                            <name>validation.provider</name>
-                            <value>${validation.provider}</value>
-                        </property>
-                    </systemProperties>
+                    <systemPropertyVariables>
+                        <validation.provider>${validation.provider}</validation.provider>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>
@@ -183,7 +180,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <outputDirectory>${project.build.directory}/surefire-reports</outputDirectory>
                     <outputName>test-report</outputName>
                 </configuration>
             </plugin>
@@ -220,16 +216,10 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <systemProperties>
-                                <property>
-                                    <name>validation.provider</name>
-                                    <value>${validation.provider}</value>
-                                </property>
-                                <property>
-                                    <name>excludeIntegrationTests</name>
-                                    <value>true</value>
-                                </property>
-                            </systemProperties>
+                            <systemPropertyVariables>
+                                <validation.provider>${validation.provider}</validation.provider>
+                                <excludeIntegrationTests>true</excludeIntegrationTests>
+                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -365,7 +355,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <forkMode>once</forkMode>
                             <systemPropertyVariables>
                                 <arquillian.launch>incontainer</arquillian.launch>
                             </systemPropertyVariables>
@@ -398,7 +387,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <forkMode>once</forkMode>
                             <systemPropertyVariables>
                                 <arquillian.launch>incontainer</arquillian.launch>
                             </systemPropertyVariables>


### PR DESCRIPTION
 - Upgraded maven-surefire-plugin/maven-failsafe-plugin/maven-surefire-report-plugin to 3.1.2
 - Removed version.surefire.plugin.java-version.asm because it's not used anymore
   - removed also the supplemental dependency of maven-surefire-plugin/maven-failsafe-plugin
 - Replaced deperecated systemProperties with systemPropertyVariables
 - Removed deprecated outputDirectory parameter for maven-surefire-report-plugin
 - Removed invalid forkMode configuration
 - Removed includes configuration for maven-surefire-plugin because it's already default.

https://hibernate.atlassian.net/browse/HV-1961

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
