### PR TITLE
HV-1986 Add .git-blame-ignore-revs to skip revs related to auto-formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Introduction of automatic formatting (https://hibernate.atlassian.net/browse/HV-1986)
+0caebd08d86a7b95f4ad654bce952b80f6f99327
+7fe0c66d69ae352d9c86da7280b9d06e25f38c9e
+38b56206a9db2e0b93f5da122735a725d89ba516

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,10 @@ few prerequisite steps:
 As discussed in the linked page, this also includes:
     * [Setting](https://help.github.com/articles/set-up-git/) up your local git install
     * Cloning your fork
+* Instruct git to ignore certain commits when using `git blame`:
+  ```
+  git config blame.ignoreRevsFile .git-blame-ignore-revs
+  ```
 
 ## Create a test case
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1986

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
