### PR TITLE
"backport" of HV-1980/HV-1981 to 8.0  - Update gpg plugin configuration / Use Maven 3.9.6 in CI builds and as a required minimum version for the build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ import org.hibernate.jenkins.pipeline.helpers.alternative.AlternativeMultiMap
  */
 
 @Field final String DEFAULT_JDK_TOOL = 'OpenJDK 17 Latest'
-@Field final String MAVEN_TOOL = 'Apache Maven 3.6'
+@Field final String MAVEN_TOOL = 'Apache Maven 3.9'
 
 // Default node pattern, to be used for resource-intensive stages.
 // Should not include the controller node.

--- a/jenkins/release.groovy
+++ b/jenkins/release.groovy
@@ -68,8 +68,9 @@ pipeline {
 							mavenLocalRepo: env.WORKSPACE_TMP + '/.m2repository') {
 						configFileProvider([configFile(fileId: 'release.config.ssh', targetLocation: env.HOME + '/.ssh/config'),
 											configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: env.HOME + '/.ssh/known_hosts')]) {
+							// using MAVEN_GPG_PASSPHRASE (the default env variable name for passphrase in maven gpg plugin)
 							withCredentials([file(credentialsId: 'release.gpg.private-key', variable: 'RELEASE_GPG_PRIVATE_KEY_PATH'),
-											 string(credentialsId: 'release.gpg.passphrase', variable: 'RELEASE_GPG_PASSPHRASE')]) {
+											 string(credentialsId: 'release.gpg.passphrase', variable: 'MAVEN_GPG_PASSPHRASE')]) {
 								sshagent(['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net']) {
 									sh 'cat $HOME/.ssh/config'
 									sh 'git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git'

--- a/pom.xml
+++ b/pom.xml
@@ -326,7 +326,8 @@
 
         <!-- JDK version required for the build -->
         <jdk.min.version>17</jdk.min.version>
-        <maven.min.version>3.3.1</maven.min.version>
+        <!-- Maven version required for the build -->
+        <maven.min.version>3.9.6</maven.min.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1365,7 +1365,7 @@
                                 </goals>
                                 <configuration>
                                     <homedir>${env.RELEASE_GPG_HOMEDIR}</homedir>
-                                    <passphrase>${env.RELEASE_GPG_PASSPHRASE}</passphrase>
+                                    <bestPractices>true</bestPractices>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1980
https://hibernate.atlassian.net/browse/HV-1981