### PR TITLE
HV-2070 Use `maven-assembly-plugin` instead of `copy-maven-plugin` to rename the pdf documents

### DIFF
--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -124,7 +124,7 @@
 			<outputDirectory>docs/api</outputDirectory>
 		</fileSet>
 		<fileSet>
-			<directory>../documentation/target/asciidoctor</directory>
+			<directory>../documentation/target/dist</directory>
 			<outputDirectory>docs/reference</outputDirectory>
 		</fileSet>
 

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -295,6 +295,27 @@
                     </attributes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>${basedir}/src/main/assembly/dist.xml</descriptor>
+                    </descriptors>
+                    <attach>false</attach>
+                    <finalName>dist</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-dist</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -302,6 +323,16 @@
             <id>documentation-pdf</id>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration combine.children="append">
+                            <descriptors>
+                                <descriptor>${basedir}/src/main/assembly/dist.xml</descriptor>
+                                <descriptor>${basedir}/src/main/assembly/pdf.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctor-maven-plugin</artifactId>
@@ -328,43 +359,6 @@
                                 </configuration>
                             </execution>
                         </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>ch.mfrey.maven.plugin</groupId>
-                        <artifactId>copy-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>copy</id>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <configuration>
-                                    <resources>
-                                        <resource>
-                                            <directory>${asciidoctor.base-output-dir}/pdf</directory>
-                                            <move>true</move>
-                                            <includes>
-                                                <include>index.pdf</include>
-                                            </includes>
-                                            <paths>
-                                                <path>
-                                                    <from>index.pdf</from>
-                                                    <to>hibernate_validator_reference.pdf</to>
-                                                </path>
-                                            </paths>
-                                        </resource>
-                                    </resources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.codehaus.plexus</groupId>
-                                <artifactId>plexus-utils</artifactId>
-                                <version>4.0.2</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/documentation/src/main/assembly/dist.xml
+++ b/documentation/src/main/assembly/dist.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+	SPDX-License-Identifier: Apache-2.0
+	Copyright Red Hat Inc. and Hibernate Authors
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+	<id>dist</id>
+	<formats>
+		<format>dir</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<fileSets>
+		<!-- Reference documentation -->
+		<fileSet>
+			<directory>${asciidoctor.base-output-dir}/html_single/</directory>
+			<outputDirectory>en-US/html_single/</outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/documentation/src/main/assembly/pdf.xml
+++ b/documentation/src/main/assembly/pdf.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+	SPDX-License-Identifier: Apache-2.0
+	Copyright Red Hat Inc. and Hibernate Authors
+-->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+	<id>pdf</id>
+	<formats>
+		<format>dir</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- PDFs: -->
+	<files>
+		<file>
+			<source>${asciidoctor.base-output-dir}/pdf/index.pdf</source>
+			<outputDirectory>en-US/pdf/</outputDirectory>
+			<destName>hibernate_validator_reference.pdf</destName>
+		</file>
+	</files>
+</assembly>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2070

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
