### PR TITLE
HV-2144 Update to com.fasterxml:classmate 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
             These dependencies should be aligned with the ones from the WildFly version we support
             See http://search.maven.org/#search|gav|1|g%3A"org.wildfly"%20AND%20a%3A"wildfly-parent"
         -->
-        <version.com.fasterxml.classmate>1.7.0</version.com.fasterxml.classmate>
+        <version.com.fasterxml.classmate>1.7.1</version.com.fasterxml.classmate>
         <version.joda-time>2.14.0</version.joda-time>
         <version.org.slf4j>2.0.17</version.org.slf4j>
         <version.org.apache.logging.log4j>2.25.2</version.org.apache.logging.log4j>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2144

Bump com.fasterxml:classmate from 1.7.0 to 1.7.1

Bumps [com.fasterxml:classmate](https://github.com/FasterXML/java-classmate) from 1.7.0 to 1.7.1.
- [Commits](https://github.com/FasterXML/java-classmate/compare/classmate-1.7.0...classmate-1.7.1)

---
updated-dependencies:
- dependency-name: com.fasterxml:classmate dependency-version: 1.7.1 dependency-type: direct:production update-type: version-update:semver-patch ...

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
