### PR TITLE
HV-2076 Test against wildfly-preview 35.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,7 @@
         <version.org.jboss.logging.jboss-logging-tools>3.0.3.Final</version.org.jboss.logging.jboss-logging-tools>
 
         <!-- Currently supported version of WildFly -->
-        <!-- Update JDK 24 configuration when changing this version: -->
-        <version.wildfly>34.0.1.Final</version.wildfly>
+        <version.wildfly>35.0.0.Final</version.wildfly>
         <!-- Used to create a patch file for the second version of WildFly we support -->
         <!--<version.wildfly.secondary>18.0.1.Final</version.wildfly.secondary>-->
         <!-- Version used to run the TCK in incontainer mode -->
@@ -1816,8 +1815,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- Remove once there's a 35 Final available -->
-                <version.wildfly>35.0.0.Beta1</version.wildfly>
                 <!-- ForbiddenAPIs doesn't work with JDK24+ yet -->
                 <forbiddenapis.skip>true</forbiddenapis.skip>
                 <!-- We need net.bytebuddy.experimental=true to make Bytebuddy work with JDK24+ -->
@@ -1834,8 +1831,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- Remove once there's a 35 Final available -->
-                <version.wildfly>35.0.0.Beta1</version.wildfly>
                 <!-- ForbiddenAPIs doesn't work with JDK25+ yet -->
                 <forbiddenapis.skip>true</forbiddenapis.skip>
                 <!-- We need net.bytebuddy.experimental=true to make Bytebuddy work with JDK25+ -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2076

Bump org.wildfly:wildfly-preview-dist from 34.0.1.Final to 35.0.0.Final

Bumps org.wildfly:wildfly-preview-dist from 34.0.1.Final to 35.0.0.Final.

---
updated-dependencies:
- dependency-name: org.wildfly:wildfly-preview-dist dependency-type: direct:production update-type: version-update:semver-major ...

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
