### PR TITLE
HV-2022 Update Javadoc generation

### DIFF
--- a/annotation-processor/pom.xml
+++ b/annotation-processor/pom.xml
@@ -18,6 +18,7 @@
     <artifactId>hibernate-validator-annotation-processor</artifactId>
 
     <name>Hibernate Validator Annotation Processor</name>
+    <description>Annotation Processor to detect incorrect usage of constraint annotations.</description>
 
     <properties>
         <!-- This is a publicly distributed module that should be published: -->

--- a/annotation-processor/pom.xml
+++ b/annotation-processor/pom.xml
@@ -91,19 +91,6 @@
                 <artifactId>forbiddenapis</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <links>
-                        <link>${java.api-docs.base-url}</link>
-                        <link>${bv.api-docs.base-url}</link>
-                    </links>
-                    <packagesheader>Hibernate Validator Annotation Processor Packages</packagesheader>
-                    <doctitle>Hibernate Validator Annotation Processor ${project.version}</doctitle>
-                    <windowtitle>Hibernate Validator Annotation Processor ${project.version}</windowtitle>
-                </configuration>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>

--- a/build/build-config/pom.xml
+++ b/build/build-config/pom.xml
@@ -22,6 +22,8 @@
 
     <properties>
         <hibernate-validator-parent.path>../..</hibernate-validator-parent.path>
+
+        <tmpdir.dependencies-javadoc-packagelists>${project.build.directory}/dependencies-javadoc-packagelists</tmpdir.dependencies-javadoc-packagelists>
     </properties>
 
     <build>
@@ -78,6 +80,15 @@
                                             <artifact>jakarta.persistence:jakarta.persistence-api</artifact>
                                             <failOnNotFound>true</failOnNotFound>
                                         </item>
+                                        <!--
+                                           We want to make sure that the value we store in the property matches
+                                           the version that is imported from the Jakarta EE BOM
+                                        -->
+                                        <item>
+                                            <property>${version.jakarta.el-api}</property>
+                                            <artifact>jakarta.el:jakarta.el-api</artifact>
+                                            <failOnNotFound>true</failOnNotFound>
+                                        </item>
                                     </propertiesToCheck>
                                 </versionAlignRule>
                             </rules>
@@ -91,6 +102,69 @@
                         <version>${project.version}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!-- See https://maven.apache.org/plugins/maven-dependency-plugin/examples/unpacking-artifacts.html -->
+                    <execution>
+                        <id>unpack-dependencies-javadoc-packagelists</id>
+                        <phase>${javadoc.download.phase}</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${maven.javadoc.skip}</skip>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.validation</groupId>
+                                    <artifactId>jakarta.validation-api</artifactId>
+                                    <classifier>javadoc</classifier>
+                                    <type>jar</type>
+                                    <version>${version.jakarta.validation-api}</version>
+                                    <outputDirectory>${tmpdir.dependencies-javadoc-packagelists}/validation-api</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>jakarta.el</groupId>
+                                    <artifactId>jakarta.el-api</artifactId>
+                                    <classifier>javadoc</classifier>
+                                    <type>jar</type>
+                                    <version>${version.jakarta.el-api}</version>
+                                    <outputDirectory>${tmpdir.dependencies-javadoc-packagelists}/el-api</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.javamoney</groupId>
+                                    <artifactId>moneta</artifactId>
+                                    <classifier>javadoc</classifier>
+                                    <type>jar</type>
+                                    <version>${version.org.javamoney.moneta}</version>
+                                    <outputDirectory>${tmpdir.dependencies-javadoc-packagelists}/javamoney-api</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                            <includes>package-list,element-list</includes>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package-dependencies-javadoc-packagelists</id>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <skipAssembly>${maven.javadoc.skip}</skipAssembly>
+                            <descriptors>
+                                <descriptor>src/main/assembly/dependencies-javadoc-packagelists.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/build/build-config/src/main/assembly/dependencies-javadoc-packagelists.xml
+++ b/build/build-config/src/main/assembly/dependencies-javadoc-packagelists.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+    <id>dependencies-javadoc-packagelists</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <baseDirectory>/</baseDirectory>
+
+    <fileSets>
+        <fileSet>
+            <directory>target/dependencies-javadoc-packagelists</directory>
+            <outputDirectory>.</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -9,9 +9,9 @@
 
     <parent>
         <groupId>org.hibernate.validator</groupId>
-        <artifactId>hibernate-validator-internal-parent</artifactId>
+        <artifactId>hibernate-validator-public-parent</artifactId>
         <version>9.0.0-SNAPSHOT</version>
-        <relativePath>../parents/internal/pom.xml</relativePath>
+        <relativePath>../parents/public/pom.xml</relativePath>
     </parent>
 
     <artifactId>hibernate-validator-distribution</artifactId>
@@ -24,7 +24,11 @@
         <maven.deploy.skip>true</maven.deploy.skip>
         <gpg.skip>true</gpg.skip>
         <maven.javadoc.skip>false</maven.javadoc.skip>
-        <javadoc.additional.param></javadoc.additional.param>
+        <!--
+            Any javadoc warnings should've been caught already while the previous modules were built.
+            Also see additional explanations on this property in the `hibernate-search-mapper-orm-jakarta-batch-core` module.
+        -->
+        <failOnJavadocWarning>false</failOnJavadocWarning>
         <hibernate-validator-parent.path>..</hibernate-validator-parent.path>
     </properties>
 
@@ -112,20 +116,8 @@
                         ${basedir}/../engine/src/main/java;
                         ${basedir}/../cdi/src/main/java;
                         ${basedir}/../annotation-processor/src/main/java
+                        ${basedir}/../test-utils/src/main/java
                     </sourcepath>
-                    <links>
-                        <link>${java.api-docs.base-url}</link>
-                        <link>${javaee.api-docs.base-url}</link>
-                        <link>${bv.api-docs.base-url}</link>
-                        <!--<link>${javamoney.api-docs.base-url}</link>-->
-                    </links>
-                    <tags>
-                        <tag>
-                            <name>hv.experimental</name>
-                            <placement>a</placement>
-                            <head>Experimental</head>
-                        </tag>
-                    </tags>
                     <packagesheader>Hibernate Validator Packages</packagesheader>
                     <doctitle>Hibernate Validator ${project.version}</doctitle>
                     <windowtitle>Hibernate Validator ${project.version}</windowtitle>
@@ -142,6 +134,10 @@
                         <group>
                             <title>Annotation Processor Packages</title>
                             <packages>org.hibernate.validator.ap*</packages>
+                        </group>
+                        <group>
+                            <title>Hibernate Validator Test Utilities Packages</title>
+                            <packages>org.hibernate.validator.testutil*</packages>
                         </group>
                     </groups>
                     <additionalOptions>${javadoc.additional.options}</additionalOptions>
@@ -179,18 +175,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>testWithJdk11+</id>
-            <activation>
-                <property>
-                    <name>java-version.test.release</name>
-                    <value>!8</value>
-                </property>
-            </activation>
-            <properties>
-                <javadoc.additional.options>-html5</javadoc.additional.options>
-            </properties>
-        </profile>
-    </profiles>
 </project>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -299,7 +299,7 @@
 
                         <!-- URLs -->
                         <javaApiDocsUrl>${java.api-docs.base-url}/</javaApiDocsUrl>
-                        <bvApiDocsUrl>${bv.api-docs.base-url}/</bvApiDocsUrl>
+                        <bvApiDocsUrl>${javadoc.jakarta.validation.url}/</bvApiDocsUrl>
                         <bvSpecUrl>${bv.spec.url}</bvSpecUrl>
                         <javaTechnotesBaseUrl>${java.technotes.base-url}</javaTechnotesBaseUrl>
                         <javafxDocsUrl>${javafx.docs.url}</javafxDocsUrl>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -27,6 +27,16 @@
         <hibernate-validator-parent.path>..</hibernate-validator-parent.path>
         <surefire.jvm.args.additional>-Duser.language=en -Duser.country=US</surefire.jvm.args.additional>
         <java.module.name>${hibernate-validator.module-name}</java.module.name>
+        <!--
+            We want to skip the javadoc warnings for this module, since Jakarta Expression Language API is using proper modules,
+            resulting in a warning like:
+                [WARNING] Javadoc Warnings
+                [WARNING] warning: The code being documented uses packages in the unnamed module, but the packages defined in https://jakarta.ee/specifications/expression-language/6.0/apidocs/ are in named modules.
+                [WARNING] 1 warning
+            when trying to build this module. Since it cannot be suppressed, but the generated docs are actually OK
+            and links point to correct addresses, we just ignore all warnings for this module.
+        -->
+        <failOnJavadocWarning>false</failOnJavadocWarning>
     </properties>
 
     <distributionManagement>

--- a/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
@@ -40,6 +40,8 @@ import org.hibernate.validator.spi.scripting.ScriptEvaluatorFactory;
  * Should not be used directly, prefer {@link HibernateValidatorConfiguration} or
  * {@link PredefinedScopeHibernateValidatorConfiguration}.
  *
+ * @param <S> The actual type of the configuration.
+ *
  * @author Emmanuel Bernard
  * @author Gunnar Morling
  * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
@@ -75,8 +77,8 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	String ALLOW_PARALLEL_METHODS_DEFINE_PARAMETER_CONSTRAINTS = "hibernate.validator.allow_parallel_method_parameter_constraint";
 
 	/**
-	 * @deprecated planned for removal. Use hibernate.validator.constraint_mapping_contributors instead.
 	 * @since 5.2
+	 * @deprecated planned for removal. Use hibernate.validator.constraint_mapping_contributors instead.
 	 */
 	@Deprecated
 	String CONSTRAINT_MAPPING_CONTRIBUTOR = "hibernate.validator.constraint_mapping_contributor";
@@ -230,7 +232,6 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 *
 	 * @return the default {@code ValueExtractor} implementations compliant
 	 * with the specification
-	 *
 	 * @since 6.0
 	 */
 	@Incubating
@@ -241,9 +242,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * will be added to the constraints configured via annotations and/or xml.
 	 *
 	 * @param mapping {@code ConstraintMapping} instance containing programmatic configured constraints
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @throws IllegalArgumentException if {@code mapping} is {@code null}
 	 */
 	S addMapping(ConstraintMapping mapping);
@@ -253,7 +252,6 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * will stop on the first constraint violation detected.
 	 *
 	 * @param failFast {@code true} to enable fail fast, {@code false} otherwise.
-	 *
 	 * @return {@code this} following the chaining method pattern
 	 */
 	S failFast(boolean failFast);
@@ -269,9 +267,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * last fallback through Hibernate Validator's own class loader.
 	 *
 	 * @param externalClassLoader The class loader for loading user-provided resources.
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 5.2
 	 */
 	S externalClassLoader(ClassLoader externalClassLoader);
@@ -288,9 +284,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * </pre>
 	 *
 	 * @param allow flag determining whether validation will allow overriding to alter parameter constraints.
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 5.3
 	 */
 	S allowOverridingMethodAlterParameterConstraint(boolean allow);
