### PR TITLE
HV-1965 Typo found in assertion fail message fixed

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/CrossParameterConstraintValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/CrossParameterConstraintValidatorContextImpl.java
@@ -34,7 +34,7 @@ public class CrossParameterConstraintValidatorContextImpl extends ConstraintVali
 			ExpressionLanguageFeatureLevel customViolationExpressionLanguageFeatureLevel) {
 		super( clockProvider, propertyPath, constraintDescriptor, constraintValidatorPayload, constraintExpressionLanguageFeatureLevel,
 				customViolationExpressionLanguageFeatureLevel );
-		Contracts.assertTrue( propertyPath.getLeafNode().getKind() == ElementKind.CROSS_PARAMETER, "Context can only be used for corss parameter validation" );
+		Contracts.assertTrue( propertyPath.getLeafNode().getKind() == ElementKind.CROSS_PARAMETER, "Context can only be used for cross parameter validation" );
 		this.methodParameterNames = methodParameterNames;
 	}
 


### PR DESCRIPTION
Typo found in assertion fail message in CrossParameterConstintValidatorContextImpl is fixed.
Jira issue: https://hibernate.atlassian.net/browse/HV-1965