### PR TITLE
Upgrade to hibernate-jenkins-pipeline-helpers 1.18 -- and configure the version on CI instead of in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,8 @@ import groovy.transform.Field
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.17')
+@Library('hibernate-jenkins-pipeline-helpers@1.17') _
+
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 import org.hibernate.jenkins.pipeline.helpers.alternative.AlternativeMultiMap
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ import groovy.transform.Field
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.17') _
+@Library('hibernate-jenkins-pipeline-helpers@1.18') _
 
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 import org.hibernate.jenkins.pipeline.helpers.alternative.AlternativeMultiMap

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ import groovy.transform.Field
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.18') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 import org.hibernate.jenkins.pipeline.helpers.job.JobHelper
 import org.hibernate.jenkins.pipeline.helpers.alternative.AlternativeMultiMap

--- a/jenkins/nightly/Jenkinsfile
+++ b/jenkins/nightly/Jenkinsfile
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-@Library('hibernate-jenkins-pipeline-helpers@1.17') _
+@Library('hibernate-jenkins-pipeline-helpers@1.18') _
 
 def withMavenWorkspace(Closure body) {
 	withMavenWorkspace('OpenJDK 17 Latest', body)

--- a/jenkins/nightly/Jenkinsfile
+++ b/jenkins/nightly/Jenkinsfile
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-@Library('hibernate-jenkins-pipeline-helpers@1.18') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 def withMavenWorkspace(Closure body) {
 	withMavenWorkspace('OpenJDK 17 Latest', body)

--- a/jenkins/release.groovy
+++ b/jenkins/release.groovy
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-@Library('hibernate-jenkins-pipeline-helpers@1.18') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 import org.hibernate.jenkins.pipeline.helpers.version.Version
 

--- a/jenkins/release.groovy
+++ b/jenkins/release.groovy
@@ -3,7 +3,7 @@
  * Copyright Red Hat Inc. and Hibernate Authors
  */
 
-@Library('hibernate-jenkins-pipeline-helpers@1.17') _
+@Library('hibernate-jenkins-pipeline-helpers@1.18') _
 
 import org.hibernate.jenkins.pipeline.helpers.version.Version
 


### PR DESCRIPTION
Upgrade to 1.18 to avoid buggy notifications.
See https://hibernate.zulipchat.com/#narrow/channel/132096-hibernate-user/topic/Jenkins.20Notifications
Full changeset: https://github.com/hibernate/hibernate-jenkins-pipeline-helpers/compare/1.17..1.18

Don't configure the version in Jenkinsfile so that it's easier to upgrade next time.
See https://ci.hibernate.org/manage/configure#global-untrusted-pipeline-libraries to change the (default) version globally for all projects.


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
