### PR TITLE
HV-1998 Use project.build.outputTimestamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,8 @@
     </modules>
 
     <properties>
+        <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
+
         <!-- Version to be used as baseline for API/SPI change reports -->
 
         <previous.stable>6.0.10.Final</previous.stable>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1998

the result of
```bash
mvn clean verify artifact:compare -DskipTests -Dbuildinfo.detect.skip=false -Dcompare.fail=false
```
is:
```
version=9.0.0-SNAPSHOT
ok=22
ko=1
ignored=0
okFiles="hibernate-validator-parent-9.0.0-SNAPSHOT.pom hibernate-validator-build-config-9.0.0-SNAPSHOT.pom hibernate-validator-build-config-9.0.0-SNAPSHOT.jar hibernate-validator-test-utils-9.0.0-SNAPSHOT.pom hibernate-validator-test-utils-9.0.0-SNAPSHOT.jar hibernate-validator-9.0.0-SNAPSHOT.pom hibernate-validator-9.0.0-SNAPSHOT.jar hibernate-validator-tck-runner-9.0.0-SNAPSHOT.pom hibernate-validator-tck-runner-9.0.0-SNAPSHOT.jar hibernate-validator-annotation-processor-9.0.0-SNAPSHOT.pom hibernate-validator-annotation-processor-9.0.0-SNAPSHOT.jar hibernate-validator-performance-9.0.0-SNAPSHOT.pom hibernate-validator-performance-9.0.0-SNAPSHOT.jar hibernate-validator-cdi-9.0.0-SNAPSHOT.pom hibernate-validator-cdi-9.0.0-SNAPSHOT.jar hibernate-validator-modules-9.0.0-SNAPSHOT.pom hibernate-validator-integrationtest-wildfly-9.0.0-SNAPSHOT.pom hibernate-validator-integrationtest-wildfly-9.0.0-SNAPSHOT.jar hibernate-validator-documentation-9.0.0-SNAPSHOT.pom hibernate-validator-documentation-9.0.0-SNAPSHOT.jar hibernate-validator-distribution-9.0.0-SNAPSHOT.pom hibernate-validator-distribution-9.0.0-SNAPSHOT.jar"
koFiles="hibernate-validator-modules-9.0.0-SNAPSHOT-wildfly-28.0.1.Final-patch.zip"
ignoredFiles=""
reference_java_version="17 (from MANIFEST.MF Build-Jdk-Spec)"
reference_os_name="Unix (from pom.properties newline)"
# diffoscope target/reference/org.hibernate.validator/hibernate-validator-modules-9.0.0-SNAPSHOT-wildfly-28.0.1.Final-patch.zip modules/target/wildfly-current-hv-patch.zip
```

and with https://github.com/hibernate/hibernate-validator/pull/1357 merged, we should get all the artifacts that we publish in the ok list.