### PR TITLE
HV-2053: Add Azerbaijani (az) locale support to validation messages

### DIFF
--- a/engine/src/main/resources/org/hibernate/validator/ValidationMessages_az.properties
+++ b/engine/src/main/resources/org/hibernate/validator/ValidationMessages_az.properties
@@ -1,56 +1,65 @@
-jakarta.validation.constraints.AssertFalse.message='false' olmal\u0131d\u0131r
-jakarta.validation.constraints.AssertTrue.message='true' olmal\u0131d\u0131r
-jakarta.validation.constraints.DecimalMax.message={value} \u0259d\u0259dind\u0259n ki\u00e7ik${inclusive == true ? ' b\u0259rab\u0259r ' : ' '}olmal\u0131d\u0131r
-jakarta.validation.constraints.DecimalMin.message={value} \u0259d\u0259dind\u0259n b\u00f6y\u00fck${inclusive == true ? ' b\u0259rab\u0259r ' : ' '}olmal\u0131d\u0131r
-jakarta.validation.constraints.Digits.message=tam hiss\u0259si {integer}, k\u0259sr hiss\u0259si {fraction} r\u0259q\u0259md\u0259n \u00e7ox olmamal\u0131d\u0131r
-jakarta.validation.constraints.Email.message=email \u00fcnvan\u0131 d\u00fczg\u00fcn formatda olmal\u0131d\u0131r
-jakarta.validation.constraints.Future.message=g\u0259l\u0259c\u0259k tarix olmal\u0131d\u0131r
-jakarta.validation.constraints.FutureOrPresent.message=indiki v\u0259 ya g\u0259l\u0259c\u0259k tarix olmal\u0131d\u0131r
-jakarta.validation.constraints.Max.message={value}-${value != 0 && value % 1000000 != 0 && value % 1000000000 != 0 && (value % 100 == 0 || value % 100 == 20 || value % 100 == 50 || value % 100 == 70 || value % 100 == 80 || value % 10 == 1 || value % 10 == 2 || value % 10 == 3 || value % 10 == 4 || value % 10 == 5 || value % 10 == 7 || value % 10 == 8) ? 'd\u0259n' : 'dan'} ki\u00e7ik b\u0259rab\u0259r olmal\u0131d\u0131r
-jakarta.validation.constraints.Min.message={value}-${value != 0 && value % 1000000 != 0 && value % 1000000000 != 0 && (value % 100 == 0 || value % 100 == 20 || value % 100 == 50 || value % 100 == 70 || value % 100 == 80 || value % 10 == 1 || value % 10 == 2 || value % 10 == 3 || value % 10 == 4 || value % 10 == 5 || value % 10 == 7 || value % 10 == 8) ? 'd\u0259n' : 'dan'} b\u00f6y\u00fck b\u0259rab\u0259r olmal\u0131d\u0131r
-jakarta.validation.constraints.Negative.message=0-dan ki\u00e7ik olmal\u0131d\u0131r
-jakarta.validation.constraints.NegativeOrZero.message=0-dan ki\u00e7ik b\u0259rab\u0259r olmal\u0131d\u0131r
-jakarta.validation.constraints.NotBlank.message=bo\u015f olmamal\u0131d\u0131r
-jakarta.validation.constraints.NotEmpty.message=bo\u015f olmamal\u0131d\u0131r
-jakarta.validation.constraints.NotNull.message=null olmamal\u0131d\u0131r
-jakarta.validation.constraints.Null.message=null olmal\u0131d\u0131r
-jakarta.validation.constraints.Past.message=ke\u00e7mi\u015f tarix olmal\u0131d\u0131r
-jakarta.validation.constraints.PastOrPresent.message=ke\u00e7mi\u015f v\u0259 ya indiki tarix olmal\u0131d\u0131r
-jakarta.validation.constraints.Pattern.message="{regexp}" n\u00fcmun\u0259sin\u0259 uy\u011fun olmal\u0131d\u0131r
-jakarta.validation.constraints.Positive.message=0-dan b\u00f6y\u00fck olmal\u0131d\u0131r
-jakarta.validation.constraints.PositiveOrZero.message=0-dan b\u00f6y\u00fck b\u0259rab\u0259r olmal\u0131d\u0131r
-jakarta.validation.constraints.Size.message=\u00f6l\u00e7\u00fc {min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
+jakarta.validation.constraints.AssertFalse.message                  = 'false' olmal\u0131d\u0131r
+jakarta.validation.constraints.AssertTrue.message                   = 'true' olmal\u0131d\u0131r
+jakarta.validation.constraints.DecimalMax.message                   = {value} \u0259d\u0259dind\u0259n ki\u00e7ik${inclusive == true ? ' b\u0259rab\u0259r ' : ' '}olmal\u0131d\u0131r
+jakarta.validation.constraints.DecimalMin.message                   = {value} \u0259d\u0259dind\u0259n b\u00f6y\u00fck${inclusive == true ? ' b\u0259rab\u0259r ' : ' '}olmal\u0131d\u0131r
+jakarta.validation.constraints.Digits.message                       = tam hiss\u0259si {integer}, k\u0259sr hiss\u0259si {fraction} r\u0259q\u0259md\u0259n \u00e7ox olmamal\u0131d\u0131r
+jakarta.validation.constraints.Email.message                        = email \u00fcnvan\u0131 d\u00fczg\u00fcn formatda olmal\u0131d\u0131r
+jakarta.validation.constraints.Future.message                       = g\u0259l\u0259c\u0259k tarix olmal\u0131d\u0131r
+jakarta.validation.constraints.FutureOrPresent.message              = indiki v\u0259 ya g\u0259l\u0259c\u0259k tarix olmal\u0131d\u0131r
+jakarta.validation.constraints.Max.message                          = {value}-${value != 0 && value % 1000000 != 0 && value % 1000000000 != 0 && (value % 100 == 0 || value % 100 == 20 || value % 100 == 50 || value % 100 == 70 || value % 100 == 80 || value % 10 == 1 || value % 10 == 2 || value % 10 == 3 || value % 10 == 4 || value % 10 == 5 || value % 10 == 7 || value % 10 == 8) ? 'd\u0259n' : 'dan'} ki\u00e7ik b\u0259rab\u0259r olmal\u0131d\u0131r
+jakarta.validation.constraints.Min.message                          = {value}-${value != 0 && value % 1000000 != 0 && value % 1000000000 != 0 && (value % 100 == 0 || value % 100 == 20 || value % 100 == 50 || value % 100 == 70 || value % 100 == 80 || value % 10 == 1 || value % 10 == 2 || value % 10 == 3 || value % 10 == 4 || value % 10 == 5 || value % 10 == 7 || value % 10 == 8) ? 'd\u0259n' : 'dan'} b\u00f6y\u00fck b\u0259rab\u0259r olmal\u0131d\u0131r
+jakarta.validation.constraints.Negative.message                     = 0-dan ki\u00e7ik olmal\u0131d\u0131r
+jakarta.validation.constraints.NegativeOrZero.message               = 0-dan ki\u00e7ik b\u0259rab\u0259r olmal\u0131d\u0131r
+jakarta.validation.constraints.NotBlank.message                     = bo\u015f olmamal\u0131d\u0131r
+jakarta.validation.constraints.NotEmpty.message                     = bo\u015f olmamal\u0131d\u0131r
+jakarta.validation.constraints.NotNull.message                      = null olmamal\u0131d\u0131r
+jakarta.validation.constraints.Null.message                         = null olmal\u0131d\u0131r
+jakarta.validation.constraints.Past.message                         = ke\u00e7mi\u015f tarix olmal\u0131d\u0131r
+jakarta.validation.constraints.PastOrPresent.message                = ke\u00e7mi\u015f v\u0259 ya indiki tarix olmal\u0131d\u0131r
+jakarta.validation.constraints.Pattern.message                      = "{regexp}" n\u00fcmun\u0259sin\u0259 uy\u011fun olmal\u0131d\u0131r
+jakarta.validation.constraints.Positive.message                     = 0-dan b\u00f6y\u00fck olmal\u0131d\u0131r
+jakarta.validation.constraints.PositiveOrZero.message               = 0-dan b\u00f6y\u00fck b\u0259rab\u0259r olmal\u0131d\u0131r
+jakarta.validation.constraints.Size.message                         = \u00f6l\u00e7\u00fc {min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
 
-org.hibernate.validator.constraints.CreditCardNumber.message=etibars\u0131z kredit kart\u0131 n\u00f6mr\u0259si
-org.hibernate.validator.constraints.Currency.message=etibars\u0131z valyuta (bunlardan biri olmal\u0131d\u0131r: {value})
-org.hibernate.validator.constraints.EAN.message=etibars\u0131z {type} barkodu
-org.hibernate.validator.constraints.Email.message=email \u00fcnvan\u0131 d\u00fczg\u00fcn formatda olmal\u0131d\u0131r
-org.hibernate.validator.constraints.ISBN.message=etibars\u0131z ISBN
-org.hibernate.validator.constraints.Length.message=uzunluq {min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
-org.hibernate.validator.constraints.CodePointLength.message=uzunluq {min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
-org.hibernate.validator.constraints.LuhnCheck.message=${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, Luhn Modulo 10 yoxlamas\u0131 u\u011fursuz oldu
-org.hibernate.validator.constraints.Mod10Check.message=${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, Modulo 10 yoxlamas\u0131 u\u011fursuz oldu
-org.hibernate.validator.constraints.Mod11Check.message=${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, Modulo 11 yoxlamas\u0131 u\u011fursuz oldu
-org.hibernate.validator.constraints.ModCheck.message=${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, {modType} yoxlamas\u0131 u\u011fursuz oldu
-org.hibernate.validator.constraints.Normalized.message=normalla\u015fd\u0131r\u0131lm\u0131\u015f olmal\u0131d\u0131r
-org.hibernate.validator.constraints.NotBlank.message=bo\u015f olmamal\u0131d\u0131r
-org.hibernate.validator.constraints.NotEmpty.message=bo\u015f olmamal\u0131d\u0131r
-org.hibernate.validator.constraints.ParametersScriptAssert.message=skript ifad\u0259si "{script}" 'true' deyil
-org.hibernate.validator.constraints.Range.message={min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
-org.hibernate.validator.constraints.ScriptAssert.message=skript ifad\u0259si "{script}" 'true' deyil
-org.hibernate.validator.constraints.UniqueElements.message=yaln\u0131z unikal elementl\u0259rd\u0259n ibar\u0259t olmal\u0131d\u0131r
-org.hibernate.validator.constraints.URL.message=etibarl\u0131 URL olmal\u0131d\u0131r
-org.hibernate.validator.constraints.UUID.message=etibarl\u0131 UUID olmal\u0131d\u0131r
+org.hibernate.validator.constraints.CreditCardNumber.message        = etibars\u0131z kredit kart\u0131 n\u00f6mr\u0259si
+org.hibernate.validator.constraints.Currency.message                = etibars\u0131z valyuta (bunlardan biri olmal\u0131d\u0131r: {value})
+org.hibernate.validator.constraints.EAN.message                     = etibars\u0131z {type} barkodu
+org.hibernate.validator.constraints.ISBN.message                    = etibars\u0131z ISBN
+org.hibernate.validator.constraints.Length.message                  = uzunluq {min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
+org.hibernate.validator.constraints.CodePointLength.message         = uzunluq {min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
+org.hibernate.validator.constraints.LuhnCheck.message               = ${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, Luhn Modulo 10 yoxlamas\u0131 u\u011fursuz oldu
+org.hibernate.validator.constraints.Mod10Check.message              = ${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, Modulo 10 yoxlamas\u0131 u\u011fursuz oldu
+org.hibernate.validator.constraints.Mod11Check.message              = ${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, Modulo 11 yoxlamas\u0131 u\u011fursuz oldu
+org.hibernate.validator.constraints.Normalized.message              = normalla\u015fd\u0131r\u0131lm\u0131\u015f olmal\u0131d\u0131r
+org.hibernate.validator.constraints.ParametersScriptAssert.message  = skript ifad\u0259si "{script}" 'true' deyil
+org.hibernate.validator.constraints.Range.message                   = {min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
+org.hibernate.validator.constraints.ScriptAssert.message            = skript ifad\u0259si "{script}" 'true' deyil
+org.hibernate.validator.constraints.UniqueElements.message          = yaln\u0131z unikal elementl\u0259rd\u0259n ibar\u0259t olmal\u0131d\u0131r
+org.hibernate.validator.constraints.URL.message                     = etibarl\u0131 URL olmal\u0131d\u0131r
+org.hibernate.validator.constraints.UUID.message                    = etibarl\u0131 UUID olmal\u0131d\u0131r
 
-org.hibernate.validator.constraints.br.CNPJ.message=Braziliya korporativ vergi \u00f6d\u0259yicisinin qeydiyyat n\u00f6mr\u0259si (CNPJ) yanl\u0131\u015fd\u0131r
-org.hibernate.validator.constraints.br.CPF.message=Braziliya f\u0259rdi vergi \u00f6d\u0259yicisinin qeydiyyat n\u00f6mr\u0259si (CPF) yanl\u0131\u015fd\u0131r
-org.hibernate.validator.constraints.br.TituloEleitoral.message=Braziliya se\u00e7ici \u015f\u0259xsiyy\u0259t v\u0259siq\u0259si n\u00f6mr\u0259si yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.br.CNPJ.message                 = Braziliya korporativ vergi \u00f6d\u0259yicisinin qeydiyyat n\u00f6mr\u0259si (CNPJ) yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.br.CPF.message                  = Braziliya f\u0259rdi vergi \u00f6d\u0259yicisinin qeydiyyat n\u00f6mr\u0259si (CPF) yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.br.TituloEleitoral.message      = Braziliya se\u00e7ici \u015f\u0259xsiyy\u0259t v\u0259siq\u0259si n\u00f6mr\u0259si yanl\u0131\u015fd\u0131r
 
-org.hibernate.validator.constraints.pl.REGON.message=Pol\u015fa vergi \u00f6d\u0259yicisinin eynil\u0259\u015fdirm\u0259 n\u00f6mr\u0259si (REGON) yanl\u0131\u015fd\u0131r
-org.hibernate.validator.constraints.pl.NIP.message=\u018fDV eynil\u0259\u015fdirm\u0259 n\u00f6mr\u0259si (NIP) yanl\u0131\u015fd\u0131r
-org.hibernate.validator.constraints.pl.PESEL.message=Pol\u015fa milli \u015f\u0259xsiyy\u0259t n\u00f6mr\u0259si (PESEL) yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.kor.KorRRN.message              = yanl\u0131\u015F Koreya rezident qeydiyyat n\u00F6mr\u0259si (KorRRN)
 
-org.hibernate.validator.constraints.ru.INN.message=Rusiya vergi \u00f6d\u0259yicisinin eynil\u0259\u015fdirm\u0259 n\u00f6mr\u0259si (INN) yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.pl.REGON.message                = Pol\u015fa vergi \u00f6d\u0259yicisinin eynil\u0259\u015fdirm\u0259 n\u00f6mr\u0259si (REGON) yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.pl.NIP.message                  = \u018fDV eynil\u0259\u015fdirm\u0259 n\u00f6mr\u0259si (NIP) yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.pl.PESEL.message                = Pol\u015fa milli \u015f\u0259xsiyy\u0259t n\u00f6mr\u0259si (PESEL) yanl\u0131\u015fd\u0131r
 
-org.hibernate.validator.constraints.time.DurationMin.message=m\u00fcdd\u0259t${days == 0 ? '' : (' ' += days += ' g\u00fcn' += (hours == 0 && minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${hours == 0 ? '' : (' ' += hours += ' saat' += (minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${minutes == 0 ? '' : (' ' += minutes += ' d\u0259qiq\u0259' += (seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${seconds == 0 ? '' : (' ' += seconds += ' saniy\u0259' += (millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${millis == 0 ? '' : (' ' += millis += ' millisaniy\u0259' += (nanos == 0 ? 'd\u0259n' : ''))}${nanos == 0 ? '' : (' ' += nanos += ' nanosaniy\u0259d\u0259n')} uzun{inclusive == true ? ' b\u0259rab\u0259r' : ''} olmal\u0131d\u0131r
-org.hibernate.validator.constraints.time.DurationMax.message=m\u00fcdd\u0259t${days == 0 ? '' : (' ' += days += ' g\u00fcn' += (hours == 0 && minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${hours == 0 ? '' : (' ' += hours += ' saat' += (minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${minutes == 0 ? '' : (' ' += minutes += ' d\u0259qiq\u0259' += (seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${seconds == 0 ? '' : (' ' += seconds += ' saniy\u0259' += (millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${millis == 0 ? '' : (' ' += millis += ' millisaniy\u0259' += (nanos == 0 ? 'd\u0259n' : ''))}${nanos == 0 ? '' : (' ' += nanos += ' nanosaniy\u0259d\u0259n')} q\u0131sa${inclusive == true ? ' b\u0259rab\u0259r' : ''} olmal\u0131d\u0131r
+org.hibernate.validator.constraints.ru.INN.message                  = Rusiya vergi \u00f6d\u0259yicisinin eynil\u0259\u015fdirm\u0259 n\u00f6mr\u0259si (INN) yanl\u0131\u015fd\u0131r
+
+org.hibernate.validator.constraints.time.DurationMin.message        = m\u00fcdd\u0259t${days == 0 ? '' : (' ' += days += ' g\u00fcn' += (hours == 0 && minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${hours == 0 ? '' : (' ' += hours += ' saat' += (minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${minutes == 0 ? '' : (' ' += minutes += ' d\u0259qiq\u0259' += (seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${seconds == 0 ? '' : (' ' += seconds += ' saniy\u0259' += (millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${millis == 0 ? '' : (' ' += millis += ' millisaniy\u0259' += (nanos == 0 ? 'd\u0259n' : ''))}${nanos == 0 ? '' : (' ' += nanos += ' nanosaniy\u0259d\u0259n')} uzun{inclusive == true ? ' b\u0259rab\u0259r' : ''} olmal\u0131d\u0131r
+org.hibernate.validator.constraints.time.DurationMax.message        = m\u00fcdd\u0259t${days == 0 ? '' : (' ' += days += ' g\u00fcn' += (hours == 0 && minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${hours == 0 ? '' : (' ' += hours += ' saat' += (minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${minutes == 0 ? '' : (' ' += minutes += ' d\u0259qiq\u0259' += (seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${seconds == 0 ? '' : (' ' += seconds += ' saniy\u0259' += (millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${millis == 0 ? '' : (' ' += millis += ' millisaniy\u0259' += (nanos == 0 ? 'd\u0259n' : ''))}${nanos == 0 ? '' : (' ' += nanos += ' nanosaniy\u0259d\u0259n')} q\u0131sa${inclusive == true ? ' b\u0259rab\u0259r' : ''} olmal\u0131d\u0131r
+
+
+org.hibernate.validator.constraints.BitcoinAddress.message.single   = bu n\u00F6v \u00FC\u00E7\u00FCn etibarl\u0131 Bitcoin \u00FCnvan\u0131 olmal\u0131d\u0131r:
+org.hibernate.validator.constraints.BitcoinAddress.message.multiple = bu n\u00F6vl\u0259rd\u0259n biri \u00FC\u00E7\u00FCn etibarl\u0131 Bitcoin \u00FCnvan\u0131 olmal\u0131d\u0131r:
+
+org.hibernate.validator.constraints.BitcoinAddress.type.p2pkh       = K\u00F6hn\u0259 (P2PKH)
+org.hibernate.validator.constraints.BitcoinAddress.type.p2sh        = Daxili SegWit (P2SH)
+org.hibernate.validator.constraints.BitcoinAddress.type.bech32      = Yerli SegWit (Bech32)
+org.hibernate.validator.constraints.BitcoinAddress.type.p2wsh       = P2SH-nin SegWit variant\u0131 (P2WSH)
+org.hibernate.validator.constraints.BitcoinAddress.type.p2wpkh      = P2PKH-nin SegWit variant\u0131 (P2WPKH)
+org.hibernate.validator.constraints.BitcoinAddress.type.p2tr        = Taproot (P2TR)

--- a/engine/src/main/resources/org/hibernate/validator/ValidationMessages_az.properties
+++ b/engine/src/main/resources/org/hibernate/validator/ValidationMessages_az.properties
@@ -1,0 +1,56 @@
+jakarta.validation.constraints.AssertFalse.message='false' olmal\u0131d\u0131r
+jakarta.validation.constraints.AssertTrue.message='true' olmal\u0131d\u0131r
+jakarta.validation.constraints.DecimalMax.message={value} \u0259d\u0259dind\u0259n ki\u00e7ik${inclusive == true ? ' b\u0259rab\u0259r ' : ' '}olmal\u0131d\u0131r
+jakarta.validation.constraints.DecimalMin.message={value} \u0259d\u0259dind\u0259n b\u00f6y\u00fck${inclusive == true ? ' b\u0259rab\u0259r ' : ' '}olmal\u0131d\u0131r
+jakarta.validation.constraints.Digits.message=tam hiss\u0259si {integer}, k\u0259sr hiss\u0259si {fraction} r\u0259q\u0259md\u0259n \u00e7ox olmamal\u0131d\u0131r
+jakarta.validation.constraints.Email.message=email \u00fcnvan\u0131 d\u00fczg\u00fcn formatda olmal\u0131d\u0131r
+jakarta.validation.constraints.Future.message=g\u0259l\u0259c\u0259k tarix olmal\u0131d\u0131r
+jakarta.validation.constraints.FutureOrPresent.message=indiki v\u0259 ya g\u0259l\u0259c\u0259k tarix olmal\u0131d\u0131r
+jakarta.validation.constraints.Max.message={value}-${value != 0 && value % 1000000 != 0 && value % 1000000000 != 0 && (value % 100 == 0 || value % 100 == 20 || value % 100 == 50 || value % 100 == 70 || value % 100 == 80 || value % 10 == 1 || value % 10 == 2 || value % 10 == 3 || value % 10 == 4 || value % 10 == 5 || value % 10 == 7 || value % 10 == 8) ? 'd\u0259n' : 'dan'} ki\u00e7ik b\u0259rab\u0259r olmal\u0131d\u0131r
+jakarta.validation.constraints.Min.message={value}-${value != 0 && value % 1000000 != 0 && value % 1000000000 != 0 && (value % 100 == 0 || value % 100 == 20 || value % 100 == 50 || value % 100 == 70 || value % 100 == 80 || value % 10 == 1 || value % 10 == 2 || value % 10 == 3 || value % 10 == 4 || value % 10 == 5 || value % 10 == 7 || value % 10 == 8) ? 'd\u0259n' : 'dan'} b\u00f6y\u00fck b\u0259rab\u0259r olmal\u0131d\u0131r
+jakarta.validation.constraints.Negative.message=0-dan ki\u00e7ik olmal\u0131d\u0131r
+jakarta.validation.constraints.NegativeOrZero.message=0-dan ki\u00e7ik b\u0259rab\u0259r olmal\u0131d\u0131r
+jakarta.validation.constraints.NotBlank.message=bo\u015f olmamal\u0131d\u0131r
+jakarta.validation.constraints.NotEmpty.message=bo\u015f olmamal\u0131d\u0131r
+jakarta.validation.constraints.NotNull.message=null olmamal\u0131d\u0131r
+jakarta.validation.constraints.Null.message=null olmal\u0131d\u0131r
+jakarta.validation.constraints.Past.message=ke\u00e7mi\u015f tarix olmal\u0131d\u0131r
+jakarta.validation.constraints.PastOrPresent.message=ke\u00e7mi\u015f v\u0259 ya indiki tarix olmal\u0131d\u0131r
+jakarta.validation.constraints.Pattern.message="{regexp}" n\u00fcmun\u0259sin\u0259 uy\u011fun olmal\u0131d\u0131r
+jakarta.validation.constraints.Positive.message=0-dan b\u00f6y\u00fck olmal\u0131d\u0131r
+jakarta.validation.constraints.PositiveOrZero.message=0-dan b\u00f6y\u00fck b\u0259rab\u0259r olmal\u0131d\u0131r
+jakarta.validation.constraints.Size.message=\u00f6l\u00e7\u00fc {min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
+
+org.hibernate.validator.constraints.CreditCardNumber.message=etibars\u0131z kredit kart\u0131 n\u00f6mr\u0259si
+org.hibernate.validator.constraints.Currency.message=etibars\u0131z valyuta (bunlardan biri olmal\u0131d\u0131r: {value})
+org.hibernate.validator.constraints.EAN.message=etibars\u0131z {type} barkodu
+org.hibernate.validator.constraints.Email.message=email \u00fcnvan\u0131 d\u00fczg\u00fcn formatda olmal\u0131d\u0131r
+org.hibernate.validator.constraints.ISBN.message=etibars\u0131z ISBN
+org.hibernate.validator.constraints.Length.message=uzunluq {min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
+org.hibernate.validator.constraints.CodePointLength.message=uzunluq {min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
+org.hibernate.validator.constraints.LuhnCheck.message=${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, Luhn Modulo 10 yoxlamas\u0131 u\u011fursuz oldu
+org.hibernate.validator.constraints.Mod10Check.message=${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, Modulo 10 yoxlamas\u0131 u\u011fursuz oldu
+org.hibernate.validator.constraints.Mod11Check.message=${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, Modulo 11 yoxlamas\u0131 u\u011fursuz oldu
+org.hibernate.validator.constraints.ModCheck.message=${validatedValue} \u00fc\u00e7\u00fcn yoxlama r\u0259q\u0259mi etibars\u0131zd\u0131r, {modType} yoxlamas\u0131 u\u011fursuz oldu
+org.hibernate.validator.constraints.Normalized.message=normalla\u015fd\u0131r\u0131lm\u0131\u015f olmal\u0131d\u0131r
+org.hibernate.validator.constraints.NotBlank.message=bo\u015f olmamal\u0131d\u0131r
+org.hibernate.validator.constraints.NotEmpty.message=bo\u015f olmamal\u0131d\u0131r
+org.hibernate.validator.constraints.ParametersScriptAssert.message=skript ifad\u0259si "{script}" 'true' deyil
+org.hibernate.validator.constraints.Range.message={min} v\u0259 {max} aras\u0131nda olmal\u0131d\u0131r
+org.hibernate.validator.constraints.ScriptAssert.message=skript ifad\u0259si "{script}" 'true' deyil
+org.hibernate.validator.constraints.UniqueElements.message=yaln\u0131z unikal elementl\u0259rd\u0259n ibar\u0259t olmal\u0131d\u0131r
+org.hibernate.validator.constraints.URL.message=etibarl\u0131 URL olmal\u0131d\u0131r
+org.hibernate.validator.constraints.UUID.message=etibarl\u0131 UUID olmal\u0131d\u0131r
+
+org.hibernate.validator.constraints.br.CNPJ.message=Braziliya korporativ vergi \u00f6d\u0259yicisinin qeydiyyat n\u00f6mr\u0259si (CNPJ) yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.br.CPF.message=Braziliya f\u0259rdi vergi \u00f6d\u0259yicisinin qeydiyyat n\u00f6mr\u0259si (CPF) yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.br.TituloEleitoral.message=Braziliya se\u00e7ici \u015f\u0259xsiyy\u0259t v\u0259siq\u0259si n\u00f6mr\u0259si yanl\u0131\u015fd\u0131r
+
+org.hibernate.validator.constraints.pl.REGON.message=Pol\u015fa vergi \u00f6d\u0259yicisinin eynil\u0259\u015fdirm\u0259 n\u00f6mr\u0259si (REGON) yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.pl.NIP.message=\u018fDV eynil\u0259\u015fdirm\u0259 n\u00f6mr\u0259si (NIP) yanl\u0131\u015fd\u0131r
+org.hibernate.validator.constraints.pl.PESEL.message=Pol\u015fa milli \u015f\u0259xsiyy\u0259t n\u00f6mr\u0259si (PESEL) yanl\u0131\u015fd\u0131r
+
+org.hibernate.validator.constraints.ru.INN.message=Rusiya vergi \u00f6d\u0259yicisinin eynil\u0259\u015fdirm\u0259 n\u00f6mr\u0259si (INN) yanl\u0131\u015fd\u0131r
+
+org.hibernate.validator.constraints.time.DurationMin.message=m\u00fcdd\u0259t${days == 0 ? '' : (' ' += days += ' g\u00fcn' += (hours == 0 && minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${hours == 0 ? '' : (' ' += hours += ' saat' += (minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${minutes == 0 ? '' : (' ' += minutes += ' d\u0259qiq\u0259' += (seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${seconds == 0 ? '' : (' ' += seconds += ' saniy\u0259' += (millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${millis == 0 ? '' : (' ' += millis += ' millisaniy\u0259' += (nanos == 0 ? 'd\u0259n' : ''))}${nanos == 0 ? '' : (' ' += nanos += ' nanosaniy\u0259d\u0259n')} uzun{inclusive == true ? ' b\u0259rab\u0259r' : ''} olmal\u0131d\u0131r
+org.hibernate.validator.constraints.time.DurationMax.message=m\u00fcdd\u0259t${days == 0 ? '' : (' ' += days += ' g\u00fcn' += (hours == 0 && minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${hours == 0 ? '' : (' ' += hours += ' saat' += (minutes == 0 && seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${minutes == 0 ? '' : (' ' += minutes += ' d\u0259qiq\u0259' += (seconds == 0 && millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${seconds == 0 ? '' : (' ' += seconds += ' saniy\u0259' += (millis == 0 && nanos == 0 ? 'd\u0259n' : ''))}${millis == 0 ? '' : (' ' += millis += ' millisaniy\u0259' += (nanos == 0 ? 'd\u0259n' : ''))}${nanos == 0 ? '' : (' ' += nanos += ' nanosaniy\u0259d\u0259n')} q\u0131sa${inclusive == true ? ' b\u0259rab\u0259r' : ''} olmal\u0131d\u0131r


### PR DESCRIPTION
[Jira issue HV-2053](https://hibernate.atlassian.net/browse/HV-2053)

- Unicode encoding applied for Azerbaijani-specific characters (e.g., `ə`, `ç`, `ş`, `ü`, `ö`, `ğ`, `ı`).
- Implemented custom EL syntax logic to handle Azerbaijani suffixes (`-dan` and `-dən`) accurately.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
