### PR TITLE
HV-2020 Use OSGi framework utils to get a classloader

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -75,12 +75,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.expressly</groupId>
-            <artifactId>expressly</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
             <scope>provided</scope>
@@ -125,6 +119,11 @@
         <!--
         Test dependencies
         -->
+        <dependency>
+            <groupId>org.glassfish.expressly</groupId>
+            <artifactId>expressly</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2020

Use OSGi framework utils to get a classloader, and do not rely on a dependency to expressly.

Based on the change from https://github.com/hibernate/hibernate-validator/pull/1493 that targets 7.0 where we still could run OSGi tests

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
