### PR TITLE
Followup on HV-1991 Remove the multi-release jar entry from AP

### DIFF
--- a/annotation-processor/pom.xml
+++ b/annotation-processor/pom.xml
@@ -116,7 +116,6 @@
                             <archive>
                                 <manifestEntries>
                                     <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
-                                    <Multi-Release>true</Multi-Release>
                                 </manifestEntries>
                             </archive>
                         </configuration>


### PR DESCRIPTION
The AP doesn't need to be multi-release jar anymore. There were some sources for jdk17, but now that we have 17 as a baseline ... we can simply remove this entry.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
