### PR TITLE
HV-2031 Make PredefinedScopeHibernateValidatorFactory aware of constraint mappings defined purely in XML

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/PredefinedScopeHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/PredefinedScopeHibernateValidatorConfiguration.java
@@ -32,4 +32,17 @@ public interface PredefinedScopeHibernateValidatorConfiguration extends BaseHibe
 	@Incubating
 	@Deprecated
 	PredefinedScopeHibernateValidatorConfiguration initializeLocales(Set<Locale> locales);
+
+	/**
+	 * Specify whether to append the {@link #builtinConstraints(Set) built-in constraints} and {@link #initializeBeanMetaData(Set) beans to initialize}
+	 * with constraints and beans provided only through XML mapping.
+	 * <p>
+	 * This option is enabled by default.
+	 *
+	 * @param include Whether to include the beans defined only in xml as part of the {@link #initializeBeanMetaData(Set) set of beans to initialize}
+	 * and also add built-in constraints used only in xml definitions as part of the {@link #builtinConstraints(Set) set of built-in constraints}.
+	 * @return {@code this} for chaining configuration method calls.
+	 */
+	@Incubating
+	PredefinedScopeHibernateValidatorConfiguration includeBeansAndConstraintsDefinedOnlyInXml(boolean include);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeConfigurationImpl.java
@@ -30,6 +30,8 @@ public class PredefinedScopeConfigurationImpl extends AbstractConfigurationImpl<
 
 	private Set<Class<?>> beanClassesToInitialize;
 
+	private boolean includeBeansAndConstraintsDefinedOnlyInXml = true;
+
 	public PredefinedScopeConfigurationImpl(BootstrapState state) {
 		super( state );
 	}
@@ -58,11 +60,21 @@ public class PredefinedScopeConfigurationImpl extends AbstractConfigurationImpl<
 		return beanClassesToInitialize;
 	}
 
+	public boolean isIncludeBeansAndConstraintsDefinedOnlyInXml() {
+		return includeBeansAndConstraintsDefinedOnlyInXml;
+	}
+
 	@Override
 	@Deprecated
 	public PredefinedScopeHibernateValidatorConfiguration initializeLocales(Set<Locale> localesToInitialize) {
 		Contracts.assertNotNull( localesToInitialize, MESSAGES.parameterMustNotBeNull( "localesToInitialize" ) );
 		locales( localesToInitialize );
+		return thisAsT();
+	}
+
+	@Override
+	public PredefinedScopeHibernateValidatorConfiguration includeBeansAndConstraintsDefinedOnlyInXml(boolean include) {
+		this.includeBeansAndConstraintsDefinedOnlyInXml = include;
 		return thisAsT();
 	}
 

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
@@ -29,6 +29,7 @@ import static org.hibernate.validator.internal.util.CollectionHelper.newArrayLis
 import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -188,9 +189,12 @@ public class PredefinedScopeValidatorFactoryImpl implements PredefinedScopeHiber
 		// or from programmatic mappings
 		registerCustomConstraintValidators( constraintMappings, constraintHelper );
 
+		Set<Class<?>> beanClassesToInitialize = new HashSet<>( hibernateSpecificConfig.getBeanClassesToInitialize() );
+
 		XmlMetaDataProvider xmlMetaDataProvider;
 		if ( mappingParser != null && mappingParser.createConstrainedElements() ) {
 			xmlMetaDataProvider = new XmlMetaDataProvider( mappingParser );
+			beanClassesToInitialize.addAll( xmlMetaDataProvider.configuredBeanClasses() );
 		}
 		else {
 			xmlMetaDataProvider = null;
@@ -205,7 +209,7 @@ public class PredefinedScopeValidatorFactoryImpl implements PredefinedScopeHiber
 				buildMetaDataProviders( constraintCreationContext, xmlMetaDataProvider, constraintMappings ),
 				methodValidationConfiguration,
 				determineBeanMetaDataClassNormalizer( hibernateSpecificConfig ),
-				hibernateSpecificConfig.getBeanClassesToInitialize()
+				beanClassesToInitialize
 		);
 
 		if ( LOG.isDebugEnabled() ) {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
@@ -147,7 +147,9 @@ public class PredefinedScopeValidatorFactoryImpl implements PredefinedScopeHiber
 		this.propertyNodeNameProvider = ValidatorFactoryConfigurationHelper.determinePropertyNodeNameProvider( hibernateSpecificConfig, properties, externalClassLoader );
 
 		this.valueExtractorManager = new ValueExtractorManager( configurationState.getValueExtractors() );
-		ConstraintHelper constraintHelper = ConstraintHelper.forBuiltinConstraints( hibernateSpecificConfig.getBuiltinConstraints() );
+		ConstraintHelper constraintHelper = ConstraintHelper.forBuiltinConstraints(
+				hibernateSpecificConfig.getBuiltinConstraints(),
+				hibernateSpecificConfig.isIncludeBeansAndConstraintsDefinedOnlyInXml() );
 		TypeResolutionHelper typeResolutionHelper = new TypeResolutionHelper();
 
 		ConstraintCreationContext constraintCreationContext = new ConstraintCreationContext( constraintHelper,
@@ -194,7 +196,9 @@ public class PredefinedScopeValidatorFactoryImpl implements PredefinedScopeHiber
 		XmlMetaDataProvider xmlMetaDataProvider;
 		if ( mappingParser != null && mappingParser.createConstrainedElements() ) {
 			xmlMetaDataProvider = new XmlMetaDataProvider( mappingParser );
-			beanClassesToInitialize.addAll( xmlMetaDataProvider.configuredBeanClasses() );
+			if ( hibernateSpecificConfig.isIncludeBeansAndConstraintsDefinedOnlyInXml() ) {
+				beanClassesToInitialize.addAll( xmlMetaDataProvider.configuredBeanClasses() );
+			}
 		}
 		else {
 			xmlMetaDataProvider = null;

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
@@ -400,8 +400,14 @@ public abstract class ConstraintHelper {
 		return new StaticConstraintHelper();
 	}
 
-	public static ConstraintHelper forBuiltinConstraints(Set<String> enabledConstraints) {
-		return new DynamicConstraintHelper( BuiltinConstraint.resolve( enabledConstraints ) );
+	public static ConstraintHelper forBuiltinConstraints(Set<String> enabledConstraints, boolean attemptToResolveMissingBuiltInConstraintsOnTheFly) {
+		Set<BuiltinConstraint> builtinConstraints = BuiltinConstraint.resolve( enabledConstraints );
+		if ( attemptToResolveMissingBuiltInConstraintsOnTheFly ) {
+			return new DynamicConstraintHelper( builtinConstraints );
+		}
+		else {
+			return new StaticConstraintHelper( builtinConstraints );
+		}
 	}
 
 	@SuppressWarnings("deprecation")
@@ -1154,7 +1160,11 @@ public abstract class ConstraintHelper {
 		private final Map<Class<? extends Annotation>, List<? extends ConstraintValidatorDescriptor<?>>> enabledBuiltinConstraints;
 
 		private StaticConstraintHelper() {
-			this.enabledBuiltinConstraints = Collections.unmodifiableMap( resolve( new HashSet<>( Arrays.asList( BuiltinConstraint.values() ) ) ) );
+			this( new HashSet<>( Arrays.asList( BuiltinConstraint.values() ) ) );
+		}
+
+		private StaticConstraintHelper(Set<BuiltinConstraint> builtinConstraints) {
+			this.enabledBuiltinConstraints = Collections.unmodifiableMap( resolve( builtinConstraints ) );
 		}
 
 		@SuppressWarnings("unchecked")

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/XmlMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/XmlMetaDataProvider.java
@@ -9,6 +9,7 @@ package org.hibernate.validator.internal.metadata.provider;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.hibernate.validator.internal.metadata.core.AnnotationProcessingOptions;
 import org.hibernate.validator.internal.metadata.raw.BeanConfiguration;
@@ -65,5 +66,10 @@ public class XmlMetaDataProvider implements MetaDataProvider {
 	@Override
 	public AnnotationProcessingOptions getAnnotationProcessingOptions() {
 		return annotationProcessingOptions;
+	}
+
+	public Set<Class<?>> configuredBeanClasses() {
+		return configuredBeans.values().stream().map( BeanConfiguration::getBeanClass )
+				.collect( Collectors.toSet() );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/predefinedscope/PredefinedScopeValidatorFactoryTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/predefinedscope/PredefinedScopeValidatorFactoryTest.java
@@ -330,7 +330,27 @@ public class PredefinedScopeValidatorFactoryTest {
 	}
 
 	@Test
-	public void testXmlDefinedConstraints() {
+	public void testXmlDefinedConstraintsDiscoveryDisabled() {
+		// we assume that all the metadata is defined in the xml,
+		// hence there is no built-in constraints nor beans to init,
+		// But we also do not ask HV to append the sets with the beans from XMLs or built-in constraints:
+		try (
+				ValidatorFactory factory = Validation.byProvider( PredefinedScopeHibernateValidator.class )
+						.configure()
+						.builtinConstraints( Collections.emptySet() )
+						.initializeBeanMetaData( Collections.emptySet() )
+						.includeBeansAndConstraintsDefinedOnlyInXml( false )
+						.addMapping( PredefinedScopeValidatorFactoryTest.class.getResourceAsStream( "constraints-simplexmlbean.xml" ) )
+						.buildValidatorFactory()
+		) {
+			Validator validator = factory.getValidator();
+			// Because all the metadata for this bean was in the XML, and we ignore it:
+			assertNoViolations( validator.validate( new SimpleXmlBean() ) );
+		}
+	}
+
+	@Test
+	public void testXmlDefinedConstraintsDiscoveryEnabled() {
 		// we assume that all the metadata is defined in the xml,
 		// hence there is no built-in constraints nor beans to init:
 		try (
@@ -349,7 +369,6 @@ public class PredefinedScopeValidatorFactoryTest {
 							violationOf( NotNull.class ).withMessage( "must not be null" )
 					);
 		}
-
 	}
 
 	private static ValidatorFactory getValidatorFactory() {

--- a/engine/src/test/java/org/hibernate/validator/test/predefinedscope/SimpleXmlBean.java
+++ b/engine/src/test/java/org/hibernate/validator/test/predefinedscope/SimpleXmlBean.java
@@ -1,0 +1,12 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.predefinedscope;
+
+public class SimpleXmlBean {
+	public int id;
+	public String name;
+}

--- a/engine/src/test/resources/org/hibernate/validator/test/predefinedscope/constraints-simplexmlbean.xml
+++ b/engine/src/test/resources/org/hibernate/validator/test/predefinedscope/constraints-simplexmlbean.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<constraint-mappings
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/validation/mapping https://jakarta.ee/xml/ns/validation/validation-mapping-3.0.xsd"
+        xmlns="https://jakarta.ee/xml/ns/validation/mapping" version="3.0">
+
+    <bean class="org.hibernate.validator.test.predefinedscope.SimpleXmlBean">
+        <field name="id">
+            <constraint annotation="jakarta.validation.constraints.Positive"/>
+        </field>
+        <field name="name">
+            <constraint annotation="jakarta.validation.constraints.NotNull"/>
+        </field>
+    </bean>
+</constraint-mappings>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2031

we have to:
- add the beans that are defined only in the XML (that's where `beanClassesToInitialize.addAll( xmlMetaDataProvider.configuredBeanClasses() )` helps)
- make sure that the constraint helper has all the constraints we need. Initially it'll have the built-in ones for the ones requested by the config. But if the XML is trying to apply any other constraint, we will be in trouble, as the helper will not have the info. So to make it work the predefined factory is using a "dynamic" version of the helper that goes back to looking up the built-in constraints. 


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
