### PR TITLE
Backport to 6.2 HV-2070 Use maven-assembly-plugin / HV-2023 Add a step to build pdf documentation to the nightly CI job

### DIFF
--- a/distribution/src/main/assembly/dist.xml
+++ b/distribution/src/main/assembly/dist.xml
@@ -118,7 +118,7 @@
             <outputDirectory>docs/api</outputDirectory>
         </fileSet>
         <fileSet>
-            <directory>../documentation/target/asciidoctor</directory>
+            <directory>../documentation/target/dist</directory>
             <outputDirectory>docs/reference</outputDirectory>
         </fileSet>
 

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -302,6 +302,27 @@
                     </attributes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>${basedir}/src/main/assembly/dist.xml</descriptor>
+                    </descriptors>
+                    <attach>false</attach>
+                    <finalName>dist</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-dist</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -309,6 +330,16 @@
             <id>documentation-pdf</id>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <configuration combine.children="append">
+                            <descriptors>
+                                <descriptor>${basedir}/src/main/assembly/dist.xml</descriptor>
+                                <descriptor>${basedir}/src/main/assembly/pdf.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </plugin>
                     <plugin>
                         <groupId>org.asciidoctor</groupId>
                         <artifactId>asciidoctor-maven-plugin</artifactId>
@@ -332,36 +363,6 @@
                                         <idprefix/>
                                         <idseparator>-</idseparator>
                                     </attributes>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>ch.mfrey.maven.plugin</groupId>
-                        <artifactId>copy-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>copy</id>
-                                <phase>install</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                                <configuration>
-                                    <resources>
-                                        <resource>
-                                            <directory>${asciidoctor.base-output-dir}/pdf</directory>
-                                            <move>true</move>
-                                            <includes>
-                                                <include>index.pdf</include>
-                                            </includes>
-                                            <paths>
-                                                <path>
-                                                    <from>index.pdf</from>
-                                                    <to>hibernate_validator_reference.pdf</to>
-                                                </path>
-                                            </paths>
-                                        </resource>
-                                    </resources>
                                 </configuration>
                             </execution>
                         </executions>

--- a/documentation/src/main/assembly/dist.xml
+++ b/documentation/src/main/assembly/dist.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+	<id>dist</id>
+	<formats>
+		<format>dir</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<fileSets>
+		<!-- Reference documentation -->
+		<fileSet>
+			<directory>${asciidoctor.base-output-dir}/html_single/</directory>
+			<outputDirectory>en-US/html_single/</outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/documentation/src/main/assembly/pdf.xml
+++ b/documentation/src/main/assembly/pdf.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ Hibernate Validator, declare and validate application constraints
+  ~
+  ~ License: Apache License, Version 2.0
+  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+  -->
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
+	<id>pdf</id>
+	<formats>
+		<format>dir</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- PDFs: -->
+	<files>
+		<file>
+			<source>${asciidoctor.base-output-dir}/pdf/index.pdf</source>
+			<outputDirectory>en-US/pdf/</outputDirectory>
+			<destName>hibernate_validator_reference.pdf</destName>
+		</file>
+	</files>
+</assembly>

--- a/jenkins/nightly/Jenkinsfile
+++ b/jenkins/nightly/Jenkinsfile
@@ -1,0 +1,70 @@
+/*
+ * Hibernate Validator, declare and validate application constraints
+ *
+ * License: Apache License, Version 2.0
+ * See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ */
+
+@Library('hibernate-jenkins-pipeline-helpers') _
+
+def withMavenWorkspace(Closure body) {
+	withMavenWorkspace('OpenJDK 17 Latest', body)
+}
+
+def withMavenWorkspace(jdk, Closure body) {
+	withMaven(jdk: jdk, maven: 'Apache Maven 3.9',
+			mavenLocalRepo: env.WORKSPACE_TMP + '/.m2repository',
+			options: [
+					// Artifacts are not needed and take up disk space
+					artifactsPublisher(disabled: true),
+					// stdout/stderr for successful tests is not needed and takes up disk space
+					// we archive test results and stdout/stderr as part of the build scan anyway,
+					// see https://ge.hibernate.org/scans?search.rootProjectNames=Hibernate%20Search
+					junitPublisher(disabled: true)
+			]) {
+		body()
+	}
+}
+
+pipeline {
+	agent none
+	triggers {
+		cron '@midnight'
+	}
+	options {
+		buildDiscarder logRotator(daysToKeepStr: '10', numToKeepStr: '3')
+		disableConcurrentBuilds(abortPrevious: true)
+		overrideIndexTriggers(false)
+	}
+	stages {
+		stage ('Run checks') {
+			parallel {
+				stage('Build documentation PDF') {
+					agent {
+						label 'Worker&&Containers'
+					}
+					steps {
+						// The timeout cannot be in stage options, because that would
+						// include the time needed to provision a node.
+						timeout(time: 15, unit: 'MINUTES') {
+							withMavenWorkspace {
+								echo "Generate documentation and distribution packages."
+								sh """mvn clean install \
+									-Pdocumentation-pdf \
+									-DskipTests \
+									--fail-at-end \
+									-Dscan=false -Dno-build-cache
+								"""
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	post {
+		always {
+			notifyBuildResult maintainers: 'marko@hibernate.org'
+		}
+	}
+}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2070
https://hibernate.atlassian.net/browse/HV-2023

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
