### PR TITLE
HV-2089 Upgrade paranamer from to 2.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 
         <version.jakarta.validation.validation-tck>3.1.1</version.jakarta.validation.validation-tck>
 
-        <version.com.thoughtworks.paranamer>2.8.1</version.com.thoughtworks.paranamer>
+        <version.com.thoughtworks.paranamer>2.8.2</version.com.thoughtworks.paranamer>
         <version.org.glassfish.expressly>6.0.0-M1</version.org.glassfish.expressly>
         <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>3.0.4.Final</version.org.jboss.logging.jboss-logging-tools>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2089

Bump com.thoughtworks.paranamer:paranamer from 2.8.1 to 2.8.2

Bumps [com.thoughtworks.paranamer:paranamer](https://github.com/paul-hammant/paranamer) from 2.8.1 to 2.8.2.
- [Commits](https://github.com/paul-hammant/paranamer/compare/paranamer-parent-2.8.1...paranamer-parent-2.8.2)

---
updated-dependencies:
- dependency-name: com.thoughtworks.paranamer:paranamer dependency-type: direct:production update-type: version-update:semver-patch ...

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
