### PR TITLE
HV-1998 Manage the versions plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,7 @@
         <version.sisu-maven-plugin>0.9.0.M3</version.sisu-maven-plugin>
         <version.impsort-maven-plugin>1.11.0</version.impsort-maven-plugin>
         <version.formatter-maven-plugin>2.24.1</version.formatter-maven-plugin>
+        <version.versions.plugin>2.17.1</version.versions.plugin>
 
         <!-- Forbidden API related properties -->
         <forbiddenapis-junit.path>forbidden-junit.txt</forbiddenapis-junit.path>
@@ -1453,6 +1454,11 @@
                     <groupId>org.eclipse.sisu</groupId>
                     <artifactId>sisu-maven-plugin</artifactId>
                     <version>${version.sisu-maven-plugin}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>versions-maven-plugin</artifactId>
+                    <version>${version.versions.plugin}</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,8 @@
     </mailingLists>
 
     <modules>
+        <module>parents/internal</module>
+        <module>parents/public</module>
         <module>build/build-config</module>
         <module>build/enforcer</module>
         <module>bom</module>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1998

so that we are at 2.9+ to make sure that calling version:set also updates the `project.build.outputTimestamp`

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
