### PR TITLE
HV-1962 - Remove relativePath in pom because it's default

### DIFF
--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -12,7 +12,6 @@
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator-parent</artifactId>
         <version>9.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-validator-build-config</artifactId>

--- a/osgi/felixtest/pom.xml
+++ b/osgi/felixtest/pom.xml
@@ -11,7 +11,6 @@
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator-osgi</artifactId>
         <version>8.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-validator-osgi-felixtest</artifactId>

--- a/osgi/integrationtest/pom.xml
+++ b/osgi/integrationtest/pom.xml
@@ -12,7 +12,6 @@
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator-osgi</artifactId>
         <version>8.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-validator-osgi-integrationtest</artifactId>

--- a/osgi/karaf-features/pom.xml
+++ b/osgi/karaf-features/pom.xml
@@ -12,7 +12,6 @@
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator-osgi</artifactId>
         <version>8.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-validator-osgi-karaf-features</artifactId>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -12,7 +12,6 @@
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator-parent</artifactId>
         <version>8.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-validator-osgi</artifactId>

--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -12,7 +12,6 @@
         <groupId>org.hibernate.validator</groupId>
         <artifactId>hibernate-validator-parent</artifactId>
         <version>9.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-validator-performance</artifactId>


### PR DESCRIPTION
 - Removed relativePath entries.

https://hibernate.atlassian.net/browse/HV-1962