### PR TITLE
Backport of HV-2114 to 9.0 Add support for Korean foreigner RRN validation

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/kor/KorRRNValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/kor/KorRRNValidator.java
@@ -22,7 +22,16 @@ import org.hibernate.validator.internal.util.ModUtil;
  */
 public class KorRRNValidator implements ConstraintValidator<KorRRN, CharSequence> {
 
-	private static final List<Integer> GENDER_DIGIT = List.of( 1, 2, 3, 4 );
+	// Gender digit in Korean Resident Registration Number (RRN):
+	// 1: Male, born 1900–1999
+	// 2: Female, born 1900–1999
+	// 3: Male, born 2000–2099
+	// 4: Female, born 2000–2099
+	// 5: Foreign male, born 1900–1999
+	// 6: Foreign female, born 1900–1999
+	// 7: Foreign male, born 2000–2099
+	// 8: Foreign female, born 2000–2099
+	private static final List<Integer> GENDER_DIGIT = List.of( 1, 2, 3, 4, 5, 6, 7, 8 );
 	// Check sum weight for ModUtil
 	private static final int[] CHECK_SUM_WEIGHT = new int[] { 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2 };
 	// index of the digit representing the gender
@@ -90,7 +99,7 @@ public class KorRRNValidator implements ConstraintValidator<KorRRN, CharSequence
 			if ( month < 1 || month > 12 || day < 1 || day > 31 ) {
 				return false;
 			}
-			return day <= 31 && ( day <= 30 || ( month != 4 && month != 6 && month != 9 && month != 11 ) ) && ( day <= 29 || month != 2 );
+			return ( day <= 30 || month != 4 && month != 6 && month != 9 && month != 11 ) && ( day <= 29 || month != 2 );
 		}
 
 		private static boolean isValidLength(String rrn) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/kor/KorRRNValidatorAlwaysAttrTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/kor/KorRRNValidatorAlwaysAttrTest.java
@@ -33,7 +33,6 @@ public class KorRRNValidatorAlwaysAttrTest extends KorRRNValidatorTestHelper {
 	// valid RRN
 	@Test
 	void testBeforeOctober2020OnlyAttr() {
-
 		assertValidRRN( "861224-2567484" );
 		assertValidRRN( "960223-2499378" );
 		assertValidRRN( "790707-1133360" );
@@ -69,6 +68,14 @@ public class KorRRNValidatorAlwaysAttrTest extends KorRRNValidatorTestHelper {
 		assertInvalidRRN( "960292-2499371" );
 		assertInvalidRRN( "000000-5920021" );
 		assertInvalidRRN( "999999-6609491" );
+	}
+
+	@Test
+	void testAlwaysForeignerGenderDigits() {
+		assertValidRRN( "850101-5000005" );
+		assertValidRRN( "920202-6000003" );
+		assertValidRRN( "010101-7000006" );
+		assertValidRRN( "030303-8000001" );
 	}
 
 	// Invalid RRN Length

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/kor/KorRRNValidatorNeverAttrTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/kor/KorRRNValidatorNeverAttrTest.java
@@ -47,6 +47,14 @@ public class KorRRNValidatorNeverAttrTest extends KorRRNValidatorTestHelper {
 		assertValidRRN( "750519-1404601" );
 	}
 
+	@Test
+	void testNeverForeignerGenderDigits() {
+		assertValidRRN( "850101-5000000" );
+		assertValidRRN( "920202-6000000" );
+		assertValidRRN( "010101-7000000" );
+		assertValidRRN( "030303-8000000" );
+	}
+
 	/**
 	 * The test succeeds without hyphen ('-')
 	 */


### PR DESCRIPTION
(cherry picked from commit dca0549d842b1d7552663c0ceb9169da99de2c4a)

Backport of https://github.com/hibernate/hibernate-validator/pull/1642

https://hibernate.atlassian.net/browse/HV-2114

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
