### PR TITLE
HV-1988 Bump jboss-logging to 3.6.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <version.com.thoughtworks.paranamer>2.8</version.com.thoughtworks.paranamer>
         <version.jakarta.el-api>5.0.1</version.jakarta.el-api>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
-        <version.org.jboss.logging.jboss-logging>3.5.3.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging>3.6.0.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
 
         <!-- Currently supported version of WildFly -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1988

Looks like logging now works with the latest WildFly 32.0.1. let's see if CI agrees. 