### PR TITLE
HV-2072 Move WildFly integration tests to a profile

### DIFF
--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -28,6 +28,7 @@
 
         <hibernate-validator-parent.path>../..</hibernate-validator-parent.path>
         <skip.wildfly.integration.test.hibernate.validator>false</skip.wildfly.integration.test.hibernate.validator>
+        <skip.failsafe.execution>false</skip.failsafe.execution>
     </properties>
 
     <dependencies>
@@ -179,6 +180,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.failsafe.execution}</skip>
                             <systemPropertyVariables>
                                 <arquillian.launch>wildfly-current</arquillian.launch>
                             </systemPropertyVariables>
@@ -256,6 +258,30 @@
             <properties>
                 <!-- required by Arquillian to connect to the JMX interface of WildFly -->
                 <surefire.jvm.args.add-opens>--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED</surefire.jvm.args.add-opens>
+            </properties>
+        </profile>
+        <profile>
+            <id>testWithJdk24</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>24</value>
+                </property>
+            </activation>
+            <properties>
+                <skip.failsafe.execution>true</skip.failsafe.execution>
+            </properties>
+        </profile>
+        <profile>
+            <id>testWithJdk25</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>25</value>
+                </property>
+            </activation>
+            <properties>
+                <skip.failsafe.execution>true</skip.failsafe.execution>
             </properties>
         </profile>
     </profiles>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2072

so that they are not included as part of the build on JDKs 24+


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
