### PR TITLE
Limit GitHub workflow permissions to contents:read

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -15,6 +15,9 @@ defaults:
 env:
   MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end -Pci-build --no-transfer-progress"
 
+permissions:
+  contents: read
+
 jobs:
   publish-build-scans:
     name: Publish Develocity build scans

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ env:
   MAVEN_ARGS: "-e -B --settings .github/mvn-settings.xml --fail-at-end -Pci-build --no-transfer-progress"
   TESTCONTAINERS_REUSE_ENABLE: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: ${{matrix.os.name}}


### PR DESCRIPTION
as this seems to be enough even though there's an artifact upload action in play ... (at least it work on a fork 😃)

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
