### PR TITLE
Backport of HV-2002 to 6.2 - Fixing mod11 check for Titulo Eleitoral

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/constraints/br/TituloEleitoral.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/br/TituloEleitoral.java
@@ -30,7 +30,7 @@ import org.hibernate.validator.constraints.Mod11Check;
 import org.hibernate.validator.constraints.br.TituloEleitoral.List;
 
 /**
- * Validates a <a href="http://ghiorzi.org/cgcancpf.htm">T\u00edtulo Eleitoral</a> (Brazilian Voter ID card number).
+ * Validates a <a href="https://pt.wikipedia.org/wiki/T%C3%ADtulo_de_eleitor">T\u00edtulo Eleitoral</a> (Brazilian Voter ID card number).
  *
  * @author George Gastaldi
  */
@@ -38,11 +38,13 @@ import org.hibernate.validator.constraints.br.TituloEleitoral.List;
 @Mod11Check.List({
 		@Mod11Check(threshold = 9,
 				endIndex = 7,
-				checkDigitIndex = 10),
+				checkDigitIndex = 10,
+				treatCheck10As = '0'),
 		@Mod11Check(threshold = 9,
 				startIndex = 8,
 				endIndex = 10,
-				checkDigitIndex = 11)
+				checkDigitIndex = 11,
+				treatCheck10As = '0')
 })
 @ReportAsSingleViolation
 @Documented

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ProgrammaticConstraintDefinitionsTest.java
@@ -51,7 +51,7 @@ public class ProgrammaticConstraintDefinitionsTest {
 
 	@Test
 	public void countrySpecificProgrammaticDefinition() {
-		doProgrammaticTest( TituloEleitoral.class, new TituloEleitoralDef(), "038763000914", "48255-77", "invalid Brazilian Voter ID card number" );
+		doProgrammaticTest( TituloEleitoral.class, new TituloEleitoralDef(), "083578481406", "48255-77", "invalid Brazilian Voter ID card number" );
 		doProgrammaticTest( CPF.class, new CPFDef(), "134.241.313-00", "48255-77", "invalid Brazilian individual taxpayer registry number (CPF)" );
 		doProgrammaticTest( CNPJ.class, new CNPJDef(), "91.509.901/0001-69", "91.509.901/0001-60",
 				"invalid Brazilian corporate taxpayer registry number (CNPJ)"

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/br/TituloEleitoralValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/br/TituloEleitoralValidatorTest.java
@@ -23,14 +23,26 @@ import org.testng.annotations.Test;
 public class TituloEleitoralValidatorTest extends AbstractConstrainedTest {
 	@Test
 	@TestForIssue(jiraKey = "HV-491")
-	public void testCorrectFormattedCPFWithReportAsSingleViolation() {
+	public void testCorrectFormattedTituloEleitoralWithReportAsSingleViolation() {
 		assertNoViolations( validator.validate( new Person( "040806680957" ) ) );
 		assertNoViolations( validator.validate( new Person( "038763000914" ) ) );
+		assertNoViolations( validator.validate( new Person( "975993331007" ) ) );
+		assertNoViolations( validator.validate( new Person( "524384240701" ) ) );
+		assertNoViolations( validator.validate( new Person( "311533282500" ) ) );
+		assertNoViolations( validator.validate( new Person( "083578481406" ) ) );
+		assertNoViolations( validator.validate( new Person( "233838490205" ) ) );
+		assertNoViolations( validator.validate( new Person( "585052440116" ) ) );
+		assertNoViolations( validator.validate( new Person( "650648840264" ) ) );
+		assertNoViolations( validator.validate( new Person( "357866370213" ) ) );
+		assertNoViolations( validator.validate( new Person( "074447240264" ) ) );
+		assertNoViolations( validator.validate( new Person( "164284280213" ) ) );
+		assertNoViolations( validator.validate( new Person( "465667341619" ) ) );
+		assertNoViolations( validator.validate( new Person( "362133720779" ) ) );
 	}
 
 	@Test
 	@TestForIssue(jiraKey = "HV-491")
-	public void testIncorrectFormattedCPFWithReportAsSingleViolation() {
+	public void testIncorrectFormattedTituloEleitoralWithReportAsSingleViolation() {
 		Set<ConstraintViolation<Person>> violations = validator.validate( new Person( "48255-77" ) );
 		assertThat( violations ).containsOnlyViolations(
 				violationOf( TituloEleitoral.class ).withProperty( "tituloEleitor" )


### PR DESCRIPTION
Fixing mod11 check to use '0' in case the rest of the division is 10, making the function to correct validate a Brazilian Titulo Eleitoral

(cherry picked from commit 0f0e8fed89cfcbf6f1883eebea556aebc3451cfc)

backport of https://github.com/hibernate/hibernate-validator/pull/1371

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
