### PR TITLE
Ignore the license check on a javadoc options xml generated in a target dir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -925,6 +925,7 @@
                                     <exclude>**/src/test/resources/org/hibernate/validator/test/internal/xml/**/*.xml</exclude>
                                     <exclude>.mvn/**</exclude>
                                     <exclude>**/generated-sources/**</exclude>
+                                    <exclude>**/javadoc-bundle-options/**</exclude>
                                 </excludes>
                                 <includes>
                                     <include>**/*.java</include>


### PR DESCRIPTION
…
why would the plugin even go check something in the target?! I'll leave that investigation for the future ... 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
