### PR TITLE
Bump arquillian and WildFly launcher versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
         <version.org.jboss.logging.jboss-logging-tools>3.0.3.Final</version.org.jboss.logging.jboss-logging-tools>
 
         <!-- Currently supported version of WildFly -->
+        <!-- Update JDK 24 configuration when changing this version: -->
         <version.wildfly>34.0.1.Final</version.wildfly>
         <!-- Used to create a patch file for the second version of WildFly we support -->
         <!--<version.wildfly.secondary>18.0.1.Final</version.wildfly.secondary>-->
@@ -166,7 +167,7 @@
             See http://search.maven.org/#search|gav|1|g%3A"org.wildfly"%20AND%20a%3A"wildfly-parent"
         -->
         <version.org.jboss.weld.weld>6.0.0.Beta4</version.org.jboss.weld.weld>
-        <version.org.wildfly.arquillian>5.0.0.Alpha3</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>5.1.0.Beta8</version.org.wildfly.arquillian>
         <version.jakarta.jakartaee-bom>11.0.0-M4</version.jakarta.jakartaee-bom>
         <!--
             These are now managed by the BOM ^ but we want to have version properties available to us
@@ -397,7 +398,8 @@
 
         <arquillian.wildfly.jvm.args.add-opens></arquillian.wildfly.jvm.args.add-opens>
         <arquillian.wildfly.jvm.args.add-modules></arquillian.wildfly.jvm.args.add-modules>
-        <arquillian.wildfly.jvm.args>-Duser.language=en -Duser.country=US ${arquillian.wildfly.jvm.args.add-opens} ${arquillian.wildfly.jvm.args.add-modules}</arquillian.wildfly.jvm.args>
+        <arquillian.jvm.args.java-version></arquillian.jvm.args.java-version>
+        <arquillian.wildfly.jvm.args>-Duser.language=en -Duser.country=US ${arquillian.wildfly.jvm.args.add-opens} ${arquillian.wildfly.jvm.args.add-modules} ${arquillian.jvm.args.java-version}</arquillian.wildfly.jvm.args>
 
         <!-- JDK version required for the build -->
         <!-- Remember to update README when changing the version here. -->
@@ -1792,8 +1794,6 @@
             <properties>
                 <!-- ForbiddenAPIs doesn't work with JDK20+ yet -->
                 <forbiddenapis.skip>true</forbiddenapis.skip>
-                <!-- We need net.bytebuddy.experimental=true to make Bytebuddy work with JDK21+ -->
-                <surefire.jvm.args.java-version>-Dnet.bytebuddy.experimental=true</surefire.jvm.args.java-version>
             </properties>
         </profile>
         <profile>
@@ -1807,8 +1807,6 @@
             <properties>
                 <!-- ForbiddenAPIs doesn't work with JDK23+ yet -->
                 <forbiddenapis.skip>true</forbiddenapis.skip>
-                <!-- We need net.bytebuddy.experimental=true to make Bytebuddy work with JDK23+ -->
-                <surefire.jvm.args.java-version>-Dnet.bytebuddy.experimental=true</surefire.jvm.args.java-version>
             </properties>
         </profile>
         <profile>
@@ -1820,10 +1818,13 @@
                 </property>
             </activation>
             <properties>
+                <!-- Remove once there's a 35 Final available -->
+                <version.wildfly>35.0.0.Beta1</version.wildfly>
                 <!-- ForbiddenAPIs doesn't work with JDK24+ yet -->
                 <forbiddenapis.skip>true</forbiddenapis.skip>
                 <!-- We need net.bytebuddy.experimental=true to make Bytebuddy work with JDK24+ -->
                 <surefire.jvm.args.java-version>-Dnet.bytebuddy.experimental=true</surefire.jvm.args.java-version>
+                <arquillian.jvm.args.java-version>-Dnet.bytebuddy.experimental=true</arquillian.jvm.args.java-version>
             </properties>
         </profile>
         <profile>


### PR DESCRIPTION
to address issues with the security manager on JDK 24


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
