### PR TITLE
Use OSGi framework utils to get a classloader (aaaand not depend on the EL implementation in engine)

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -53,11 +53,6 @@
         Provided dependencies
         -->
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>jakarta.el</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-processor</artifactId>
             <!--
@@ -79,6 +74,11 @@
         <!--
         Optional dependencies
         -->
+        <dependency>
+            <groupId>jakarta.el</groupId>
+            <artifactId>jakarta.el-api</artifactId>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
@@ -115,6 +115,11 @@
         <!--
         Test dependencies
         -->
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -391,6 +391,11 @@
                 <version>${version.org.glassfish.jakarta.el}</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
+                <version>${version.jakarta.el-api}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml</groupId>
                 <artifactId>classmate</artifactId>
                 <version>${version.com.fasterxml.classmate}</version>


### PR DESCRIPTION
I am opening this as a draft just to share.

That's what I ended up with to make that work .... and since we don't have a dependency on OSGi in the engine (and we wouldn't want that one, right ?! 😄) I ended up with some reflection... which is essentially doing this:

```java
	ClassLoader classLoaderForExpressionFactory() {
		for ( Bundle bundle : FrameworkUtil.getBundle( ResourceBundleMessageInterpolator.class ).getBundleContext().getBundles() ) {
			try {
				return bundle.loadClass( "com.sun.el.ExpressionFactoryImpl" ).getClassLoader();
			}
			catch (ClassNotFoundException e) {
				// ignore
			}
		}
		return null;
	}
```

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
