### PR TITLE
HV-2207 Use Maven 3.9.15 as a required minimum version for the build / update build dependencies 

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -7,7 +7,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>common-custom-user-data-maven-extension</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </extension>
     <extension>
         <groupId>org.hibernate.infra.develocity</groupId>

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=bin
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.14/apache-maven-3.9.14-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.15/apache-maven-3.9.15-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.3.4/maven-wrapper-3.3.4.jar

--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <version.javax.annotation>1.2</version.javax.annotation>
 
         <!-- JavaFX dependencies -->
-        <version.org.openjfx>17.0.18</version.org.openjfx>
+        <version.org.openjfx>17.0.19</version.org.openjfx>
 
         <!-- Test dependencies -->
         <version.org.jboss.arquillian>1.10.1.Final</version.org.jboss.arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
                 - update README
                 - run mvn wrapper:wrapper to re-generate the maven wrapper
             -->
-        <maven.min.version>3.9.14</maven.min.version>
+        <maven.min.version>3.9.15</maven.min.version>
 
         <!-- Formatting -->
         <format.skip>false</format.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <!-- Test dependencies -->
         <version.org.jboss.arquillian>1.10.1.Final</version.org.jboss.arquillian>
         <version.shrinkwrap.core>1.2.6</version.shrinkwrap.core>
-        <version.shrinkwrap.resolvers>3.3.5</version.shrinkwrap.resolvers>
+        <version.shrinkwrap.resolvers>3.3.6</version.shrinkwrap.resolvers>
         <version.shrinkwrap.descriptors>2.0.0</version.shrinkwrap.descriptors>
         <version.org.testng>7.12.0</version.org.testng>
         <version.org.assertj.assertj-core>3.27.7</version.org.assertj.assertj-core>
@@ -198,8 +198,8 @@
         <version.org.easymock>5.6.0</version.org.easymock>
         <version.io.rest-assured>6.0.0</version.io.rest-assured>
         <version.org.apache.groovy>5.0.5</version.org.apache.groovy>
-        <version.com.google.guava>33.5.0-jre</version.com.google.guava>
-        <version.org.springframework.spring-expression>7.0.6</version.org.springframework.spring-expression>
+        <version.com.google.guava>33.6.0-jre</version.com.google.guava>
+        <version.org.springframework.spring-expression>7.0.7</version.org.springframework.spring-expression>
         <version.org.jboss.arquillian.container.arquillian-weld-embedded>4.0.0.Final</version.org.jboss.arquillian.container.arquillian-weld-embedded>
         <version.tools.jackson.core.jackson-bom>3.1.1</version.tools.jackson.core.jackson-bom>
         <version.net.bytebuddy.byte-buddy>1.18.8</version.net.bytebuddy.byte-buddy>
@@ -218,7 +218,7 @@
             overridden by a CI job of the Checkstyle project so that they can
             check for regressions. Which is obviously good for us, too.
          -->
-        <puppycrawl.checkstyle.version>13.4.0</puppycrawl.checkstyle.version>
+        <puppycrawl.checkstyle.version>13.4.1</puppycrawl.checkstyle.version>
 
         <!-- Asciidoctor -->
 
@@ -246,7 +246,7 @@
         <version.forbiddenapis.plugin>3.10</version.forbiddenapis.plugin>
         <version.gmavenplus.plugin>4.3.1</version.gmavenplus.plugin>
         <version.install.plugin>3.1.4</version.install.plugin>
-        <version.japicmp.plugin>0.25.5</version.japicmp.plugin>
+        <version.japicmp.plugin>0.25.6</version.japicmp.plugin>
         <version.jar.plugin>3.5.0</version.jar.plugin>
         <version.jqassistant.plugin>2.9.1</version.jqassistant.plugin>
         <version.javadoc.plugin>3.12.0</version.javadoc.plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2207
https://hibernate.atlassian.net/browse/HV-2208

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
