### PR TITLE
HV-2211 Upgrade Jackson test dependency to 3.1.3 / HV-2212 Bump joda-time to 2.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,7 +156,7 @@
             See http://search.maven.org/#search|gav|1|g%3A"org.wildfly"%20AND%20a%3A"wildfly-parent"
         -->
         <version.com.fasterxml.classmate>1.7.3</version.com.fasterxml.classmate>
-        <version.joda-time>2.14.1</version.joda-time>
+        <version.joda-time>2.14.2</version.joda-time>
         <version.org.slf4j>2.0.17</version.org.slf4j>
         <version.org.apache.logging.log4j>2.25.4</version.org.apache.logging.log4j>
 

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
         <version.com.google.guava>33.6.0-jre</version.com.google.guava>
         <version.org.springframework.spring-expression>7.0.7</version.org.springframework.spring-expression>
         <version.org.jboss.arquillian.container.arquillian-weld-embedded>4.0.0.Final</version.org.jboss.arquillian.container.arquillian-weld-embedded>
-        <version.tools.jackson.core.jackson-bom>3.1.2</version.tools.jackson.core.jackson-bom>
+        <version.tools.jackson.core.jackson-bom>3.1.3</version.tools.jackson.core.jackson-bom>
         <version.net.bytebuddy.byte-buddy>1.18.8</version.net.bytebuddy.byte-buddy>
 
         <!-- OSGi dependencies -->


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2211
https://hibernate.atlassian.net/browse/HV-2212

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
