### PR TITLE
Drop log4j-core test-jar from dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,12 +524,6 @@
                 <version>${version.org.apache.logging.log4j}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <type>test-jar</type>
-                <version>${version.org.apache.logging.log4j}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${version.org.slf4j}</version>


### PR DESCRIPTION
- since it is not available and causing issues with Dependabot (most likely)
- there's a log4j-core-test now if we'd ever need it ...

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
