### PR TITLE
HV-2072 Run TCK tests without the SM on JDK 24 (8.0)

### DIFF
--- a/tck-runner/pom.xml
+++ b/tck-runner/pom.xml
@@ -203,7 +203,8 @@
                 <!-- Use Local for testing without security manager -->
                 <arquillian.protocol>LocalSecurityManagerTesting</arquillian.protocol>
                 <!-- Remove for testing without security manager -->
-                <surefire.jvm.args.additional>-DincludeJavaFXTests=true -Djava.security.manager -Djava.security.policy=${project.build.directory}/test-classes/test.policy -Duser.language=en -Duser.country=US</surefire.jvm.args.additional>
+                <surefire.jvm.args.additional.security>-Djava.security.manager -Djava.security.policy=${project.build.directory}/test-classes/test.policy</surefire.jvm.args.additional.security>
+                <surefire.jvm.args.additional>-DincludeJavaFXTests=true -Duser.language=en -Duser.country=US ${surefire.jvm.args.additional.security}</surefire.jvm.args.additional>
                 <!-- Uncomment the following line to obtain the access log of the security manager -->
                 <!--<surefire.jvm.args.additional>-DincludeJavaFXTests=true -Djava.security.manager -Djava.security.policy=${project.build.directory}/test-classes/test.policy -Djava.security.debug=access -Duser.language=en -Duser.country=US</surefire.jvm.args.additional>-->
             </properties>
@@ -551,6 +552,32 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>testWithJdk24</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>24</value>
+                </property>
+            </activation>
+            <properties>
+                <arquillian.protocol>Local</arquillian.protocol>
+                <surefire.jvm.args.additional.security></surefire.jvm.args.additional.security>
+            </properties>
+        </profile>
+        <profile>
+            <id>testWithJdk25</id>
+            <activation>
+                <property>
+                    <name>java-version.test.release</name>
+                    <value>25</value>
+                </property>
+            </activation>
+            <properties>
+                <arquillian.protocol>Local</arquillian.protocol>
+                <surefire.jvm.args.additional.security></surefire.jvm.args.additional.security>
+            </properties>
         </profile>
         <!-- Resolution of the JavaFX platform -->
         <profile>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2072

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
