### PR TITLE
HV-2049 Bump Apache Groovy to 4.0.23 / HV-2048 Bump joda-time to 2.13.0 / HV-2047 Test against wildfly-preview 33.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
         <version.junit>4.13.2</version.junit>
         <version.org.easymock>5.4.0</version.org.easymock>
         <version.io.rest-assured>5.5.0</version.io.rest-assured>
-        <version.org.apache.groovy>4.0.22</version.org.apache.groovy>
+        <version.org.apache.groovy>4.0.23</version.org.apache.groovy>
         <version.com.google.guava>33.3.0-jre</version.com.google.guava>
         <version.org.springframework.spring-expression>6.1.12</version.org.springframework.spring-expression>
         <version.org.jboss.arquillian.container.arquillian-weld-embedded>4.0.0.Final</version.org.jboss.arquillian.container.arquillian-weld-embedded>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <version.org.jboss.logging.jboss-logging-tools>3.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
 
         <!-- Currently supported version of WildFly -->
-        <version.wildfly>33.0.1.Final</version.wildfly>
+        <version.wildfly>33.0.2.Final</version.wildfly>
         <!-- Used to create a patch file for the second version of WildFly we support -->
         <!--<version.wildfly.secondary>18.0.1.Final</version.wildfly.secondary>-->
         <!-- Version used to run the TCK in incontainer mode -->

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
             See http://search.maven.org/#search|gav|1|g%3A"org.wildfly"%20AND%20a%3A"wildfly-parent"
         -->
         <version.com.fasterxml.classmate>1.7.0</version.com.fasterxml.classmate>
-        <version.joda-time>2.12.7</version.joda-time>
+        <version.joda-time>2.13.0</version.joda-time>
         <version.org.slf4j>2.0.16</version.org.slf4j>
         <version.org.apache.logging.log4j>2.24.0</version.org.apache.logging.log4j>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2049
https://hibernate.atlassian.net/browse/HV-2048
https://hibernate.atlassian.net/browse/HV-2047

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
