### PR TITLE
Backport of HV-2109 to 9.0  -  Bump Expressly version to 6.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Logging will delegate any log requests to that provider.
         <dependency>
            <groupId>org.glassfish.expressly</groupId>
            <artifactId>expressly</artifactId>
-           <version>6.0.0-M1</version>
+           <version>6.0.0</version>
         </dependency>
 
 * Jakarta Validation defines integration points with [CDI](http://jcp.org/en/jsr/detail?id=346). If your application runs

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/ValidatorFactoryNoELBootstrapTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/ValidatorFactoryNoELBootstrapTest.java
@@ -40,7 +40,7 @@ public class ValidatorFactoryNoELBootstrapTest {
 
 	private final String EL_PACKAGE_PREFIX = "jakarta.el";
 
-	private final String EL_IMPL_PACKAGE_PREFIX = "com.sun.el";
+	private final String EL_IMPL_PACKAGE_PREFIX = "org.glassfish.expressly";
 
 	@Test
 	@TestForIssue(jiraKey = "HV-793")

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
         <version.jakarta.validation.validation-tck>3.1.1</version.jakarta.validation.validation-tck>
 
         <version.com.thoughtworks.paranamer>2.8.3</version.com.thoughtworks.paranamer>
-        <version.org.glassfish.expressly>6.0.0-M1</version.org.glassfish.expressly>
+        <version.org.glassfish.expressly>6.0.0</version.org.glassfish.expressly>
         <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>3.0.4.Final</version.org.jboss.logging.jboss-logging-tools>
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2109

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