@@ -308,9 +302,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * </pre>
 	 *
 	 * @param allow flag determining whether validation will allow multiple cascaded validation on return values.
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 5.3
 	 */
 	S allowMultipleCascadedValidationOnReturnValues(boolean allow);
@@ -328,9 +320,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * </pre>
 	 *
 	 * @param allow flag determining whether validation will allow parameter constraints in parallel hierarchies
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 5.3
 	 */
 	S allowParallelMethodsDefineParameterConstraints(boolean allow);
@@ -344,9 +334,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 *
 	 * @param enabled flag determining whether per validation call caching is enabled for {@code TraversableResolver}
 	 * results.
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 6.0.3
 	 */
 	S enableTraversableResolverResultCache(boolean enabled);
@@ -356,9 +344,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * used to evaluate script expressions for {@link ScriptAssert} and {@link ParameterScriptAssert} constraints.
 	 *
 	 * @param scriptEvaluatorFactory the {@link ScriptEvaluatorFactory} to be used
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 6.0.3
 	 */
 	@Incubating
@@ -369,9 +355,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * {@link Past}/{@link PastOrPresent} and {@link Future}/{@link FutureOrPresent}.
 	 *
 	 * @param temporalValidationTolerance the acceptable tolerance
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 6.0.5
 	 */
 	@Incubating
@@ -382,9 +366,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * times, only the payload passed last will be propagated.
 	 *
 	 * @param constraintValidatorPayload the payload passed to constraint validators
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 6.0.8
 	 */
 	@Incubating
@@ -395,9 +377,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * or not.
 	 *
 	 * @param getterPropertySelectionStrategy the {@link GetterPropertySelectionStrategy} to be used
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 6.1.0
 	 */
 	@Incubating
@@ -408,9 +388,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * when constructing a property path as the one returned by {@link ConstraintViolation#getPropertyPath()}.
 	 *
 	 * @param propertyNodeNameProvider the {@link PropertyNodeNameProvider} to be used
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 6.1.0
 	 */
 	@Incubating
@@ -458,9 +436,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * Allows setting a locale resolver, defining how the locale will be resolved when interpolating the message of a constraint violation.
 	 *
 	 * @param localeResolver the {@link LocaleResolver} to be used
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 6.1.1
 	 */
 	@Incubating
@@ -479,7 +455,6 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 *
 	 * @param expressionLanguageFeatureLevel the {@link ExpressionLanguageFeatureLevel} to be used
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 6.2
 	 */
 	@Incubating
@@ -492,7 +467,6 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 *
 	 * @param expressionLanguageFeatureLevel the {@link ExpressionLanguageFeatureLevel} to be used
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 6.2
 	 */
 	@Incubating
@@ -505,7 +479,6 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 *
 	 * @param enabled flag determining whether validated values will be printed out into trace level logs or not.
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 8.0
 	 */
 	@Incubating
@@ -517,9 +490,7 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	 * constraints generated a violation.
 	 *
 	 * @param failFastOnPropertyViolation {@code true} to enable the skipping mode, {@code false} otherwise.
-	 *
 	 * @return {@code this} following the chaining method pattern
-	 *
 	 * @since 9.0
 	 */
 	@Incubating

--- a/engine/src/main/java/org/hibernate/validator/cfg/GenericConstraintDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/GenericConstraintDef.java
@@ -15,6 +15,7 @@ import java.lang.annotation.Annotation;
  * {@link GenericConstraintDef#param(String, Object)} which allows to add
  * arbitrary constraint parameters.
  *
+ * @param <A> The constraint annotation type.
  * @author Hardy Ferentschik
  * @author Gunnar Morling
  */

--- a/engine/src/main/java/org/hibernate/validator/cfg/context/Cascadable.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/context/Cascadable.java
@@ -10,6 +10,7 @@ package org.hibernate.validator.cfg.context;
  * Facet of a constraint mapping creational context which allows to mark the underlying
  * element as to be validated in a cascaded way.
  *
+ * @param <C> The concrete type of the cascadable.
  * @author Gunnar Morling
  * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */

--- a/engine/src/main/java/org/hibernate/validator/cfg/context/ConstraintDefinitionContext.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/context/ConstraintDefinitionContext.java
@@ -44,7 +44,6 @@ public interface ConstraintDefinitionContext<A extends Annotation> extends Const
 	/**
 	 * Allows to configure a validation implementation using a Lambda expression or method reference. Useful for simple
 	 * validations without the need for accessing constraint properties or customization of error messages etc.
-	 * <p>
 	 *
 	 * @param type The type of the value to validate
 	 * @return This context for method chaining

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/AssertFalseDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/AssertFalseDef.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.AssertFalse;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * An {@link AssertFalse} constraint definition.
  * @author Hardy Ferentschik
  */
 public class AssertFalseDef extends ConstraintDef<AssertFalseDef, AssertFalse> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/AssertTrueDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/AssertTrueDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.AssertTrue;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * An {@link AssertTrue} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class AssertTrueDef extends ConstraintDef<AssertTrueDef, AssertTrue> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/BitcoinAddressDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/BitcoinAddressDef.java
@@ -11,6 +11,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.BitcoinAddress;
 
 /**
+ * A {@link BitcoinAddress} constraint definition.
+ *
  * @author José Yoshiriro
  * @since 9.0.0
  */

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/CreditCardNumberDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/CreditCardNumberDef.java
@@ -11,6 +11,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.CreditCardNumber;
 
 /**
+ * A {@link CreditCardNumber} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class CreditCardNumberDef extends ConstraintDef<CreditCardNumberDef, CreditCardNumber> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/CurrencyDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/CurrencyDef.java
@@ -10,6 +10,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.Currency;
 
 /**
+ * A {@link Currency} constraint definition.
+ *
  * @author Gunnar Morling
  */
 public class CurrencyDef extends ConstraintDef<CurrencyDef, Currency> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/DecimalMaxDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/DecimalMaxDef.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.DecimalMax;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link DecimalMax} constraint definition.
  * @author Hardy Ferentschik
  */
 public class DecimalMaxDef extends ConstraintDef<DecimalMaxDef, DecimalMax> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/DecimalMinDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/DecimalMinDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.DecimalMin;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link DecimalMin} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class DecimalMinDef extends ConstraintDef<DecimalMinDef, DecimalMin> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/DigitsDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/DigitsDef.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Digits;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link Digits} constraint definition.
  * @author Hardy Ferentschik
  */
 public class DigitsDef extends ConstraintDef<DigitsDef, Digits> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/DurationMaxDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/DurationMaxDef.java
