### PR TITLE
HV-2012 Bump org.openjfx:javafx-base from 17.0.11 to 17.0.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <version.javax.annotation>1.2</version.javax.annotation>
 
         <!-- JavaFX dependencies -->
-        <version.org.openjfx>17.0.11</version.org.openjfx>
+        <version.org.openjfx>17.0.12</version.org.openjfx>
 
         <!-- Test dependencies -->
         <version.org.jboss.arquillian>1.8.1.Final</version.org.jboss.arquillian>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2012
https://github.com/hibernate/hibernate-validator/pull/1384

Bumps org.openjfx:javafx-base from 17.0.11 to 17.0.12.

---
updated-dependencies:
- dependency-name: org.openjfx:javafx-base dependency-type: direct:production update-type: version-update:semver-patch ...


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
