### PR TITLE
HV-2135 Do not initialize the alreadyProcessedGroups unless necessary in BeanValueContext

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valuecontext/BeanValueContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valuecontext/BeanValueContext.java
@@ -41,7 +41,6 @@ public final class BeanValueContext<T, V> extends ValueContext<T, V> {
 	BeanValueContext(ValueContext<?, ?> parentContext, ExecutableParameterNameProvider parameterNameProvider, T currentBean, BeanMetaData<T> currentBeanMetaData, MutablePath propertyPath) {
 		super( parentContext, parameterNameProvider, currentBean, currentBeanMetaData, propertyPath );
 		this.currentBeanMetaData = currentBeanMetaData;
-		this.alreadyProcessedGroups = new HashSet<>();
 	}
 
 	public BeanMetaData<T> getCurrentBeanMetaData() {

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/valuecontext/ValueContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/valuecontext/ValueContext.java
@@ -147,7 +147,9 @@ public abstract sealed class ValueContext<T, V> permits BeanValueContext, Execut
 	}
 
 	public final void setCurrentGroup(Class<?> currentGroup) {
-		this.previousGroup = this.currentGroup;
+		if ( this.previousGroup != this.currentGroup ) {
+			this.previousGroup = this.currentGroup;
+		}
 		this.currentGroup = currentGroup;
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2135

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
