### PR TITLE
Add Jakarta APIs to the dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,13 +53,9 @@ updates:
       # dependencies that we align on Wildfly version that is used:
       - dependency-name: "org.jboss.weld:*"
       - dependency-name: "org.wildfly.arquillian:*"
-      - dependency-name: "jakarta.enterprise:jakarta.enterprise.cdi-api"
-      - dependency-name: "jakarta.ejb:jakarta.ejb-api"
-      - dependency-name: "jakarta.interceptor:jakarta.interceptor-api"
-      - dependency-name: "jakarta.annotation:jakarta.annotation-api"
-      - dependency-name: "jakarta.inject:jakarta.inject-api"
+      - dependency-name: "jakarta.validation:jakarta.validation-api"
       - dependency-name: "jakarta.persistence:jakarta.persistence-api"
-      - dependency-name: "jakarta.ws.rs:jakarta.ws.rs-api"
+      - dependency-name: "jakarta.el:jakarta.el-api"
         # We are managing the version of AssertJ manually:
         #    - tck-runner requires a specific version of AssertJ aligned with the Jakarta Validation TCK
         #    - all other modules are using a more recent version (latest)


### PR DESCRIPTION
as these are managed by the Jakarta EE BOM

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
