### PR TITLE
HV-2056 Update to OpenJFX from 17.0.12 to 17.0.13 / HV-2055 Update version.org.jboss.logging.jboss-logging-tools from 3.0.1.Final to 3.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
         <version.com.thoughtworks.paranamer>2.8</version.com.thoughtworks.paranamer>
         <version.org.glassfish.expressly>6.0.0-M1</version.org.glassfish.expressly>
         <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.jboss-logging-tools>3.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logging.jboss-logging-tools>3.0.2.Final</version.org.jboss.logging.jboss-logging-tools>
 
         <!-- Currently supported version of WildFly -->
         <version.wildfly>33.0.2.Final</version.wildfly>

--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <version.javax.annotation>1.2</version.javax.annotation>
 
         <!-- JavaFX dependencies -->
-        <version.org.openjfx>17.0.12</version.org.openjfx>
+        <version.org.openjfx>17.0.13</version.org.openjfx>
 
         <!-- Test dependencies -->
         <version.org.jboss.arquillian>1.9.1.Final</version.org.jboss.arquillian>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2055
https://hibernate.atlassian.net/browse/HV-2056

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
