### PR TITLE
HV-1955-1 Use String#isBlank in NullOrNotBlankValidator

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/NullOrNotBlankValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/constraintvalidators/hv/NullOrNotBlankValidator.java
@@ -10,21 +10,30 @@ import jakarta.validation.ConstraintValidatorContext;
 import org.hibernate.validator.constraints.NullOrNotBlank;
 
 /**
- * Check that the character sequence is either {@code null} or not blank.
+ * Check that the character sequence is either {@code null} or not {@link String#isBlank() blank}.
  *
  * @author Koen Aers
  */
 public class NullOrNotBlankValidator implements ConstraintValidator<NullOrNotBlank, CharSequence> {
 
+	/**
+	 * Checks that the character sequence is {@code null} or not {@link String#isBlank() blank}.
+	 *
+	 * @param charSequence the character sequence to validate
+	 * @param constraintValidatorContext context in which the constraint is evaluated
+	 * @return returns {@code true} if the string is {@code null} or
+	 * the call to {@link String#isBlank() charSequence.isBlank()} returns {@code false}, {@code false} otherwise
+	 * @see String#isBlank()
+	 */
 	@Override
 	public boolean isValid(
-			CharSequence value,
+			CharSequence charSequence,
 			ConstraintValidatorContext constraintValidatorContext) {
-		if ( value == null ) {
+		if ( charSequence == null ) {
 			return true;
 		}
 		else {
-			return !value.toString().trim().isEmpty();
+			return !charSequence.toString().isBlank();
 		}
 	}
 }


### PR DESCRIPTION
This PR addresses an inconsistency between `NotBlankValidator` and `NullOrNotBlankValidator`. Following the approach established in [HV-1955](https://hibernate.atlassian.net/browse/HV-1955), both validators should rely on `String.isBlank()` for consistent and correct blank-check behavior. This change updates `NullOrNotBlankValidator` to match that logic.

I cannot create tickets in the Hibernate Validator JIRA, so I referenced HV-1955 as a placeholder. If a dedicated ticket is required for this change, please let me know who can create it or if I should proceed with this reference. I'll update the PR title, branch, commit message, and description accordingly.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------

[HV-1955]: https://hibernate.atlassian.net/browse/HV-1955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