@@ -10,6 +10,7 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.time.DurationMax;
 
 /**
+ * A {@link DurationMax} constraint definition.
  * @author Marko Bekhta
  */
 public class DurationMaxDef extends ConstraintDef<DurationMaxDef, DurationMax> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/DurationMinDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/DurationMinDef.java
@@ -10,6 +10,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.time.DurationMin;
 
 /**
+ * A {@link DurationMin} constraint definition.
+ *
  * @author Marko Bekhta
  */
 public class DurationMinDef extends ConstraintDef<DurationMinDef, DurationMin> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/EANDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/EANDef.java
@@ -10,6 +10,7 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.EAN;
 
 /**
+ * An {@link EAN} constraint definition.
  * @author Hardy Ferentschik
  */
 public class EANDef extends ConstraintDef<EANDef, EAN> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/EmailDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/EmailDef.java
@@ -13,6 +13,8 @@ import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * An {@link Email} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class EmailDef extends ConstraintDef<EmailDef, Email> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/FutureDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/FutureDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.Future;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link Future} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class FutureDef extends ConstraintDef<FutureDef, Future> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/FutureOrPresentDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/FutureOrPresentDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.FutureOrPresent;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link FutureOrPresent} constraint definition.
+ *
  * @author Marko Bekhta
  */
 public class FutureOrPresentDef extends ConstraintDef<FutureOrPresentDef, FutureOrPresent> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/ISBNDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/ISBNDef.java
@@ -10,6 +10,7 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.ISBN;
 
 /**
+ * An {@link ISBN} constraint definition.
  * @author Marko Bekhta
  * @since 6.0.6
  */

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/LengthDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/LengthDef.java
@@ -11,6 +11,7 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.Length;
 
 /**
+ * A {@link Length} constraint definition.
  * @author Hardy Ferentschik
  */
 public class LengthDef extends ConstraintDef<LengthDef, Length> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/LuhnCheckDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/LuhnCheckDef.java
@@ -10,6 +10,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.LuhnCheck;
 
 /**
+ * A {@link LuhnCheck} constraint definition.
+ *
  * @author Marko Bekta
  */
 public class LuhnCheckDef extends ConstraintDef<LuhnCheckDef, LuhnCheck> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/MaxDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/MaxDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.Max;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link Max} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class MaxDef extends ConstraintDef<MaxDef, Max> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/MinDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/MinDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.Min;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link Min} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class MinDef extends ConstraintDef<MinDef, Min> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/Mod10CheckDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/Mod10CheckDef.java
@@ -11,6 +11,7 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.Mod10Check;
 
 /**
+ * A {@link Mod10Check} constraint definition.
  * @author Hardy Ferentschik
  */
 public class Mod10CheckDef extends ConstraintDef<Mod10CheckDef, Mod10Check> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/Mod11CheckDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/Mod11CheckDef.java
@@ -11,6 +11,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.Mod11Check;
 
 /**
+ * A {@link Mod11Check} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class Mod11CheckDef extends ConstraintDef<Mod11CheckDef, Mod11Check> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/NegativeDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/NegativeDef.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Negative;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link Negative} constraint definition.
  * @author Gunnar Morling
  */
 public class NegativeDef extends ConstraintDef<NegativeDef, Negative> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/NegativeOrZeroDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/NegativeOrZeroDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.NegativeOrZero;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link NegativeOrZero} constraint definition.
+ *
  * @author Gunnar Morling
  */
 public class NegativeOrZeroDef extends ConstraintDef<NegativeOrZeroDef, NegativeOrZero> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/NotBlankDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/NotBlankDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.NotBlank;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link NotBlank} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class NotBlankDef extends ConstraintDef<NotBlankDef, NotBlank> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/NotEmptyDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/NotEmptyDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.NotEmpty;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link NotEmpty} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class NotEmptyDef extends ConstraintDef<NotEmptyDef, NotEmpty> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/NotNullDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/NotNullDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.NotNull;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link NotNull} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class NotNullDef extends ConstraintDef<NotNullDef, NotNull> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/NullDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/NullDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.Null;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link Null} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class NullDef extends ConstraintDef<NullDef, Null> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/ParameterScriptAssertDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/ParameterScriptAssertDef.java
@@ -10,6 +10,7 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.ParameterScriptAssert;
 
 /**
+ * A {@link ParameterScriptAssert} constraint definition.
  * @author Marko Bekta
  */
 public class ParameterScriptAssertDef extends ConstraintDef<ParameterScriptAssertDef, ParameterScriptAssert> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/PastDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/PastDef.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Past;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link Past} constraint definition.
  * @author Hardy Ferentschik
  */
 public class PastDef extends ConstraintDef<PastDef, Past> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/PastOrPresentDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/PastOrPresentDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.PastOrPresent;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link PastOrPresent} constraint definition.
