### PR TITLE
Backport of HV-1829 to 8.0 Remove mentions of the ConstraintDefinitionContributor from the docs

### DIFF
--- a/documentation/src/main/asciidoc/ch12.asciidoc
+++ b/documentation/src/main/asciidoc/ch12.asciidoc
@@ -780,8 +780,8 @@ configuring the default validator factory using _META-INF/validation.xml_ (see
 One use case for registering constraint definitions through the programmatic API is the ability to specify an alternative
 constraint validator for the `@URL` constraint. Historically, Hibernate Validator's default constraint
 validator for this constraint uses the `java.net.URL` constructor to validate an URL.
-However, there is also a purely regular expression based version available which can be configured using
-a `ConstraintDefinitionContributor`:
+However, there is also a purely regular expression based version available, which can be configured using
+the programmatic constraint declaration API:
 
 .Using the programmatic constraint declaration API to register a regular expression based constraint definition for `@URL`
 [source, JAVA, indent=0]


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1829
https://github.com/hibernate/hibernate-validator/pull/1514

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
