### PR TITLE
HV-2102 Fixed potential vulnerable function

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/xml/XmlParserHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/XmlParserHelper.java
@@ -136,18 +136,27 @@ public class XmlParserHelper {
 	}
 
 	private Schema loadSchema(String schemaResource) {
-		ClassLoader loader = GetClassLoader.fromClass( XmlParserHelper.class );
-
-		URL schemaUrl = GetResource.action( loader, schemaResource );
-		SchemaFactory sf = SchemaFactory.newInstance( javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI );
-		Schema schema = null;
-		try {
-			schema = NewSchema.action( sf, schemaUrl );
-		}
-		catch (Exception e) {
-			LOG.unableToCreateSchema( schemaResource, e.getMessage() );
-		}
-		return schema;
-	}
+	    ClassLoader loader = GetClassLoader.fromClass(XmlParserHelper.class);
+	
+	    URL schemaUrl = GetResource.action(loader, schemaResource);
+	    SchemaFactory sf = SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI);
+	    
+	    // Add security protection against XXE attacks
+	    try {
+	        sf.setProperty(javax.xml.XMLConstants.ACCESS_EXTERNAL_DTD, "");
+	        sf.setProperty(javax.xml.XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+	    } catch (SAXException e) {
+	        LOG.unableToCreateSchema(schemaResource, "Failed to set security properties: " + e.getMessage());
+	    }
+	    
+	    Schema schema = null;
+	    try {
+	        schema = NewSchema.action(sf, schemaUrl);
+	    }
+	    catch (Exception e) {
+	        LOG.unableToCreateSchema(schemaResource, e.getMessage());
+	    }
+	    return schema;
+}
 
 }


### PR DESCRIPTION
This PR fixes a potential vulnerability in loadSchema() that was cloned from importer-exporter but did not receive the security patch. The original issue was reported and fixed under 3dcitydb/importer-exporter@8ab7fb6. This PR applies the same patch to eliminate the vulnerability.

**References:**
1. 3dcitydb/importer-exporter@8ab7fb6
2. https://nvd.nist.gov/vuln/detail/CVE-2018-1000840

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
HV-2102
-->


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