+ *
  * @author Marko Bekhta
  */
 public class PastOrPresentDef extends ConstraintDef<PastOrPresentDef, PastOrPresent> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/PatternDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/PatternDef.java
@@ -11,6 +11,8 @@ import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * An {@link Pattern} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class PatternDef extends ConstraintDef<PatternDef, Pattern> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/PositiveDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/PositiveDef.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Positive;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link Positive} constraint definition.
  * @author Gunnar Morling
  */
 public class PositiveDef extends ConstraintDef<PositiveDef, Positive> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/RangeDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/RangeDef.java
@@ -10,6 +10,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.Range;
 
 /**
+ * A {@link Range} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class RangeDef extends ConstraintDef<RangeDef, Range> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/ScriptAssertDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/ScriptAssertDef.java
@@ -10,6 +10,7 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.ScriptAssert;
 
 /**
+ * A {@link ScriptAssert} constraint definition.
  * @author Hardy Ferentschik
  */
 public class ScriptAssertDef extends ConstraintDef<ScriptAssertDef, ScriptAssert> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/SizeDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/SizeDef.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.Size;
 import org.hibernate.validator.cfg.ConstraintDef;
 
 /**
+ * A {@link Size} constraint definition.
  * @author Hardy Ferentschik
  */
 public class SizeDef extends ConstraintDef<SizeDef, Size> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/URLDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/URLDef.java
@@ -12,6 +12,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.URL;
 
 /**
+ * An {@link URL} constraint definition.
+ *
  * @author Hardy Ferentschik
  */
 public class URLDef extends ConstraintDef<URLDef, URL> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/UniqueElementsDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/UniqueElementsDef.java
@@ -11,6 +11,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.UniqueElements;
 
 /**
+ * An {@link UniqueElements} constraint definition.
+ *
  * @author Guillaume Smet
  * @since 6.0.5
  */

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/br/CNPJDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/br/CNPJDef.java
@@ -10,6 +10,7 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.br.CNPJ;
 
 /**
+ * A {@link CNPJ} constraint definition.
  * @author Marko Bekta
  */
 public class CNPJDef extends ConstraintDef<CNPJDef, CNPJ> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/br/CPFDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/br/CPFDef.java
@@ -10,6 +10,7 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.br.CPF;
 
 /**
+ * A {@link CPF} constraint definition.
  * @author Marko Bekta
  */
 public class CPFDef extends ConstraintDef<CPFDef, CPF> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/br/TituloEleitoralDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/br/TituloEleitoralDef.java
@@ -10,6 +10,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.br.TituloEleitoral;
 
 /**
+ * A {@link TituloEleitoral} constraint definition.
+ *
  * @author Marko Bekta
  */
 public class TituloEleitoralDef extends ConstraintDef<TituloEleitoralDef, TituloEleitoral> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/kor/KorRRNDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/kor/KorRRNDef.java
@@ -10,6 +10,9 @@ import org.hibernate.validator.Incubating;
 import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.kor.KorRRN;
 
+/**
+ * A {@link KorRRN} constraint definition.
+ */
 @Incubating
 public class KorRRNDef extends ConstraintDef<KorRRNDef, KorRRN> {
 

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/pl/NIPDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/pl/NIPDef.java
@@ -10,6 +10,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.pl.NIP;
 
 /**
+ * An {@link NIP} constraint definition.
+ *
  * @author Marko Bekta
  */
 public class NIPDef extends ConstraintDef<NIPDef, NIP> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/pl/PESELDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/pl/PESELDef.java
@@ -10,6 +10,7 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.pl.PESEL;
 
 /**
+ * A {@link PESEL} constraint definition.
  * @author Marko Bekta
  */
 public class PESELDef extends ConstraintDef<PESELDef, PESEL> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/pl/REGONDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/pl/REGONDef.java
@@ -10,6 +10,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.pl.REGON;
 
 /**
+ * A {@link REGON} constraint definition.
+ *
  * @author Marko Bekta
  */
 public class REGONDef extends ConstraintDef<REGONDef, REGON> {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/ru/INNDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/ru/INNDef.java
@@ -10,6 +10,8 @@ import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.ru.INN;
 
 /**
+ * An {@link INN} constraint definition.
+ *
  * @author Artem Boiarshinov
  */
 public class INNDef extends ConstraintDef<INNDef, INN> {

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidator.java
@@ -18,6 +18,8 @@ import org.hibernate.validator.Incubating;
 /**
  * Hibernate Validator specific extension to the {@link ConstraintValidator} contract.
  *
+ * @param <A> The constraint annotation type this validator applies to.
+ * @param <T> The target type this validator can validate.
  * @author Marko Bekhta
  * @since 6.0.5
  */

--- a/engine/src/main/java/org/hibernate/validator/engine/HibernateConstraintViolation.java
+++ b/engine/src/main/java/org/hibernate/validator/engine/HibernateConstraintViolation.java
@@ -13,6 +13,7 @@ import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator
 /**
  * A custom {@link ConstraintViolation} which allows to get additional information for a constraint violation.
  *
+ * @param <T> The type of the root bean.
  * @since 5.3
  */
 public interface HibernateConstraintViolation<T> extends ConstraintViolation<T> {

--- a/engine/src/main/java/org/hibernate/validator/spi/cfg/ConstraintMappingContributor.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/cfg/ConstraintMappingContributor.java
@@ -39,7 +39,7 @@ import org.hibernate.validator.cfg.ConstraintMapping;
  * }
  * }
  * </pre>
- * <p>
+ *
  * @see org.hibernate.validator.HibernateValidatorConfiguration#CONSTRAINT_MAPPING_CONTRIBUTORS
  * @author Gunnar Morling
  */

--- a/parents/internal/pom.xml
+++ b/parents/internal/pom.xml
@@ -47,6 +47,98 @@
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-wildfly-patching-script</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.wildfly.patch.hibernate.validator}</skip>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>hibernate-validator-build-config</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>jar</type>
+                                    <outputDirectory>${project.build.directory}/hibernate-validator-patch</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-wildfly</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.wildfly.patch.unpack.server}</skip>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.wildfly</groupId>
+                                    <artifactId>${wildfly.distribution.name}-dist</artifactId>
+                                    <version>${version.wildfly}</version>
+                                    <type>tar.gz</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/wildfly-patched</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <!-- Update the BV/HV JARs in the unpacked ^ WF copy -->
+                    <execution>
+                        <id>prepare-patch-jars</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <skip>${skip.wildfly.patch.hibernate.validator}</skip>
+                            <artifactItems>
+                                <!-- WildFly current -->
+                                <artifactItem>
+                                    <groupId>jakarta.validation</groupId>
+                                    <artifactId>jakarta.validation-api</artifactId>
+                                    <version>${version.jakarta.validation-api}</version>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${wildfly.actual.target-dir}/modules/system/layers/base/jakarta/validation/api/main</outputDirectory>
+                                    <!-- Specifying name to avoid timestamp in version on CI -->
+                                    <destFileName>jakarta.validation-api-${version.jakarta.validation-api}.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>hibernate-validator</artifactId>
+                                    <version>${project.version}</version>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${wildfly.actual.target-dir}/modules/system/layers/base/org/hibernate/validator/main</outputDirectory>
+                                    <destFileName>hibernate-validator-${project.version}.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>hibernate-validator-cdi</artifactId>
+                                    <version>${project.version}</version>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${wildfly.actual.target-dir}/modules/system/layers/base/org/hibernate/validator/cdi/main</outputDirectory>
+                                    <destFileName>hibernate-validator-cdi-${project.version}.jar</destFileName>
+                                </artifactItem>
+                                <!-- We also need to patch the jboss logging jar  -->
+                                <artifactItem>
+                                    <groupId>org.jboss.logging</groupId>
+                                    <artifactId>jboss-logging</artifactId>
+                                    <version>${version.org.jboss.logging.jboss-logging}</version>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${wildfly.actual.target-dir}/modules/system/layers/base/org/jboss/logging/main</outputDirectory>
+                                    <destFileName>jboss-logging-${version.org.jboss.logging.jboss-logging}.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/parents/public/pom.xml
+++ b/parents/public/pom.xml
@@ -51,6 +51,88 @@
                 <groupId>net.revelc.code.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>dist</id>
