### PR TITLE
HV-2058 Test against wildfly-preview 34.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <version.org.jboss.logging.jboss-logging-tools>3.0.2.Final</version.org.jboss.logging.jboss-logging-tools>
 
         <!-- Currently supported version of WildFly -->
-        <version.wildfly>33.0.2.Final</version.wildfly>
+        <version.wildfly>34.0.0.Final</version.wildfly>
         <!-- Used to create a patch file for the second version of WildFly we support -->
         <!--<version.wildfly.secondary>18.0.1.Final</version.wildfly.secondary>-->
         <!-- Version used to run the TCK in incontainer mode -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2058

Bumps org.wildfly:wildfly-preview-dist from 33.0.2.Final to 34.0.0.Final.

---
updated-dependencies:
- dependency-name: org.wildfly:wildfly-preview-dist dependency-type: direct:production update-type: version-update:semver-major ...


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
