### PR TITLE
HV-2114 Add support for Korean foreigner RRN validation

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/kor/KorRRNValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/kor/KorRRNValidator.java
@@ -22,7 +22,16 @@ import org.hibernate.validator.internal.util.ModUtil;
  */
 public class KorRRNValidator implements ConstraintValidator<KorRRN, CharSequence> {
 
-	private static final List<Integer> GENDER_DIGIT = List.of( 1, 2, 3, 4 );
+	// Gender digit in Korean Resident Registration Number (RRN):
+  // 1: Male, born 1900–1999
+  // 2: Female, born 1900–1999
+  // 3: Male, born 2000–2099
+  // 4: Female, born 2000–2099
+  // 5: Foreign male, born 1900–1999
+  // 6: Foreign female, born 1900–1999
+  // 7: Foreign male, born 2000–2099
+  // 8: Foreign female, born 2000–2099
+	private static final List<Integer> GENDER_DIGIT = List.of(1, 2, 3, 4, 5, 6, 7, 8);
 	// Check sum weight for ModUtil
 	private static final int[] CHECK_SUM_WEIGHT = new int[] { 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 };
 	// index of the digit representing the gender
@@ -90,7 +99,7 @@ public class KorRRNValidator implements ConstraintValidator<KorRRN, CharSequence
 			if ( month < 1 || month > 12 || day < 1 || day > 31 ) {
 				return false;
 			}
-			return day <= 31 && ( day <= 30 || ( month != 4 && month != 6 && month != 9 && month != 11 ) ) && ( day <= 29 || month != 2 );
+			return (day <= 30 || month != 4 && month != 6 && month != 9 && month != 11) && (day <= 29 || month != 2);
 		}
 
 		private static boolean isValidLength(String rrn) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/kor/KorRRNValidatorNeverAttrTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/kor/KorRRNValidatorNeverAttrTest.java
@@ -47,6 +47,14 @@ public class KorRRNValidatorNeverAttrTest extends KorRRNValidatorTestHelper {
 		assertValidRRN( "750519-1404601" );
 	}
 
+	@Test
+	void testNeverForeignerGenderDigits() {
+		assertValidRRN( "850101-5000000" );
+		assertValidRRN( "920202-6000000" );
+		assertValidRRN( "010101-7000000" );
+		assertValidRRN( "030303-8000000" );
+	}
+
 	/**
 	 * The test succeeds without hyphen ('-')
 	 */


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

This change adds support for Korean Resident Registration Numbers (RRNs) issued to foreign residents living in Korea.

Currently, the KorRRNValidator rejects RRNs with gender digits 5 to 8, which represent foreign males and females born in the 1900s and 2000s:
- 5: Foreign male, born 1900–1999
- 6: Foreign female, born 1900–1999
- 7: Foreign male, born 2000–2099
- 8: Foreign female, born 2000–2099

By adding these digits to the `GENDER_DIGIT` list, this validator now correctly accepts valid RRNs for foreign residents.

Jira Issue: [HV-2114](https://hibernate.atlassian.net/browse/HV-2114)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------


[HV-2114]: https://hibernate.atlassian.net/browse/HV-2114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