+            <activation>
+                <property>
+                    <name>disableDistributionBuild</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>unpack-dependencies-javadoc-packagelists</id>
+                                <phase>${javadoc.download.phase}</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>hibernate-validator-build-config</artifactId>
+                                            <classifier>dependencies-javadoc-packagelists</classifier>
+                                            <type>zip</type>
+                                            <version>${project.version}</version>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <outputDirectory>${javadoc.packagelists.directory}</outputDirectory>
+                                    <overWriteSnapshots>true</overWriteSnapshots>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <!--
+                                This ensures that using mvn install -pl <some project> -am
+                                will correctly force the build of the build-config module.
+                             -->
+                            <dependency>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>hibernate-validator-build-config</artifactId>
+                                <classifier>dependencies-javadoc-packagelists</classifier>
+                                <type>zip</type>
+                                <version>${project.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-javadoc</id>
+                                <goals>
+                                    <goal>javadoc-no-fork</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                            </execution>
+                            <execution>
+                                <!--
+                                    This is the default name of an execution that is added automatically if release profile is enabled.
+                                    We want to "override" it so that we can control when it is actually executed.
+                                 -->
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <phase>${javadoc.generate.jar.phase}</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -120,8 +120,6 @@
         <java.technotes.base-url>http://docs.oracle.com/javase/8/docs/technotes</java.technotes.base-url>
         <javaee.api-docs.base-url>https://jakarta.ee/specifications/platform/11/apidocs</javaee.api-docs.base-url>
         <javafx.docs.url>https://openjfx.io/openjfx-docs/</javafx.docs.url>
-        <bv.api-docs.base-url>https://jakarta.ee/specifications/bean-validation/3.1/apidocs</bv.api-docs.base-url>
-        <javamoney.api-docs.base-url>http://javamoney.github.io/apidocs</javamoney.api-docs.base-url>
 
         <!-- Module names used for Java 9 modules and OSGi bundles -->
 
@@ -178,6 +176,7 @@
         -->
         <version.jakarta.validation-api>3.1.0</version.jakarta.validation-api>
         <version.jakarta.persistence-api>3.2.0</version.jakarta.persistence-api>
+        <version.jakarta.el-api>6.0.0</version.jakarta.el-api>
 
         <!-- JavaMoney dependencies -->
         <version.javax.money>1.1</version.javax.money>
@@ -329,8 +328,21 @@
         <java-version.test.launcher.java_home>${java-version.test.compiler.java_home}</java-version.test.launcher.java_home>
         <java-version.test.launcher>${java-version.test.launcher.java_home}/bin/java</java-version.test.launcher>
 
-        <!-- No need to build the javadocs per module. Aggregated javadocs are build in the distribution module. See also HV-894 -->
-        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <!-- Set empty default value to avoid Maven leaving property references (${...}) when it doesn't find a value -->
+        <maven.javadoc.skip>false</maven.javadoc.skip>
+        <!-- Whether javadoc warnings should fail the build -->
+        <failOnJavadocWarning>true</failOnJavadocWarning>
+        <javadoc.generate.jar.phase>none</javadoc.generate.jar.phase>
+        <!-- We control whether we should download javadoc based on this property
+             that defines the phase of some Maven plugin executions,
+             because just skipping those plugins doesn't skip dependency resolution,
+             which will fail if javadoc wasn't downloaded. -->
+        <javadoc.download.phase>generate-resources</javadoc.download.phase>
+        <javadoc.packagelists.directory>${project.build.directory}/dependencies-javadoc-packagelists</javadoc.packagelists.directory>
+        <javadoc.jakarta.validation.url>https://jakarta.ee/specifications/bean-validation/${parsed-version.jakarta.validation-api.majorVersion}.${parsed-version.jakarta.validation-api.minorVersion}/apidocs/</javadoc.jakarta.validation.url>
+        <javadoc.jakarta.el.url>https://jakarta.ee/specifications/expression-language/${parsed-version.jakarta.el-api.majorVersion}.${parsed-version.jakarta.el-api.minorVersion}/apidocs/</javadoc.jakarta.el.url>
+        <javadoc.jakarta.el.url>https://jakarta.ee/specifications/expression-language/${parsed-version.jakarta.el-api.majorVersion}.${parsed-version.jakarta.el-api.minorVersion}/apidocs/</javadoc.jakarta.el.url>
+        <javadoc.javamoney.url>http://javamoney.github.io/apidocs</javadoc.javamoney.url>
 
         <!-- Also set source/target, because several other plugins rely on this and don't understand release -->
         <maven.compiler.source>${java-version.main.release}</maven.compiler.source>
@@ -658,6 +670,16 @@
                         <configuration>
                             <propertyPrefix>parsed-version.jakarta.persistence-api</propertyPrefix>
                             <versionString>${version.jakarta.persistence-api}</versionString>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>parse-jakarta-el-spec-version</id>
+                        <goals>
+                            <goal>parse-version</goal>
+                        </goals>
+                        <configuration>
+                            <propertyPrefix>parsed-version.jakarta.el-api</propertyPrefix>
+                            <versionString>${version.jakarta.el-api}</versionString>
                         </configuration>
                     </execution>
                 </executions>
@@ -1007,95 +1029,6 @@
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${version.dependency.plugin}</version>
-                    <executions>
-                        <execution>
-                            <id>unpack-wildfly-patching-script</id>
-                            <phase>generate-sources</phase>
-                            <goals>
-                                <goal>unpack</goal>
-                            </goals>
-                            <configuration>
-                                <skip>${skip.wildfly.patch.hibernate.validator}</skip>
-                                <artifactItems>
-                                    <artifactItem>
-                                        <groupId>${project.groupId}</groupId>
-                                        <artifactId>hibernate-validator-build-config</artifactId>
-                                        <version>${project.version}</version>
-                                        <type>jar</type>
-                                        <outputDirectory>${project.build.directory}/hibernate-validator-patch</outputDirectory>
-                                    </artifactItem>
-                                </artifactItems>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>unpack-wildfly</id>
-                            <phase>generate-sources</phase>
-                            <goals>
-                                <goal>unpack</goal>
-                            </goals>
-                            <configuration>
-                                <skip>${skip.wildfly.patch.unpack.server}</skip>
-                                <artifactItems>
-                                    <artifactItem>
-                                        <groupId>org.wildfly</groupId>
-                                        <artifactId>${wildfly.distribution.name}-dist</artifactId>
-                                        <version>${version.wildfly}</version>
-                                        <type>tar.gz</type>
-                                        <overWrite>false</overWrite>
-                                        <outputDirectory>${project.build.directory}/wildfly-patched</outputDirectory>
-                                    </artifactItem>
-                                </artifactItems>
-                            </configuration>
-                        </execution>
-                        <!-- Update the BV/HV JARs in the unpacked ^ WF copy -->
-                        <execution>
-                            <id>prepare-patch-jars</id>
-                            <phase>generate-resources</phase>
-                            <goals>
-                                <goal>copy</goal>
-                            </goals>
-                            <configuration>
-                                <skip>${skip.wildfly.patch.hibernate.validator}</skip>
-                                <artifactItems>
-                                    <!-- WildFly current -->
-                                    <artifactItem>
-                                        <groupId>jakarta.validation</groupId>
-                                        <artifactId>jakarta.validation-api</artifactId>
-                                        <version>${version.jakarta.validation-api}</version>
-                                        <overWrite>false</overWrite>
-                                        <outputDirectory>${wildfly.actual.target-dir}/modules/system/layers/base/jakarta/validation/api/main</outputDirectory>
-                                        <!-- Specifying name to avoid timestamp in version on CI -->
-                                        <destFileName>jakarta.validation-api-${version.jakarta.validation-api}.jar</destFileName>
-                                    </artifactItem>
-                                    <artifactItem>
-                                        <groupId>${project.groupId}</groupId>
-                                        <artifactId>hibernate-validator</artifactId>
-                                        <version>${project.version}</version>
-                                        <overWrite>false</overWrite>
-                                        <outputDirectory>${wildfly.actual.target-dir}/modules/system/layers/base/org/hibernate/validator/main</outputDirectory>
-                                        <destFileName>hibernate-validator-${project.version}.jar</destFileName>
-                                    </artifactItem>
-                                    <artifactItem>
-                                        <groupId>${project.groupId}</groupId>
-                                        <artifactId>hibernate-validator-cdi</artifactId>
-                                        <version>${project.version}</version>
-                                        <overWrite>false</overWrite>
-                                        <outputDirectory>${wildfly.actual.target-dir}/modules/system/layers/base/org/hibernate/validator/cdi/main</outputDirectory>
-                                        <destFileName>hibernate-validator-cdi-${project.version}.jar</destFileName>
-                                    </artifactItem>
-                                    <!-- We also need to patch the jboss logging jar  -->
-                                    <artifactItem>
-                                        <groupId>org.jboss.logging</groupId>
-                                        <artifactId>jboss-logging</artifactId>
-                                        <version>${version.org.jboss.logging.jboss-logging}</version>
-                                        <overWrite>false</overWrite>
-                                        <outputDirectory>${wildfly.actual.target-dir}/modules/system/layers/base/org/jboss/logging/main</outputDirectory>
-                                        <destFileName>jboss-logging-${version.org.jboss.logging.jboss-logging}.jar</destFileName>
-                                    </artifactItem>
-                                </artifactItems>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -1153,15 +1086,90 @@
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>${version.source.plugin}</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>jar-no-fork</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${version.javadoc.plugin}</version>
                     <configuration>
+                        <!-- Fail on error alternative -->
                         <quiet>true</quiet>
-                        <docfilessubdirs>true</docfilessubdirs>
-                        <bottom>
-                            <![CDATA[Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="http://redhat.com">Red Hat, Inc.</a> All Rights Reserved]]></bottom>
+                        <verbose>false</verbose>
+                        <failOnWarnings>${failOnJavadocWarning}</failOnWarnings>
+                        <failOnError>true</failOnError>
+                        <release>${maven.compiler.release}</release>
+                        <!-- Exclude implementation classes from the javadoc -->
+                        <excludePackageNames>*.impl,*.impl.*,*.internal,*.internal.*</excludePackageNames>
+                        <!--
+                            This feature tries to set up links between javadoc of different modules.
+                            We don't need that since we merge everything together in the end,
+                            and it leads to really annoying additional Maven executions
+                            that end up publishing build scans on CI,
+                            so we disable it.
+                         -->
+                        <detectOfflineLinks>false</detectOfflineLinks>
+                        <!--
+                            Make sure to always use offline links,
+                            otherwise the build will need to access external websites,
+                            which leads to build failures from time to time when the websites are not available
+                            (used to happen a lot with apache.org in particular).
+                            maven-javadoc-plugin needs a package-list file to determine,
+                            for each package/class, the most appropriate link.
+                            These files are fetched from javadoc Maven artifacts
+                            in the build-config module and regrouped in a single ZIP
+                            (see maven-assembly-plugin config in the build-config POM)
+                            which is then extracted to target/ in each module that needs to generate javadoc
+                            (see maven-dependency-plugin config in this POM).
+                          -->
+                        <bottom><![CDATA[Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="http://redhat.com">Red Hat, Inc.</a> All Rights Reserved]]></bottom>
+                        <!--
+                           Make sure to always use offline links,
+                           otherwise the build will need to access external websites,
+                           which leads to build failures from time to time when the websites are not available
+                           (used to happen a lot with apache.org in particular).
+                           maven-javadoc-plugin needs a package-list file to determine,
+                           for each package/class, the most appropriate link.
+                           These files are fetched from javadoc Maven artifacts
+                           in the build-config module and regrouped in a single ZIP
+                           (see maven-assembly-plugin config in the build-config POM)
+                           which is then extracted to target/ in each module that needs to generate javadoc
+                           (see maven-dependency-plugin config in this POM).
+                         -->
+                        <offlineLinks>
+                            <offlineLink>
+                                <url>${javadoc.javamoney.url}</url>
+                                <location>${javadoc.packagelists.directory}/javamoney-api</location>
+                            </offlineLink>
+                            <offlineLink>
+                                <url>${javadoc.jakarta.validation.url}</url>
+                                <location>${javadoc.packagelists.directory}/validation-api</location>
+                            </offlineLink>
+                            <offlineLink>
+                                <url>${javadoc.jakarta.el.url}</url>
+                                <location>${javadoc.packagelists.directory}/el-api</location>
+                            </offlineLink>
+                        </offlineLinks>
+                        <tags>
+                            <tag>
+                                <name>hv.experimental</name>
+                                <placement>a</placement>
+                                <head>Experimental</head>
+                            </tag>
+                        </tags>
+                        <additionalOptions>
+                            <!-- Java 9+ supports HTML5 for javadoc generation -->
+                            <additionalOption>-html5</additionalOption>
+                            <!-- Java 17+ adds a warning for every single class/method/etc. without a javadoc comment, and we have lots of those.-->
+                            <additionalOption>-Xdoclint:all,-missing</additionalOption>
+                        </additionalOptions>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1588,6 +1596,10 @@
         </profile>
         <profile>
             <id>release</id>
+            <properties>
+                <!-- We want this execution to happen before moditect (which executes at package phase) -->
+                <javadoc.generate.jar.phase>prepare-package</javadoc.generate.jar.phase>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -16,6 +16,7 @@
     <artifactId>hibernate-validator-test-utils</artifactId>
 
     <name>Hibernate Validator Test Utils</name>
+    <description>Set of test utilities that can help testing custom constraints.</description>
 
     <properties>
         <!-- This is a publicly distributed module that should be published: -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2022

This patch updates how the Javadocs are rendered.

It solves some of the previously visible errors, uses offline links renders javadocs per module as well as aggregated javadocs, removes internal packages from the docs.

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
