### PR TITLE
[8.0] HV-2218 Backport JDK 25 jboss-logging fix from HV 9.x

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/LoggerFactory.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/LoggerFactory.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.validator.internal.util.logging;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 
 import org.jboss.logging.Logger;
@@ -19,7 +20,7 @@ public final class LoggerFactory {
 
 	public static Log make(final Lookup creationContext) {
 		final String className = creationContext.lookupClass().getName();
-		return Logger.getMessageLogger( Log.class, className );
+		return Logger.getMessageLogger( MethodHandles.lookup(), Log.class, className );
 	}
 
 	// private constructor to avoid instantiation

--- a/engine/src/main/java/org/hibernate/validator/internal/util/logging/Messages.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/util/logging/Messages.java
@@ -6,6 +6,8 @@
  */
 package org.hibernate.validator.internal.util.logging;
 
+import java.lang.invoke.MethodHandles;
+
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
 
@@ -17,7 +19,7 @@ public interface Messages {
 	/**
 	 * The messages.
 	 */
-	Messages MESSAGES = org.jboss.logging.Messages.getBundle( Messages.class );
+	Messages MESSAGES = org.jboss.logging.Messages.getBundle( MethodHandles.lookup(), Messages.class );
 
 	@Message(value = "must not be null.", format = Message.Format.NO_FORMAT)
 	String mustNotBeNull();

--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@
         <version.com.thoughtworks.paranamer>2.8</version.com.thoughtworks.paranamer>
         <version.jakarta.el-api>5.0.1</version.jakarta.el-api>
         <version.org.glassfish.expressly>5.0.0</version.org.glassfish.expressly>
-        <version.org.jboss.logging.jboss-logging>3.4.3.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logging.jboss-logging>3.6.1.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging-tools>2.2.2.Final</version.org.jboss.logging.jboss-logging-tools>
 
         <!-- Currently supported version of WildFly -->
         <version.wildfly>27.0.0.Alpha4</version.wildfly>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2218

## Summary

Backport of upstream fixes from `main` to HV 8.0.x for JDK 25 compatibility.

HV 8.0.x uses the deprecated `Logger.getMessageLogger(Class, String)` and `Messages.getBundle(Class)` APIs from jboss-logging 3.4.3.Final, which rely on `SecurityManager`-based class lookup. JDK 24 removed `SecurityManager`, causing "implementation not found" errors on JDK 25.

This was already fixed upstream in `main` / HV 9.x but never backported to 8.0.x.

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->


<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
