### PR TITLE
Update asciidoctor configuration and theme

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -30,8 +30,6 @@
         <asciidoctor.engine-source-dir>${basedir}/../engine/src/main/java</asciidoctor.engine-source-dir>
         <asciidoctor.osgi-integrationtest-source-dir>${basedir}/../osgi/integrationtest/src/test/java</asciidoctor.osgi-integrationtest-source-dir>
 
-        <html.meta.description>Hibernate Validator, Annotation based constraints for your domain model - Reference Documentation</html.meta.description>
-        <html.meta.keywords>hibernate, validator, hibernate validator, validation, jakarta bean validation, bean validation</html.meta.keywords>
         <html.meta.project-key>validator</html.meta.project-key>
         <html.google-analytics.id>G-282CVRCQHZ</html.google-analytics.id>
         <html.outdated-content.project-key>${html.meta.project-key}</html.outdated-content.project-key>

--- a/documentation/src/main/asciidoc/index.asciidoc
+++ b/documentation/src/main/asciidoc/index.asciidoc
@@ -11,6 +11,9 @@ Hardy Ferentschik; Gunnar Morling; Guillaume Smet
 :docinfodir: {docinfodir}
 :docinfo: shared,private
 :title-logo-image: image:hibernate_logo_a.png[align=left,pdfwidth=33%]
+:html-meta-description: Hibernate Validator, Annotation based constraints for your domain model - Reference Documentation
+:html-meta-keywords: hibernate, validator, hibernate validator, validation, jakarta bean validation, bean validation
+:html-meta-canonical-link: https://docs.jboss.org/hibernate/stable/validator/reference/en-US/html_single/
 
 include::pr01.asciidoc[]
 

--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <!-- Asciidoctor -->
 
         <version.asciidoctor.plugin>2.2.4</version.asciidoctor.plugin>
-        <version.org.hibernate.infra.hibernate-asciidoctor-theme>2.0.0.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
+        <version.org.hibernate.infra.hibernate-asciidoctor-theme>4.0.0.Final</version.org.hibernate.infra.hibernate-asciidoctor-theme>
         <version.org.hibernate.infra.hibernate-asciidoctor-extensions>2.0.0.Final</version.org.hibernate.infra.hibernate-asciidoctor-extensions>
         <version.org.jruby>9.3.2.0</version.org.jruby>
         <version.org.asciidoctor.asciidoctorj>2.5.10</version.org.asciidoctor.asciidoctorj>


### PR DESCRIPTION
While this is not really needed for Validator, let's keep it updated and using the latest theme so we won't forget to address this change once we actually would need to use a newer version of the theme for Validator.