### PR TITLE
HV-2004 Add constraint initialization payload

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
+++ b/engine/src/main/java/org/hibernate/validator/BaseHibernateValidatorConfiguration.java
@@ -364,6 +364,18 @@ public interface BaseHibernateValidatorConfiguration<S extends BaseHibernateVali
 	S constraintValidatorPayload(Object constraintValidatorPayload);
 
 	/**
+	 * Allows adding a payload which will be  available during the constraint validators initialization.
+	 * If the method is called multiple times passing different instances of the same class,
+	 * only the payload passed last will be available for that type.
+	 *
+	 * @param constraintValidatorInitializationPayload the payload to retrieve from the constraint validator initializers
+	 * @return {@code this} following the chaining method pattern
+	 * @since 9.0.0
+	 */
+	@Incubating
+	S addConstraintValidatorInitializationPayload(Object constraintValidatorInitializationPayload);
+
+	/**
 	 * Allows to set a getter property selection strategy defining the rules determining if a method is a getter
 	 * or not.
 	 *

--- a/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidation/HibernateConstraintValidatorInitializationContext.java
@@ -56,4 +56,18 @@ public interface HibernateConstraintValidatorInitializationContext {
 	 */
 	@Incubating
 	Duration getTemporalValidationTolerance();
+
+	/**
+	 * Returns an instance of the specified type or {@code null} if the current constraint initialization context does not
+	 * contain an instance of such type.
+	 *
+	 * @param type the type of payload to retrieve
+	 * @return an instance of the specified type or {@code null} if the current constraint initialization context does not
+	 * contain an instance of such type
+	 *
+	 * @since 9.0.0
+	 * @see org.hibernate.validator.HibernateValidatorConfiguration#addConstraintValidatorInitializationPayload(Object)
+	 */
+	@Incubating
+	<C> C getConstraintValidatorInitializationPayload(Class<C> type);
 }

--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/PatternValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/bv/PatternValidator.java
@@ -8,11 +8,14 @@ import java.lang.invoke.MethodHandles;
 import java.util.regex.Matcher;
 import java.util.regex.PatternSyntaxException;
 
-import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.metadata.ConstraintDescriptor;
 
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidator;
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorInitializationContext;
+import org.hibernate.validator.internal.engine.constraintvalidation.PatternConstraintInitializer;
 import org.hibernate.validator.internal.engine.messageinterpolation.util.InterpolationHelper;
 import org.hibernate.validator.internal.util.logging.Log;
 import org.hibernate.validator.internal.util.logging.LoggerFactory;
@@ -20,7 +23,7 @@ import org.hibernate.validator.internal.util.logging.LoggerFactory;
 /**
  * @author Hardy Ferentschik
  */
-public class PatternValidator implements ConstraintValidator<Pattern, CharSequence> {
+public class PatternValidator implements HibernateConstraintValidator<Pattern, CharSequence> {
 
 	private static final Log LOG = LoggerFactory.make( MethodHandles.lookup() );
 
@@ -28,7 +31,8 @@ public class PatternValidator implements ConstraintValidator<Pattern, CharSequen
 	private String escapedRegexp;
 
 	@Override
-	public void initialize(Pattern parameters) {
+	public void initialize(ConstraintDescriptor<Pattern> constraintDescriptor, HibernateConstraintValidatorInitializationContext initializationContext) {
+		Pattern parameters = constraintDescriptor.getAnnotation();
 		Pattern.Flag[] flags = parameters.flags();
 		int intFlag = 0;
 		for ( Pattern.Flag flag : flags ) {
@@ -36,7 +40,8 @@ public class PatternValidator implements ConstraintValidator<Pattern, CharSequen
 		}
 
 		try {
-			pattern = java.util.regex.Pattern.compile( parameters.regexp(), intFlag );
+			pattern = initializationContext.getConstraintValidatorInitializationPayload( PatternConstraintInitializer.class )
+					.of( parameters.regexp(), intFlag );
 		}
 		catch (PatternSyntaxException e) {
 			throw LOG.getInvalidRegularExpressionException( e );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/AbstractConfigurationImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/AbstractConfigurationImpl.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.validator.internal.engine;
 
+import static org.hibernate.validator.internal.util.CollectionHelper.newHashMap;
 import static org.hibernate.validator.internal.util.CollectionHelper.newHashSet;
 import static org.hibernate.validator.internal.util.logging.Messages.MESSAGES;
 
@@ -122,6 +123,7 @@ public abstract class AbstractConfigurationImpl<T extends BaseHibernateValidator
 	private ScriptEvaluatorFactory scriptEvaluatorFactory;
 	private Duration temporalValidationTolerance;
 	private Object constraintValidatorPayload;
+	private final Map<Class<?>, Object> constraintValidatorInitializationPayload = newHashMap();
 	private GetterPropertySelectionStrategy getterPropertySelectionStrategy;
 	private Set<Locale> locales = Collections.emptySet();
 	private Locale defaultLocale = Locale.getDefault();
@@ -351,6 +353,14 @@ public abstract class AbstractConfigurationImpl<T extends BaseHibernateValidator
 	}
 
 	@Override
+	public T addConstraintValidatorInitializationPayload(Object constraintValidatorInitializationPayload) {
+		Contracts.assertNotNull( constraintValidatorInitializationPayload, MESSAGES.parameterMustNotBeNull( "constraintValidatorInitializationPayload" ) );
+
+		this.constraintValidatorInitializationPayload.put( constraintValidatorInitializationPayload.getClass(), constraintValidatorInitializationPayload );
+		return thisAsT();
+	}
+
+	@Override
 	public T getterPropertySelectionStrategy(GetterPropertySelectionStrategy getterPropertySelectionStrategy) {
 		Contracts.assertNotNull( getterPropertySelectionStrategy, MESSAGES.parameterMustNotBeNull( "getterPropertySelectionStrategy" ) );
 
@@ -544,6 +554,10 @@ public abstract class AbstractConfigurationImpl<T extends BaseHibernateValidator
 
 	public Object getConstraintValidatorPayload() {
 		return constraintValidatorPayload;
+	}
+
+	public Map<Class<?>, Object> getConstraintValidatorInitializationPayload() {
+		return constraintValidatorInitializationPayload;
 	}
 
 	public GetterPropertySelectionStrategy getGetterPropertySelectionStrategy() {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/PredefinedScopeValidatorFactoryImpl.java
@@ -10,6 +10,7 @@ import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurat
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineBeanMetaDataClassNormalizer;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintExpressionLanguageFeatureLevel;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintMappings;
+import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintValidatorInitializationPayload;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintValidatorPayload;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineCustomViolationExpressionLanguageFeatureLevel;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineExternalClassLoader;
@@ -46,6 +47,7 @@ import org.hibernate.validator.HibernateValidatorFactory;
 import org.hibernate.validator.PredefinedScopeHibernateValidatorFactory;
 import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
+import org.hibernate.validator.internal.engine.constraintvalidation.PatternConstraintInitializer;
 import org.hibernate.validator.internal.engine.constraintvalidation.PredefinedScopeConstraintValidatorManagerImpl;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.engine.valueextraction.ValueExtractorManager;
@@ -118,6 +120,7 @@ public class PredefinedScopeValidatorFactoryImpl implements PredefinedScopeHiber
 						determineAllowParallelMethodsDefineParameterConstraints( hibernateSpecificConfig, properties )
 				).build();
 
+		PatternConstraintInitializer.CachingPatternConstraintInitializer patternConstraintInitializer = new PatternConstraintInitializer.CachingPatternConstraintInitializer();
 		this.validatorFactoryScopedContext = new ValidatorFactoryScopedContext(
 				configurationState.getMessageInterpolator(),
 				configurationState.getTraversableResolver(),
@@ -129,6 +132,7 @@ public class PredefinedScopeValidatorFactoryImpl implements PredefinedScopeHiber
 				determineFailFastOnPropertyViolation( hibernateSpecificConfig, properties ),
 				determineTraversableResolverResultCacheEnabled( hibernateSpecificConfig, properties ),
 				determineConstraintValidatorPayload( hibernateSpecificConfig ),
+				determineConstraintValidatorInitializationPayload( hibernateSpecificConfig, patternConstraintInitializer ),
 				determineConstraintExpressionLanguageFeatureLevel( hibernateSpecificConfig, properties ),
 				determineCustomViolationExpressionLanguageFeatureLevel( hibernateSpecificConfig, properties ),
 				determineShowValidatedValuesInTraceLogs( hibernateSpecificConfig, properties )
@@ -213,6 +217,9 @@ public class PredefinedScopeValidatorFactoryImpl implements PredefinedScopeHiber
 				determineBeanMetaDataClassNormalizer( hibernateSpecificConfig ),
 				beanClassesToInitialize
 		);
+
+		// at this point all constraints had to be initialized, so we can clear up the pattern cache:
+		patternConstraintInitializer.close();
 
 		if ( LOG.isDebugEnabled() ) {
 			logValidatorFactoryScopedConfiguration( validatorFactoryScopedContext );

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryConfigurationHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryConfigurationHelper.java
@@ -11,6 +11,7 @@ import java.lang.annotation.Annotation;
 import java.lang.invoke.MethodHandles;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -21,6 +22,7 @@ import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.cfg.ConstraintMapping;
 import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
 import org.hibernate.validator.internal.engine.constraintdefinition.ConstraintDefinitionContribution;
+import org.hibernate.validator.internal.engine.constraintvalidation.PatternConstraintInitializer;
 import org.hibernate.validator.internal.engine.messageinterpolation.DefaultLocaleResolver;
 import org.hibernate.validator.internal.engine.scripting.DefaultScriptEvaluatorFactory;
 import org.hibernate.validator.internal.metadata.DefaultBeanMetaDataClassNormalizer;
@@ -252,8 +254,7 @@ final class ValidatorFactoryConfigurationHelper {
 	}
 
 	static Object determineConstraintValidatorPayload(ConfigurationState configurationState) {
-		if ( configurationState instanceof AbstractConfigurationImpl ) {
-			AbstractConfigurationImpl<?> hibernateSpecificConfig = (AbstractConfigurationImpl<?>) configurationState;
+		if ( configurationState instanceof AbstractConfigurationImpl<?> hibernateSpecificConfig ) {
 			if ( hibernateSpecificConfig.getConstraintValidatorPayload() != null ) {
 				LOG.logConstraintValidatorPayload( hibernateSpecificConfig.getConstraintValidatorPayload() );
 				return hibernateSpecificConfig.getConstraintValidatorPayload();
@@ -261,6 +262,23 @@ final class ValidatorFactoryConfigurationHelper {
 		}
 
 		return null;
+	}
+
+	static Map<Class<?>, Object> determineConstraintValidatorInitializationPayload(ConfigurationState configurationState, PatternConstraintInitializer patternConstraintInitializer) {
+		if ( configurationState instanceof AbstractConfigurationImpl<?> hibernateSpecificConfig ) {
+			if ( hibernateSpecificConfig.getConstraintValidatorPayload() != null ) {
+				Map<Class<?>, Object> configured = hibernateSpecificConfig.getConstraintValidatorInitializationPayload();
+				Map<Class<?>, Object> payload = new HashMap<>();
+				payload.put( PatternConstraintInitializer.class, patternConstraintInitializer );
+				if ( configured != null ) {
+					payload.putAll( configured );
+				}
+				LOG.logConstraintValidatorInitializationPayload( payload );
+				return Collections.unmodifiableMap( payload );
+			}
+		}
+
+		return Map.of( PatternConstraintInitializer.class, patternConstraintInitializer );
 	}
 
 	static ExpressionLanguageFeatureLevel determineConstraintExpressionLanguageFeatureLevel(AbstractConfigurationImpl<?> hibernateSpecificConfig,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryImpl.java
@@ -10,6 +10,7 @@ import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurat
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineBeanMetaDataClassNormalizer;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintExpressionLanguageFeatureLevel;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintMappings;
+import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintValidatorInitializationPayload;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineConstraintValidatorPayload;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineCustomViolationExpressionLanguageFeatureLevel;
 import static org.hibernate.validator.internal.engine.ValidatorFactoryConfigurationHelper.determineExternalClassLoader;
@@ -47,6 +48,7 @@ import org.hibernate.validator.HibernateValidatorFactory;
 import org.hibernate.validator.internal.cfg.context.DefaultConstraintMapping;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManager;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManagerImpl;
+import org.hibernate.validator.internal.engine.constraintvalidation.PatternConstraintInitializer;
 import org.hibernate.validator.internal.engine.groups.ValidationOrderGenerator;
 import org.hibernate.validator.internal.engine.valueextraction.ValueExtractorManager;
 import org.hibernate.validator.internal.metadata.BeanMetaDataManager;
@@ -163,6 +165,7 @@ public class ValidatorFactoryImpl implements HibernateValidatorFactory {
 				determineFailFastOnPropertyViolation( hibernateSpecificConfig, properties ),
 				determineTraversableResolverResultCacheEnabled( hibernateSpecificConfig, properties ),
 				determineConstraintValidatorPayload( hibernateSpecificConfig ),
+				determineConstraintValidatorInitializationPayload( hibernateSpecificConfig, new PatternConstraintInitializer.SimplePatternConstraintInitializer() ),
 				determineConstraintExpressionLanguageFeatureLevel( hibernateSpecificConfig, properties ),
 				determineCustomViolationExpressionLanguageFeatureLevel( hibernateSpecificConfig, properties ),
 				determineShowValidatedValuesInTraceLogs( hibernateSpecificConfig, properties )

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryScopedContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/ValidatorFactoryScopedContext.java
@@ -5,6 +5,7 @@
 package org.hibernate.validator.internal.engine;
 
 import java.time.Duration;
+import java.util.Map;
 
 import jakarta.validation.ClockProvider;
 import jakarta.validation.MessageInterpolator;
@@ -102,6 +103,7 @@ public class ValidatorFactoryScopedContext {
 			boolean failFastOnPropertyViolation,
 			boolean traversableResolverResultCacheEnabled,
 			Object constraintValidatorPayload,
+			Map<Class<?>, Object> constraintValidatorInitializationPayload,
 			ExpressionLanguageFeatureLevel constraintExpressionLanguageFeatureLevel,
 			ExpressionLanguageFeatureLevel customViolationExpressionLanguageFeatureLevel,
 			boolean showValidatedValuesInTraceLogs) {
@@ -109,7 +111,8 @@ public class ValidatorFactoryScopedContext {
 				failFastOnPropertyViolation, traversableResolverResultCacheEnabled, showValidatedValuesInTraceLogs, constraintValidatorPayload, constraintExpressionLanguageFeatureLevel,
 				customViolationExpressionLanguageFeatureLevel,
 				new HibernateConstraintValidatorInitializationContextImpl( scriptEvaluatorFactory, clockProvider,
-						temporalValidationTolerance ) );
+						temporalValidationTolerance, constraintValidatorInitializationPayload
+				) );
 	}
 
 	private ValidatorFactoryScopedContext(MessageInterpolator messageInterpolator,
@@ -214,7 +217,7 @@ public class ValidatorFactoryScopedContext {
 		private ExpressionLanguageFeatureLevel customViolationExpressionLanguageFeatureLevel;
 
 		private boolean showValidatedValuesInTraceLogs;
-		private HibernateConstraintValidatorInitializationContextImpl constraintValidatorInitializationContext;
+		private final HibernateConstraintValidatorInitializationContextImpl constraintValidatorInitializationContext;
 
 		Builder(ValidatorFactoryScopedContext defaultContext) {
 			Contracts.assertNotNull( defaultContext, "Default context cannot be null." );
@@ -348,7 +351,8 @@ public class ValidatorFactoryScopedContext {
 							constraintValidatorInitializationContext,
 							scriptEvaluatorFactory,
 							clockProvider,
-							temporalValidationTolerance
+							temporalValidationTolerance,
+							constraintValidatorInitializationContext.getConstraintValidatorInitializationPayload()
 					)
 			);
 		}

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/HibernateConstraintValidatorInitializationContextImpl.java
@@ -5,6 +5,7 @@
 package org.hibernate.validator.internal.engine.constraintvalidation;
 
 import java.time.Duration;
+import java.util.Map;
 
 import jakarta.validation.ClockProvider;
 
@@ -23,25 +24,29 @@ public class HibernateConstraintValidatorInitializationContextImpl implements Hi
 
 	private final Duration temporalValidationTolerance;
 
+	private final Map<Class<?>, Object> constraintValidatorInitializationPayload;
+
 	private final int hashCode;
 
 	public HibernateConstraintValidatorInitializationContextImpl(ScriptEvaluatorFactory scriptEvaluatorFactory, ClockProvider clockProvider,
-			Duration temporalValidationTolerance) {
+			Duration temporalValidationTolerance, Map<Class<?>, Object> constraintValidatorInitializationPayload
+	) {
 		this.scriptEvaluatorFactory = scriptEvaluatorFactory;
 		this.clockProvider = clockProvider;
 		this.temporalValidationTolerance = temporalValidationTolerance;
+		this.constraintValidatorInitializationPayload = constraintValidatorInitializationPayload;
 		this.hashCode = createHashCode();
 	}
 
 	public static HibernateConstraintValidatorInitializationContextImpl of(HibernateConstraintValidatorInitializationContextImpl defaultContext,
-			ScriptEvaluatorFactory scriptEvaluatorFactory, ClockProvider clockProvider, Duration temporalValidationTolerance) {
+			ScriptEvaluatorFactory scriptEvaluatorFactory, ClockProvider clockProvider, Duration temporalValidationTolerance, Map<Class<?>, Object> constraintValidatorInitializationPayload) {
 		if ( scriptEvaluatorFactory == defaultContext.scriptEvaluatorFactory
 				&& clockProvider == defaultContext.clockProvider
 				&& temporalValidationTolerance.equals( defaultContext.temporalValidationTolerance ) ) {
 			return defaultContext;
 		}
 
-		return new HibernateConstraintValidatorInitializationContextImpl( scriptEvaluatorFactory, clockProvider, temporalValidationTolerance );
+		return new HibernateConstraintValidatorInitializationContextImpl( scriptEvaluatorFactory, clockProvider, temporalValidationTolerance, constraintValidatorInitializationPayload );
 	}
 
 	@Override
@@ -57,6 +62,16 @@ public class HibernateConstraintValidatorInitializationContextImpl implements Hi
 	@Override
 	public Duration getTemporalValidationTolerance() {
 		return temporalValidationTolerance;
+	}
+
+	@SuppressWarnings("unchecked") // because of the way we populate that map
+	@Override
+	public <C> C getConstraintValidatorInitializationPayload(Class<C> type) {
+		return ( (C) constraintValidatorInitializationPayload.get( type ) );
+	}
+
+	public Map<Class<?>, Object> getConstraintValidatorInitializationPayload() {
+		return constraintValidatorInitializationPayload;
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/PatternConstraintInitializer.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/PatternConstraintInitializer.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.validator.internal.engine.constraintvalidation;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+
+public interface PatternConstraintInitializer extends AutoCloseable {
+
+	Pattern of(String pattern, int flags);
+
+	@Override
+	default void close() {
+	}
+
+	class SimplePatternConstraintInitializer implements PatternConstraintInitializer {
+
+		@Override
+		public Pattern of(String pattern, int flags) {
+			return Pattern.compile( pattern, flags );
+		}
+	}
+
+	class CachingPatternConstraintInitializer implements PatternConstraintInitializer {
+		private final Map<PatternKey, Pattern> cache = new ConcurrentHashMap<PatternKey, Pattern>();
+
+		@Override
+		public Pattern of(String pattern, int flags) {
+			return cache.computeIfAbsent( new PatternKey( pattern, flags ), key -> Pattern.compile( pattern, flags ) );
+		}
+
+		@Override
+		public void close() {
+			cache.clear();
+		}
+
+		private record PatternKey(String pattern, int flags) {
+		}
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Log.java
@@ -942,4 +942,8 @@ public interface Log extends BasicLogger {
 	@Message(id = 268, value = "The default group sequence provider %s does not implement neither `getValidationGroups(Class<?> klass, T object)` nor `getValidationGroups(T object)` methods."
 			+ " One of them has to be implemented for the default group sequence provider to be correctly defined.")
 	GroupDefinitionException getDefaultGroupSequenceProviderTypeDoesNotImplementAnyMethodsException(@FormatWith(ClassObjectFormatter.class) Class<?> klass);
+
+	@LogMessage(level = DEBUG)
+	@Message(id = 269, value = "Constraint validator initialization payload set to %1$s.")
+	void logConstraintValidatorInitializationPayload(Object payload);
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/PatternValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/bv/PatternValidatorTest.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.validator.test.internal.constraintvalidators.bv;
 
+import static org.hibernate.validator.testutils.ConstraintValidatorInitializationHelper.initialize;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -26,10 +27,10 @@ public class PatternValidatorTest {
 		ConstraintAnnotationDescriptor.Builder<Pattern> descriptorBuilder = new ConstraintAnnotationDescriptor.Builder<>( Pattern.class );
 		descriptorBuilder.setAttribute( "regexp", "foobar" );
 		descriptorBuilder.setMessage( "pattern does not match" );
-		Pattern p = descriptorBuilder.build().getAnnotation();
+		ConstraintAnnotationDescriptor<Pattern> descriptor = descriptorBuilder.build();
 
 		PatternValidator constraint = new PatternValidator();
-		constraint.initialize( p );
+		initialize( constraint, descriptor );
 
 		assertTrue( constraint.isValid( null, null ) );
 		assertFalse( constraint.isValid( "", null ) );
@@ -42,10 +43,10 @@ public class PatternValidatorTest {
 	public void testIsValidForCharSequence() {
 		ConstraintAnnotationDescriptor.Builder<Pattern> descriptorBuilder = new ConstraintAnnotationDescriptor.Builder<>( Pattern.class );
 		descriptorBuilder.setAttribute( "regexp", "char sequence" );
-		Pattern p = descriptorBuilder.build().getAnnotation();
+		ConstraintAnnotationDescriptor<Pattern> descriptor = descriptorBuilder.build();
 
 		PatternValidator constraint = new PatternValidator();
-		constraint.initialize( p );
+		initialize( constraint, descriptor );
 
 		assertTrue( constraint.isValid( new MyCustomStringImpl( "char sequence" ), null ) );
 	}
@@ -55,10 +56,10 @@ public class PatternValidatorTest {
 		ConstraintAnnotationDescriptor.Builder<Pattern> descriptorBuilder = new ConstraintAnnotationDescriptor.Builder<>( Pattern.class );
 		descriptorBuilder.setAttribute( "regexp", "|^.*foo$" );
 		descriptorBuilder.setMessage( "pattern does not match" );
-		Pattern p = descriptorBuilder.build().getAnnotation();
+		ConstraintAnnotationDescriptor<Pattern> descriptor = descriptorBuilder.build();
 
 		PatternValidator constraint = new PatternValidator();
-		constraint.initialize( p );
+		initialize( constraint, descriptor );
 
 		assertTrue( constraint.isValid( null, null ) );
 		assertTrue( constraint.isValid( "", null ) );
@@ -72,9 +73,9 @@ public class PatternValidatorTest {
 		ConstraintAnnotationDescriptor.Builder<Pattern> descriptorBuilder = new ConstraintAnnotationDescriptor.Builder<>( Pattern.class );
 		descriptorBuilder.setAttribute( "regexp", "(unbalanced parentheses" );
 		descriptorBuilder.setMessage( "pattern does not match" );
-		Pattern p = descriptorBuilder.build().getAnnotation();
+		ConstraintAnnotationDescriptor<Pattern> descriptor = descriptorBuilder.build();
 
 		PatternValidator constraint = new PatternValidator();
-		constraint.initialize( p );
+		initialize( constraint, descriptor );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
+++ b/engine/src/test/java/org/hibernate/validator/testutils/ConstraintValidatorInitializationHelper.java
@@ -17,6 +17,7 @@ import org.hibernate.validator.constraintvalidation.spi.DefaultConstraintValidat
 import org.hibernate.validator.internal.engine.ConstraintCreationContext;
 import org.hibernate.validator.internal.engine.DefaultClockProvider;
 import org.hibernate.validator.internal.engine.constraintvalidation.ConstraintValidatorManagerImpl;
+import org.hibernate.validator.internal.engine.constraintvalidation.PatternConstraintInitializer;
 import org.hibernate.validator.internal.engine.scripting.DefaultScriptEvaluatorFactory;
 import org.hibernate.validator.internal.engine.valueextraction.ValueExtractorManager;
 import org.hibernate.validator.internal.metadata.core.ConstraintHelper;
@@ -95,6 +96,14 @@ public class ConstraintValidatorInitializationHelper {
 			@Override
 			public Duration getTemporalValidationTolerance() {
 				return duration;
+			}
+
+			@Override
+			public <C> C getConstraintValidatorInitializationPayload(Class<C> type) {
+				if ( PatternConstraintInitializer.class.equals( type ) ) {
+					return (C) new PatternConstraintInitializer.SimplePatternConstraintInitializer();
+				}
+				return null;
 			}
 		};
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2004

I didn't want to have some hardcoded cache for patterns within the pattern constraint validator impl itself. Hence I was thinking that leveraging something similar to what we have for validation with payload could work. 
initialization payload would be available to any constraints. As for patterns and their caching, limiting it to the predefined scope makes sense as we have all constraints initialized and can clear out the cache. 

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
