### PR TITLE
HV-2113 Adding Korean resident registration number validation condition

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/kor/KorRRNValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/kor/KorRRNValidator.java
@@ -87,7 +87,7 @@ public class KorRRNValidator implements ConstraintValidator<KorRRN, CharSequence
 		private static boolean isValidDate(final String rrn) {
 			final int month = extractMonth( rrn );
 			final int day = extractDay( rrn );
-			if ( month > 12 || day < 0 || day > 31 ) {
+			if ( month < 1 || month > 12 || day < 1 || day > 31 ) {
 				return false;
 			}
 			return day <= 31 && ( day <= 30 || ( month != 4 && month != 6 && month != 9 && month != 11 ) ) && ( day <= 29 || month != 2 );

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/kor/KorRRNValidatorNeverAttrTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/kor/KorRRNValidatorNeverAttrTest.java
@@ -70,6 +70,9 @@ public class KorRRNValidatorNeverAttrTest extends KorRRNValidatorTestHelper {
 	void invalidDate() {
 		assertInvalidRRN( "861324-2567481" );
 		assertInvalidRRN( "960292-2499371" );
+		assertInvalidRRN( "000001-1234560" );
+		assertInvalidRRN( "000100-1234560" );
+		assertInvalidRRN( "000000-1234560" );
 	}
 
 	// Invalid RRN Length


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->
In a Korean resident registration number, the month and day parts cannot be 00 each.
In other words, 0 month and 0 day are not valid.
I've added the date validation condition in KorRRNValidator.

- [Jira HV-2113](https://hibernate.atlassian.net/browse/HV-2113)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
