### PR TITLE
Exclude .cache from the distribution package

### DIFF
--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -112,6 +112,7 @@
                 <exclude>**/*.iws</exclude>
                 <exclude>**/performance/hibernate-validator.log</exclude>
                 <exclude>**/performance/dependency-reduced-pom.xml</exclude>
+                <exclude>**/.cache/**</exclude>
             </excludes>
         </fileSet>
 


### PR DESCRIPTION
Was adding the same for Search (https://github.com/hibernate/hibernate-search/pull/4248) and noticed that I've missed the .cache for HV

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
