### PR TITLE
[HV-1928] reduces calls to isSubPathOf

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/PathImpl.java
@@ -453,4 +453,21 @@ public final class PathImpl implements Path, Serializable {
 		}
 		return true;
 	}
+
+	public boolean isSubPathOrContains(PathImpl other) {
+
+		// prefetch contant return values
+		int oSize = other.nodeList.size();
+		// calling Math.min will reduce speed significantly
+		int mySize = nodeList.size() < oSize
+				? nodeList.size()
+				: oSize;
+
+		for ( int i = 0; i < mySize; i++ ) {
+			if ( !nodeList.get( i ).equals( other.nodeList.get( i ) ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/AbstractValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/AbstractValidationContext.java
@@ -48,6 +48,7 @@ import org.hibernate.validator.messageinterpolation.ExpressionLanguageFeatureLev
  * @author Gunnar Morling
  * @author Guillaume Smet
  * @author Marko Bekhta
+ * @author Thomas Strauß
  */
 abstract class AbstractValidationContext<T> implements BaseBeanValidationContext<T> {
 
@@ -344,7 +345,7 @@ abstract class AbstractValidationContext<T> implements BaseBeanValidationContext
 		}
 
 		for ( PathImpl p : pathSet ) {
-			if ( path.isRootPath() || p.isRootPath() || isSubPathOf( path, p ) || isSubPathOf( p, path ) ) {
+			if ( pathsSharePrefix( p, path ) ) {
 				return true;
 			}
 		}
@@ -352,19 +353,34 @@ abstract class AbstractValidationContext<T> implements BaseBeanValidationContext
 		return false;
 	}
 
-	private boolean isSubPathOf(Path p1, Path p2) {
+	/**
+	 * this method compares two PathImpl to decide if either one is a prefix of the other.
+	 *
+	 * @param p1 first Path
+	 * @param p2 second Path
+	 * @return true if p1 ⊃ p2 or p2 ⊃ p1
+	 */
+	private boolean pathsSharePrefix(PathImpl p1, PathImpl p2) {
+		// root path is a common prefix of any path != null
+		if ( p1.isRootPath() || p2.isRootPath() ) {
+			return true;
+		}
+
+		// at this point, p1 and p2 will have at least one element in the iterator
 		Iterator<Path.Node> p1Iter = p1.iterator();
 		Iterator<Path.Node> p2Iter = p2.iterator();
 		while ( p1Iter.hasNext() ) {
 			Path.Node p1Node = p1Iter.next();
 			if ( !p2Iter.hasNext() ) {
-				return false;
+				// p1 ⊃ p2
+				return true;
 			}
 			Path.Node p2Node = p2Iter.next();
 			if ( !p1Node.equals( p2Node ) ) {
 				return false;
 			}
 		}
+		// p2 ⊃ p1
 		return true;
 	}
 
@@ -434,6 +450,7 @@ abstract class AbstractValidationContext<T> implements BaseBeanValidationContext
 
 		@Override
 		public boolean equals(Object o) {
+			// null check intentionally left out
 			if ( this == o ) {
 				return true;
 			}
@@ -482,6 +499,7 @@ abstract class AbstractValidationContext<T> implements BaseBeanValidationContext
 
 		@Override
 		public boolean equals(Object o) {
+			// null check intentionally left out
 			if ( this == o ) {
 				return true;
 			}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/path/PathImplTest.java
@@ -50,6 +50,7 @@ import org.testng.annotations.Test;
  * @author Hardy Ferentschik
  * @author Gunnar Morling
  * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
+ * @author Thomas Strauß
  */
 public class PathImplTest {
 
@@ -164,6 +165,28 @@ public class PathImplTest {
 	public void testEmptyString() {
 		Path path = PathImpl.createPathFromString( "" );
 		assertTrue( path.iterator().hasNext() );
+	}
+
+	@Test
+	public void testIsSubPathOrContains() {
+		PathImpl rootPath = PathImpl.createPathFromString( "" );
+		PathImpl subPath = PathImpl.createPathFromString( "annotation" );
+		PathImpl middlePath = PathImpl.createPathFromString( "annotation.property" );
+		PathImpl middlePath2 = PathImpl.createPathFromString( "annotation.property[2]" );
+		PathImpl middlePath3 = PathImpl.createPathFromString( "annotation.property[3]" );
+		PathImpl fullPath3 = PathImpl.createPathFromString( "annotation.property[3].element" );
+		PathImpl fullPath4 = PathImpl.createPathFromString( "annotation.property[4].element" );
+
+		assertTrue( rootPath.isSubPathOrContains( middlePath ), "root path is in every path" );
+		assertTrue( middlePath.isSubPathOrContains( rootPath ), "every path contains the root path" );
+		assertTrue( subPath.isSubPathOrContains( middlePath ), "bean is subpath of its properties" );
+		assertTrue( middlePath.isSubPathOrContains( subPath ), "a property is an extension of its bean" );
+		assertTrue( subPath.isSubPathOrContains( fullPath3 ), "bean is subpath of its tree" );
+		assertTrue( subPath.isSubPathOrContains( fullPath4 ), "bean is subpath of its tree, for every array index" );
+		assertFalse( middlePath.isSubPathOrContains( fullPath3 ), "property is not a subpath of an array" );
+		assertFalse( middlePath3.isSubPathOrContains( fullPath3 ), "array property is not a subpath of a property of a bean in an array" );
+		assertFalse( middlePath2.isSubPathOrContains( fullPath3 ), "array element is not a subpath of another element's children" );
+		assertFalse( fullPath3.isSubPathOrContains( fullPath4 ), "different array elements are not subpaths of the other" );
 	}
 
 	@Test


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1928

does not fix the issue but reduces the calls to isSubPathOf by one. 

Refactors isSubPathOf() to pathsSharePrefix() to make the semantic change clear.