### PR TITLE
HV-2045 Upgrade to JBoss logging 3.6.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 
         <version.com.thoughtworks.paranamer>2.8</version.com.thoughtworks.paranamer>
         <version.org.glassfish.expressly>6.0.0-M1</version.org.glassfish.expressly>
-        <version.org.jboss.logging.jboss-logging>3.6.0.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>3.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
 
         <!-- Currently supported version of WildFly -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2045

https://github.com/hibernate/hibernate-validator/pull/1445

Bump org.jboss.logging:jboss-logging from 3.6.0.Final to 3.6.1.Final

Bumps [org.jboss.logging:jboss-logging](https://github.com/jboss-logging/jboss-logging) from 3.6.0.Final to 3.6.1.Final.
- [Release notes](https://github.com/jboss-logging/jboss-logging/releases)
- [Commits](https://github.com/jboss-logging/jboss-logging/compare/3.6.0.Final...3.6.1.Final)

---
updated-dependencies:
- dependency-name: org.jboss.logging:jboss-logging dependency-type: direct:production update-type: version-update:semver-patch ...

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
