### PR TITLE
HV-2008 Use latest AssertJ version for the main build and override it to Jakarta Validation TCK required for a TCK run

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,7 +60,10 @@ updates:
       - dependency-name: "jakarta.inject:jakarta.inject-api"
       - dependency-name: "jakarta.persistence:jakarta.persistence-api"
       - dependency-name: "jakarta.ws.rs:jakarta.ws.rs-api"
-        # Bean Validation TCK requires a particular version of AssertJ and using others leads to errors:
+        # We are managing the version of AssertJ manually:
+        #    - tck-runner requires a specific version of AssertJ aligned with the Jakarta Validation TCK
+        #    - all other modules are using a more recent version (latest)
+        #  we cannot enable the automatic updates as those will constantly push us to change the version in the TCK module
       - dependency-name: "org.assertj:*"
         # We have a fixed major version of OpenJFX to work with the min JDK we require
       - dependency-name: "org.openjfx:*"

--- a/pom.xml
+++ b/pom.xml
@@ -181,8 +181,7 @@
         <version.shrinkwrap.resolvers>3.3.0</version.shrinkwrap.resolvers>
         <version.shrinkwrap.descriptors>2.0.0</version.shrinkwrap.descriptors>
         <version.org.testng>7.10.2</version.org.testng>
-        <!-- it must be the exact same version than the one used in the Bean Validation TCK -->
-        <version.org.assertj.assertj-core>3.8.0</version.org.assertj.assertj-core>
+        <version.org.assertj.assertj-core>3.26.3</version.org.assertj.assertj-core>
         <version.junit>4.13.2</version.junit>
         <version.org.easymock>5.3.0</version.org.easymock>
         <version.io.rest-assured>5.5.0</version.io.rest-assured>

--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -21,12 +21,29 @@
     <description>Aggregates dependencies and runs the Jakarta Validation TCK</description>
 
     <properties>
+        <!--
+            We are overriding the AssertJ version here and adding a dependency management for it
+            to override the one we are using for the main build.
+            The version here must be the exact same version as the one used in the Bean Validation TCK
+        -->
+        <version.org.assertj.assertj-core>3.8.0</version.org.assertj.assertj-core>
+
         <tck.suite.file>${project.build.directory}/dependency/validation-tck-tests-suite.xml</tck.suite.file>
         <validation.provider>org.hibernate.validator.HibernateValidator</validation.provider>
         <remote.debug />
 
         <hibernate-validator-parent.path>..</hibernate-validator-parent.path>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.org.assertj.assertj-core}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2008

Change the AssertJ dependency management to override the version for TCK run to the version required by the Jakarta Validation TCK and keep the version up to date for the rest of the project build. 

I'm also enabling the dependabot updates for assertj, I suspect that dependaobt may get a bit dizzy with multiple assertj dependencies, but let's see how it'll go.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
