### PR TITLE
HV-2018 Keep the interface if it is the hierarchy root

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/PredefinedScopeBeanMetaDataManager.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/PredefinedScopeBeanMetaDataManager.java
@@ -88,7 +88,8 @@ public class PredefinedScopeBeanMetaDataManager implements BeanMetaDataManager {
 			Class<?> normalizedValidatedClass = beanMetaDataClassNormalizer.normalize( validatedClass );
 
 			@SuppressWarnings("unchecked")
-			List<Class<?>> classHierarchy = (List<Class<?>>) (Object) ClassHierarchyHelper.getHierarchy( normalizedValidatedClass, Filters.excludeInterfaces() );
+			List<Class<?>> classHierarchy = (List<Class<?>>) (Object) ClassHierarchyHelper.getHierarchy( normalizedValidatedClass,
+					Filters.excludeInterfaces( normalizedValidatedClass ) );
 
 			// note that the hierarchy also contains the initial class
 			for ( Class<?> hierarchyElement : classHierarchy ) {
@@ -200,7 +201,7 @@ public class PredefinedScopeBeanMetaDataManager implements BeanMetaDataManager {
 		@SuppressWarnings("unchecked")
 		private UninitializedBeanMetaData(Class<T> beanClass) {
 			this.beanClass = beanClass;
-			this.classHierarchy = (List<Class<? super T>>) (Object) ClassHierarchyHelper.getHierarchy( beanClass, Filters.excludeInterfaces() );
+			this.classHierarchy = (List<Class<? super T>>) (Object) ClassHierarchyHelper.getHierarchy( beanClass, Filters.excludeInterfaces( beanClass ) );
 			this.beanDescriptor = new UninitializedBeanDescriptor( beanClass );
 		}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -253,7 +253,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 
 		this.classHierarchyWithoutInterfaces = CollectionHelper.toImmutableList( ClassHierarchyHelper.getHierarchy(
 				beanClass,
-				Filters.excludeInterfaces()
+				Filters.excludeInterfaces( beanClass )
 		) );
 
 		DefaultGroupSequenceContext<? super T> defaultGroupContext = getDefaultGroupSequenceData( beanClass, defaultGroupSequence, defaultGroupSequenceProvider, validationOrderGenerator );

--- a/engine/src/main/java/org/hibernate/validator/internal/util/classhierarchy/Filters.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/classhierarchy/Filters.java
@@ -15,7 +15,6 @@ package org.hibernate.validator.internal.util.classhierarchy;
 public class Filters {
 
 	private static final Filter PROXY_FILTER = new WeldProxyFilter();
-	private static final Filter INTERFACES_FILTER = new InterfacesFilter();
 
 	private Filters() {
 		// Not allowed
@@ -26,8 +25,8 @@ public class Filters {
 	 *
 	 * @return a filter which excludes interfaces
 	 */
-	public static Filter excludeInterfaces() {
-		return INTERFACES_FILTER;
+	public static Filter excludeInterfaces(Class<?> self) {
+		return new InterfacesFilter( self );
 	}
 
 	/**
@@ -41,9 +40,15 @@ public class Filters {
 
 	private static class InterfacesFilter implements Filter {
 
+		private final Class<?> self;
+
+		public InterfacesFilter(Class<?> self) {
+			this.self = self;
+		}
+
 		@Override
 		public boolean accepts(Class<?> clazz) {
-			return !clazz.isInterface();
+			return !clazz.isInterface() || self.equals( clazz );
 		}
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/ValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/ValidatorTest.java
@@ -353,6 +353,20 @@ public class ValidatorTest {
 		);
 	}
 
+	@Test
+	public void testValidateValueConstraintOnInterface() {
+		Validator validator = getValidator();
+
+		Set<ConstraintViolation<MyConstraints>> violations = validator.validateValue( MyConstraints.class, "property", null );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( NotNull.class ).withProperty( "property" ) );
+	}
+
+	interface MyConstraints {
+		@NotNull
+		String getProperty();
+	}
+
 	class A {
 		@NotNull
 		String b;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/util/classhierarchy/ClassHierarchyHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/util/classhierarchy/ClassHierarchyHelperTest.java
@@ -30,9 +30,23 @@ public class ClassHierarchyHelperTest {
 
 		List<Class<? super Fubar>> superClasses = ClassHierarchyHelper.getHierarchy(
 				Fubar.class,
-				Filters.excludeInterfaces()
+				Filters.excludeInterfaces( Fubar.class )
 		);
 		assertThat( superClasses ).containsOnly( Fubar.class, Object.class );
+	}
+
+	@Test
+	public void testHierarchyWithoutInterfaces() {
+		List<Class<? super Snafu>> superClasses = ClassHierarchyHelper.getHierarchy(
+				Snafu.class
+		);
+		assertThat( superClasses ).containsOnly( Snafu.class );
+
+		superClasses = ClassHierarchyHelper.getHierarchy(
+				Snafu.class,
+				Filters.excludeInterfaces( Snafu.class )
+		);
+		assertThat( superClasses ).containsOnly( Snafu.class );
 	}
 
 	private interface Snafu {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2018

I guess we never anticipated that the validation constraints will be only defined on an interface and that interface is passed to the `validateValue()`. 
What currently happens is that `beanMetaData.getClassHierarchy()` is empty and once we want to validate things we never get into this loop:

https://github.com/hibernate/hibernate-validator/blob/bb6129938a096d0928f64b7d34eb844a2d682419/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorImpl.java#L458-L462

Which means we actually do not evaluate any constraints... 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
