### PR TITLE
Remove additional management of log4j in the perf module

### DIFF
--- a/performance/pom.xml
+++ b/performance/pom.xml
@@ -40,7 +40,6 @@
         <profilingOptions>-showversion</profilingOptions>
         <history.directory>${project.basedir}/history</history.directory>
         <jmh.version>1.37</jmh.version>
-        <version.log4j-core>2.23.1</version.log4j-core>
 
         <!-- default values, overridden per profile -->
         <beanvalidation-impl.name>none</beanvalidation-impl.name>
@@ -48,16 +47,6 @@
 
         <hibernate-validator-parent.path>../..</hibernate-validator-parent.path>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-core</artifactId>
-                <version>${version.log4j-core}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
- as now it can match the one managed in the root for tests

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
