### PR TITLE
Backport of HV-1989 to 8.0  -  Update documentation examples to use the min required Java version where applicable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The full list of changes for this release can be found in changelog.txt.
 
 ## System Requirements
 
-JDK 8 or above.
+JDK 11 or above.
 
 ## Using Hibernate Validator
 

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -171,7 +171,7 @@
                                 <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                                 <manifestEntries>
                                     <Specification-Title>Jakarta Bean Validation</Specification-Title>
-                                    <Specification-Version>2.0</Specification-Version>
+                                    <Specification-Version>3.0</Specification-Version>
                                     <Automatic-Module-Name>${hibernate-validator-cdi.module-name}</Automatic-Module-Name>
                                 </manifestEntries>
                             </archive>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -294,6 +294,9 @@
                         <wildflyVersion>${version.wildfly}</wildflyVersion>
                         <wildflySecondaryVersion>${version.wildfly.secondary}</wildflySecondaryVersion>
 
+                        <jdkVersion>${java-version.main.release}</jdkVersion>
+                        <compilerPluginVersion>${version.compiler.plugin}</compilerPluginVersion>
+
                         <!-- URLs -->
                         <javaApiDocsUrl>${java.api-docs.base-url}/</javaApiDocsUrl>
                         <bvApiDocsUrl>${bv.api-docs.base-url}/</bvApiDocsUrl>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -289,7 +289,6 @@
                         <bvVersion>${version.jakarta.validation-api}</bvVersion>
                         <jbossLoggingVersion>${version.org.jboss.logging.jboss-logging}</jbossLoggingVersion>
                         <classmateVersion>${version.com.fasterxml.classmate}</classmateVersion>
-                        <jakartaElVersion>${version.org.glassfish.jakarta.el}</jakartaElVersion>
                         <expresslyVersion>${version.org.glassfish.expressly}</expresslyVersion>
 
                         <wildflyVersion>${version.wildfly}</wildflyVersion>

--- a/documentation/src/main/asciidoc/ch01.asciidoc
+++ b/documentation/src/main/asciidoc/ch01.asciidoc
@@ -191,10 +191,10 @@ $JBOSS_HOME/bin/jboss-cli.sh patch rollback --reset-configuration=true
 
 You can learn more about the WildFly patching infrastructure in general https://developer.jboss.org/wiki/SingleInstallationPatching/[here] and http://www.mastertheboss.com/jboss-server/jboss-configuration/managing-wildfly-and-eap-patches[here].
 
-[[validator-gettingstarted-java9]]
-==== Running on Java 11+
+[[validator-gettingstarted-modulepath]]
+==== [[validator-gettingstarted-java9]] Running in the modulepath
 
-Support for Java 11 and the Java Platform Module System (JPMS) is present in a preliminary form.
+Support for the Java Platform Module System (JPMS) is present in a preliminary form.
 There are no JPMS module descriptors provided, but Hibernate Validator is usable as automatic modules.
 
 These are the module names as declared using the `Automatic-Module-Name` header:

--- a/documentation/src/main/asciidoc/ch13.asciidoc
+++ b/documentation/src/main/asciidoc/ch13.asciidoc
@@ -94,10 +94,10 @@ For using the Hibernate Validator annotation processor with Maven, set it up via
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>{compilerPluginVersion}</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>{jdkVersion}</source>
+                    <target>{jdkVersion}</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.hibernate.validator</groupId>
@@ -185,7 +185,7 @@ provided you have the https://www.eclipse.org/m2e/[M2E Eclipse plug-in] installe
 For plain Eclipse projects follow these steps to set up the annotation processor:
 
 * Right-click your project, choose "Properties"
-* Go to "Java Compiler" and make sure, that "Compiler compliance level" is set to "1.8".
+* Go to "Java Compiler" and make sure, that "Compiler compliance level" is set to "{jdkVersion}".
 Otherwise the processor won't be activated
 * Go to "Java Compiler - Annotation Processing" and choose "Enable annotation processing"
 * Go to "Java Compiler - Annotation Processing - Factory Path" and add the JAR


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1989

backport of https://github.com/hibernate/hibernate-validator/pull/1362