### PR TITLE
HV-1942 Allow a single impl of a DefaultGroupSequenceProvider to be used on a wider range of types

### DIFF
--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/BazDefaultGroupSequenceProvider.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/BazDefaultGroupSequenceProvider.java
@@ -16,5 +16,5 @@ import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
  */
 public interface BazDefaultGroupSequenceProvider extends DefaultGroupSequenceProvider<Baz> {
 	@Override
-	List<Class<?>> getValidationGroups(GroupSequenceProviderDefinition.Baz object);
+	List<Class<?>> getValidationGroups(Class<?> klass, GroupSequenceProviderDefinition.Baz object);
 }

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/FooBarBazDefaultGroupSequenceProvider.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/FooBarBazDefaultGroupSequenceProvider.java
@@ -20,7 +20,7 @@ public class FooBarBazDefaultGroupSequenceProvider implements DefaultGroupSequen
 	}
 
 	@Override
-	public List<Class<?>> getValidationGroups(FooBarBaz object) {
+	public List<Class<?>> getValidationGroups(Class<?> klass, FooBarBaz object) {
 		return null;
 	}
 }

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/FooBarDefaultGroupSequenceProvider.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/FooBarDefaultGroupSequenceProvider.java
@@ -17,5 +17,5 @@ import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 public abstract class FooBarDefaultGroupSequenceProvider implements DefaultGroupSequenceProvider<FooBar> {
 
 	@Override
-	public abstract List<Class<?>> getValidationGroups(FooBar object);
+	public abstract List<Class<?>> getValidationGroups(Class<?> klass, FooBar object);
 }

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/FooDefaultGroupSequenceProvider.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/FooDefaultGroupSequenceProvider.java
@@ -17,7 +17,7 @@ import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 public class FooDefaultGroupSequenceProvider implements DefaultGroupSequenceProvider<Foo> {
 
 	@Override
-	public List<Class<?>> getValidationGroups(Foo object) {
+	public List<Class<?>> getValidationGroups(Class<?> klass, Foo object) {
 		return null;
 	}
 }

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/QuxDefaultGroupSequenceProvider.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/QuxDefaultGroupSequenceProvider.java
@@ -17,7 +17,7 @@ import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 public class QuxDefaultGroupSequenceProvider implements DefaultGroupSequenceProvider<Qux> {
 
 	@Override
-	public List<Class<?>> getValidationGroups(Qux object) {
+	public List<Class<?>> getValidationGroups(Class<?> klass, Qux object) {
 		return null;
 	}
 }

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/SampleDefaultGroupSequenceProvider.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/groupsequenceprovider/SampleDefaultGroupSequenceProvider.java
@@ -17,7 +17,7 @@ import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 public class SampleDefaultGroupSequenceProvider implements DefaultGroupSequenceProvider<Sample> {
 
 	@Override
-	public List<Class<?>> getValidationGroups(Sample object) {
+	public List<Class<?>> getValidationGroups(Class<?> klass, Sample object) {
 		return null;
 	}
 }

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter05/groupsequenceprovider/RentalCarGroupSequenceProvider.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter05/groupsequenceprovider/RentalCarGroupSequenceProvider.java
@@ -13,7 +13,7 @@ public class RentalCarGroupSequenceProvider
 		implements DefaultGroupSequenceProvider<RentalCar> {
 
 	@Override
-	public List<Class<?>> getValidationGroups(RentalCar car) {
+	public List<Class<?>> getValidationGroups(Class<?> klass, RentalCar car) {
 		List<Class<?>> defaultGroupSequence = new ArrayList<Class<?>>();
 		defaultGroupSequence.add( RentalCar.class );
 

--- a/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/constraintapi/RentalCarGroupSequenceProvider.java
+++ b/documentation/src/test/java/org/hibernate/validator/referenceguide/chapter12/constraintapi/RentalCarGroupSequenceProvider.java
@@ -6,7 +6,7 @@ import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 
 public class RentalCarGroupSequenceProvider implements DefaultGroupSequenceProvider<RentalCar> {
 	@Override
-	public List<Class<?>> getValidationGroups(RentalCar car) {
+	public List<Class<?>> getValidationGroups(Class<?> klass, RentalCar car) {
 		return null;
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/aggregated/BeanMetaDataImpl.java
@@ -378,7 +378,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	@Override
 	public List<Class<?>> getDefaultGroupSequence(T beanState) {
 		if ( hasDefaultGroupSequenceProvider() ) {
-			List<Class<?>> providerDefaultGroupSequence = defaultGroupSequenceProvider.getValidationGroups( beanState );
+			List<Class<?>> providerDefaultGroupSequence = defaultGroupSequenceProvider.getValidationGroups( beanClass, beanState );
 			return getValidDefaultGroupSequence( beanClass, providerDefaultGroupSequence );
 		}
 
@@ -388,7 +388,7 @@ public final class BeanMetaDataImpl<T> implements BeanMetaData<T> {
 	@Override
 	public Iterator<Sequence> getDefaultValidationSequence(T beanState) {
 		if ( hasDefaultGroupSequenceProvider() ) {
-			List<Class<?>> providerDefaultGroupSequence = defaultGroupSequenceProvider.getValidationGroups( beanState );
+			List<Class<?>> providerDefaultGroupSequence = defaultGroupSequenceProvider.getValidationGroups( beanClass, beanState );
 			return validationOrderGenerator.getDefaultValidationOrder(
 					beanClass,
 					getValidDefaultGroupSequence( beanClass, providerDefaultGroupSequence )

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/provider/AnnotationMetaDataProvider.java
@@ -169,13 +169,29 @@ public class AnnotationMetaDataProvider implements MetaDataProvider {
 	private <T> DefaultGroupSequenceProvider<? super T> newGroupSequenceProviderClassInstance(Class<T> beanClass,
 			Class<? extends DefaultGroupSequenceProvider<? super T>> providerClass) {
 		Method[] providerMethods = GetMethods.action( providerClass );
+		int numberOfDefaultMethods = 0;
 		for ( Method method : providerMethods ) {
 			if ( "getValidationGroups".equals( method.getName() )
 					&& !method.isBridge()
 					&& method.getParameterCount() == 1 && method.getParameterTypes()[0].isAssignableFrom( beanClass ) ) {
-
+				if ( method.isDefault() ) {
+					numberOfDefaultMethods++;
+					continue;
+				}
 				return NewInstance.action( providerClass, "the default group sequence provider" );
 			}
+			if ( "getValidationGroups".equals( method.getName() )
+					&& !method.isBridge()
+					&& method.getParameterCount() == 2 && method.getParameterTypes()[1].isAssignableFrom( beanClass ) ) {
+				if ( method.isDefault() ) {
+					numberOfDefaultMethods++;
+					continue;
+				}
+				return NewInstance.action( providerClass, "the default group sequence provider" );
+			}
+		}
+		if ( numberOfDefaultMethods == 2 ) {
+			throw LOG.getDefaultGroupSequenceProviderTypeDoesNotImplementAnyMethodsException( providerClass );
 		}
 
 		throw LOG.getWrongDefaultGroupSequenceProviderTypeException( beanClass );

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -940,4 +940,8 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 267, value = "'%c' is neither a digit nor an upper case ASCII letter.")
 	IllegalArgumentException getCharacterIsNotDigitOrUpperCaseLetterException(char c);
+
+	@Message(id = 268, value = "The default group sequence provider %s does not implement neither `getValidationGroups(Class<?> klass, T object)` nor `getValidationGroups(T object)` methods."
+			+ " One of them has to be implemented for the default group sequence provider to be correctly defined.")
+	GroupDefinitionException getDefaultGroupSequenceProviderTypeDoesNotImplementAnyMethodsException(@FormatWith(ClassObjectFormatter.class) Class<?> klass);
 }

--- a/engine/src/main/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProvider.java
+++ b/engine/src/main/java/org/hibernate/validator/spi/group/DefaultGroupSequenceProvider.java
@@ -11,27 +11,44 @@ import java.util.List;
 /**
  * This class defines the dynamic group sequence provider contract.
  * <p>
- * In order to redefine dynamically the default group sequence for a type T, the {@link org.hibernate.validator.group.GroupSequenceProvider} annotation
- * must be placed on T, specifying as its value a concrete implementation of {@code DefaultGroupSequenceProvider}, which
- * must be parametrized with the type T.
- * </p>
+ * In order to dynamically redefine the default group sequence for a type {@code T},
+ * the {@link org.hibernate.validator.group.GroupSequenceProvider} annotation
+ * must be placed on {@code T}, specifying as its value a concrete implementation of {@code DefaultGroupSequenceProvider}, which
+ * must be parametrized with that same type {@code T}, its subclass {@code Y} ({@code T t; t instanceof Y == true }
+ * or an interface {@code I} that is common to the beans on for which this sequence provider is expected to be applied to.
  * <p>
- * If during the validation process the {@code Default} group is validated for T, the actual validated instance
+ * If during the validation process the {@code Default} group is validated for {@code T}, the actual validated instance
  * is passed to the {@code DefaultGroupSequenceProvider} to determine the default group sequence.
- * </p>
  * <p>
  * Note:
  * <ul>
  * <li>Implementations must provide a public default constructor.</li>
  * <li>Implementations must be thread-safe.</li>
+ * <li>Implementations must return a valid default group sequence,
+ * i.e. the returned sequence <b>must</b> contain the bean type itself,
+ * which represents the {@link jakarta.validation.groups.Default default group}.</li>
  * </ul>
  *
  * @param <T> The type for which an implementation is defined.
- *
  * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  * @author Hardy Ferentschik
  */
 public interface DefaultGroupSequenceProvider<T> {
+
+	/**
+	 * This method returns the default group sequence for the given {@code klass} bean type and {@code object} instance.
+	 * <p>
+	 * The object parameter allows to dynamically compose the default group sequence based on the state of the validated value.
+	 *
+	 * @param klass the type of the bean for which the group sequence is requested.
+	 * @param object the instance under validation. This value <b>can</b> be {@code null}, e.g. in case this method was called as part of
+	 * {@linkplain jakarta.validation.Validator#validateValue(Class, String, Object, Class[]) Validator#validateValue}.
+	 * @return a list of classes specifying the default group sequence. The same constraints to the redefined group list
+	 * apply as for lists defined via {@code GroupSequence}. In particular the list has to contain the type T.
+	 */
+	default List<Class<?>> getValidationGroups(Class<?> klass, T object) {
+		return getValidationGroups( object );
+	}
 
 	/**
 	 * This method returns the default group sequence for the given instance.
@@ -41,9 +58,12 @@ public interface DefaultGroupSequenceProvider<T> {
 	 *
 	 * @param object the instance being validated. This value can be {@code null} in case this method was called as part of
 	 * {@linkplain jakarta.validation.Validator#validateValue(Class, String, Object, Class[]) Validator#validateValue}.
-	 *
 	 * @return a list of classes specifying the default group sequence. The same constraints to the redefined group list
-	 *         apply as for lists defined via {@code GroupSequence}. In particular the list has to contain the type T.
+	 * apply as for lists defined via {@code GroupSequence}. In particular the list has to contain the type T.
+	 * @deprecated Use the {@link #getValidationGroups(Class, Object)} instead.
 	 */
-	List<Class<?>> getValidationGroups(T object);
+	@Deprecated(forRemoval = true, since = "9.0.0")
+	default List<Class<?>> getValidationGroups(T object) {
+		throw new AssertionError( "Unexpected call to get the validation group sequence. " + "The variant receiving the bean type must be used by Hibernate Validator" );
+	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/ConstraintMappingTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/ConstraintMappingTest.java
@@ -628,21 +628,21 @@ public class ConstraintMappingTest {
 
 	public static class MarathonDefaultGroupSequenceProvider implements DefaultGroupSequenceProvider<Marathon> {
 		@Override
-		public List<Class<?>> getValidationGroups(Marathon object) {
+		public List<Class<?>> getValidationGroups(Class<?> klass, Marathon object) {
 			return Arrays.<Class<?>>asList( Foo.class, Marathon.class );
 		}
 	}
 
 	public static class BDefaultGroupSequenceProvider implements DefaultGroupSequenceProvider<B> {
 		@Override
-		public List<Class<?>> getValidationGroups(B object) {
+		public List<Class<?>> getValidationGroups(Class<?> klass, B object) {
 			return Arrays.<Class<?>>asList( Foo.class, B.class );
 		}
 	}
 
 	public static class ADefaultGroupSequenceProvider implements DefaultGroupSequenceProvider<A> {
 		@Override
-		public List<Class<?>> getValidationGroups(A object) {
+		public List<Class<?>> getValidationGroups(Class<?> klass, A object) {
 			return Arrays.<Class<?>>asList( Foo.class, A.class );
 		}
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/cfg/MultipleConstraintMappingsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/cfg/MultipleConstraintMappingsTest.java
@@ -178,7 +178,7 @@ public class MultipleConstraintMappingsTest {
 
 	public static class MarathonDefaultGroupSequenceProvider implements DefaultGroupSequenceProvider<Marathon> {
 		@Override
-		public List<Class<?>> getValidationGroups(Marathon object) {
+		public List<Class<?>> getValidationGroups(Class<?> klass, Marathon object) {
 			return Arrays.<Class<?>>asList( Foo.class, Marathon.class );
 		}
 	}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupsequenceprovider/DefaultGroupSequenceProviderTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupsequenceprovider/DefaultGroupSequenceProviderTest.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.test.internal.engine.groups.defaultgroupsequenceprovider;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 import static org.hibernate.validator.testutils.ValidatorUtil.getValidator;
@@ -15,12 +17,16 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.GroupDefinitionException;
 import jakarta.validation.Validator;
+import jakarta.validation.constraints.Negative;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Null;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.group.GroupSequenceProvider;
@@ -82,6 +88,25 @@ public class DefaultGroupSequenceProviderTest {
 		);
 	}
 
+	@SuppressWarnings("removal")
+	@Deprecated(forRemoval = true)
+	@Test
+	public void testValidateUserProviderDefaultGroupSequenceDeprecated() {
+		DeprecatedUser user = new DeprecatedUser( "$password" );
+		Set<ConstraintViolation<DeprecatedUser>> violations = validator.validate( user );
+
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Pattern.class ).withMessage( "must match \"\\w+\"" )
+		);
+
+		DeprecatedUser admin = new DeprecatedUser( "short", true );
+		violations = validator.validate( admin );
+
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Length.class ).withMessage( "length must be between 10 and 20" )
+		);
+	}
+
 	@Test
 	public void testValidatePropertyUserProviderDefaultGroupSequence() {
 		User user = new User( "$password" );
@@ -128,6 +153,44 @@ public class DefaultGroupSequenceProviderTest {
 		);
 	}
 
+	@Test
+	public void testGenericGroupSequenceProvider() {
+		GenericBean1 bean1 = new GenericBean1();
+
+		assertThat( validator.validate( bean1 ) ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
+
+		GenericGroupSequenceProvider.key.set( false );
+		assertNoViolations( validator.validate( bean1 ) );
+
+		GenericBean2 bean2 = new GenericBean2( "" );
+
+		assertThat( validator.validate( bean2 ) ).containsOnlyViolations(
+				violationOf( Positive.class )
+		);
+
+		GenericGroupSequenceProvider.key.set( true );
+		assertThat( validator.validate( bean2 ) ).containsOnlyViolations(
+				violationOf( Negative.class )
+		);
+
+		// validation stopped on the first (default) group validation.
+		assertThat( validator.validate( new GenericBean2( null ) ) ).containsOnlyViolations(
+				violationOf( NotNull.class )
+		);
+
+		assertThat( validator.validateValue( GenericBean2.class, "number", 0 ) ).containsOnlyViolations(
+				violationOf( Negative.class )
+		);
+	}
+
+	@Test
+	public void testNothingImplemented() {
+		assertThatThrownBy( () -> validator.validate( new DummyBean() ) )
+				.isInstanceOf( GroupDefinitionException.class );
+	}
+
 	@GroupSequenceProvider(NullGroupSequenceProvider.class)
 	private static class A {
 		@NotNull
@@ -167,7 +230,7 @@ public class DefaultGroupSequenceProviderTest {
 	public static class MethodGroupSequenceProvider implements DefaultGroupSequenceProvider<CImpl> {
 
 		@Override
-		public List<Class<?>> getValidationGroups(CImpl object) {
+		public List<Class<?>> getValidationGroups(Class<?> klass, CImpl object) {
 			return Arrays.<Class<?>>asList( TestGroup.class, CImpl.class );
 		}
 	}
@@ -175,7 +238,7 @@ public class DefaultGroupSequenceProviderTest {
 	public static class NullGroupSequenceProvider implements DefaultGroupSequenceProvider<A> {
 
 		@Override
-		public List<Class<?>> getValidationGroups(A object) {
+		public List<Class<?>> getValidationGroups(Class<?> klass, A object) {
 			return null;
 		}
 	}
@@ -183,11 +246,74 @@ public class DefaultGroupSequenceProviderTest {
 	public static class InvalidGroupSequenceProvider implements DefaultGroupSequenceProvider<B> {
 
 		@Override
-		public List<Class<?>> getValidationGroups(B object) {
+		public List<Class<?>> getValidationGroups(Class<?> klass, B object) {
 			List<Class<?>> defaultGroupSequence = new ArrayList<Class<?>>();
 			defaultGroupSequence.add( TestGroup.class );
 
 			return defaultGroupSequence;
 		}
+	}
+
+	/*
+	 * The idea is that the same group sequence provider can be applied to different, possibly unrelated, beans.
+	 * Because of that the sequence provider implementation does not know the bean type,
+	 * and passed in object value may be {@code null}, hence it wouldn't be possible to obtain the type info from the instance.
+	 * {@code null} instance can be passed in case of validating values, or on the startup when the defaults are initialized.
+	 */
+	public static class GenericGroupSequenceProvider implements DefaultGroupSequenceProvider<Object> {
+
+		public static final AtomicBoolean key = new AtomicBoolean( true );
+
+		@Override
+		public List<Class<?>> getValidationGroups(Class<?> clazz, Object object) {
+			if ( key.get() ) {
+				return List.of( clazz, GenericGroup1.class );
+			}
+			else {
+				return List.of( clazz, GenericGroup2.class );
+			}
+		}
+	}
+
+	interface GenericGroup1 {
+	}
+
+	interface GenericGroup2 {
+	}
+
+	@GroupSequenceProvider(GenericGroupSequenceProvider.class)
+	private static class GenericBean1 {
+		@NotNull(groups = GenericGroup1.class)
+		@Null(groups = GenericGroup2.class)
+		String string;
+	}
+
+	@GroupSequenceProvider(GenericGroupSequenceProvider.class)
+	private static class GenericBean2 {
+
+		private String string;
+
+		public GenericBean2(String string) {
+			this.string = string;
+		}
+
+		@Negative(groups = GenericGroup1.class)
+		@Positive(groups = GenericGroup2.class)
+		public int getNumber() {
+			return 0;
+		}
+
+		@NotNull
+		public String getString() {
+			return string;
+		}
+	}
+
+	public static class DummyGroupSequenceProvider implements DefaultGroupSequenceProvider<Object> {
+
+	}
+
+	@GroupSequenceProvider(DummyGroupSequenceProvider.class)
+	private static class DummyBean {
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupsequenceprovider/DeprecatedDynamicGroupSequenceProvider.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupsequenceprovider/DeprecatedDynamicGroupSequenceProvider.java
@@ -14,12 +14,14 @@ import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 /**
  * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
  */
-public class DynamicGroupSequenceProvider implements DefaultGroupSequenceProvider<User> {
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "9.0.0")
+public class DeprecatedDynamicGroupSequenceProvider implements DefaultGroupSequenceProvider<DeprecatedUser> {
 
 	@Override
-	public List<Class<?>> getValidationGroups(Class<?> klass, User user) {
-		List<Class<?>> defaultGroupSequence = new ArrayList<>();
-		defaultGroupSequence.add( User.class );
+	public List<Class<?>> getValidationGroups(DeprecatedUser user) {
+		List<Class<?>> defaultGroupSequence = new ArrayList<Class<?>>();
+		defaultGroupSequence.add( DeprecatedUser.class );
 
 		if ( user != null && user.isAdmin() ) {
 			defaultGroupSequence.add( StrongCheck.class );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupsequenceprovider/DeprecatedUser.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/groups/defaultgroupsequenceprovider/DeprecatedUser.java
@@ -1,0 +1,43 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+package org.hibernate.validator.test.internal.engine.groups.defaultgroupsequenceprovider;
+
+import jakarta.validation.constraints.Pattern;
+
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.group.GroupSequenceProvider;
+
+/**
+ * @author Kevin Pollet &lt;kevin.pollet@serli.com&gt; (C) 2011 SERLI
+ */
+@SuppressWarnings("removal")
+@Deprecated(forRemoval = true, since = "9.0.0")
+@GroupSequenceProvider(DeprecatedDynamicGroupSequenceProvider.class)
+public class DeprecatedUser {
+
+	private boolean admin;
+
+	//Define message to avoid comparison problem with validation error message
+	//with a different locale than en
+	@Pattern(regexp = "\\w+", message = "must match \"{regexp}\"")
+	@Length(min = 10, max = 20, message = "length must be between {min} and {max}", groups = StrongCheck.class)
+	private String password;
+
+	public DeprecatedUser(String password) {
+		this( password, false );
+	}
+
+	public DeprecatedUser(String password, boolean admin) {
+		this.password = password;
+		this.admin = admin;
+	}
+
+	public boolean isAdmin() {
+		return admin;
+	}
+
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1942

Since the existing assumption is that the provider is specific to a single type and cannot be placed on multiple types

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
