### PR TITLE
HV-2219 Expose constraint validator payload to message interpolators

### DIFF
--- a/documentation/src/main/asciidoc/reference/_ch04.adoc
+++ b/documentation/src/main/asciidoc/reference/_ch04.adoc
@@ -177,6 +177,10 @@ Jakarta Validation XML descriptor _META-INF/validation.xml_ (see
 `Validator` (see <<section-validator-factory-message-interpolator>> and
 <<section-configuring-validator>>, respectively).
 
+When using the Hibernate Validator-specific `HibernateMessageInterpolatorContext`, custom message interpolators can
+access the <<constraint-validator-payload,constraint validator payload>>, if one was configured for the
+`ValidatorFactory` or `Validator`.
+
 [[section-resource-bundle-locator]]
 ==== `ResourceBundleLocator`
 

--- a/documentation/src/main/asciidoc/reference/_ch06.adoc
+++ b/documentation/src/main/asciidoc/reference/_ch06.adoc
@@ -270,6 +270,11 @@ include::{sourcedir}/org/hibernate/validator/referenceguide/chapter06/constraint
 `HibernateConstraintValidatorContext#getConstraintValidatorPayload()` has a type parameter
 and returns the payload only if the payload is of the given type.
 
+The same constraint validator payload is also available to custom message interpolators by unwrapping
+`MessageInterpolator.Context` to `HibernateMessageInterpolatorContext` and calling
+`HibernateMessageInterpolatorContext#getConstraintValidatorPayload(Class)`.
+See <<section-custom-message-interpolation>> for more information on custom message interpolation.
+
 [NOTE]
 ====
 It is important to note that the constraint validator payload is different from the dynamic payload you can include in

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/MessageInterpolatorContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/MessageInterpolatorContext.java
@@ -38,9 +38,10 @@ public class MessageInterpolatorContext implements HibernateMessageInterpolatorC
 	private final Map<String, Object> expressionVariables;
 	private final ExpressionLanguageFeatureLevel expressionLanguageFeatureLevel;
 	private final boolean customViolation;
+	private final Object constraintValidatorPayload;
 
 	public MessageInterpolatorContext(ConstraintDescriptor<?> constraintDescriptor, Object validatedValue, Class<?> rootBeanType, Path propertyPath, Map<String, Object> messageParameters,
-			Map<String, Object> expressionVariables, ExpressionLanguageFeatureLevel expressionLanguageFeatureLevel, boolean customViolation) {
+			Map<String, Object> expressionVariables, ExpressionLanguageFeatureLevel expressionLanguageFeatureLevel, boolean customViolation, Object constraintValidatorPayload) {
 		this.constraintDescriptor = constraintDescriptor;
 		this.validatedValue = validatedValue;
 		this.rootBeanType = rootBeanType;
@@ -49,6 +50,7 @@ public class MessageInterpolatorContext implements HibernateMessageInterpolatorC
 		this.expressionVariables = expressionVariables;
 		this.expressionLanguageFeatureLevel = expressionLanguageFeatureLevel;
 		this.customViolation = customViolation;
+		this.constraintValidatorPayload = constraintValidatorPayload;
 	}
 
 	@Override
@@ -88,6 +90,16 @@ public class MessageInterpolatorContext implements HibernateMessageInterpolatorC
 	@Override
 	public Path getPropertyPath() {
 		return propertyPath;
+	}
+
+	@Override
+	public <C> C getConstraintValidatorPayload(Class<C> type) {
+		if ( constraintValidatorPayload != null && type.isAssignableFrom( constraintValidatorPayload.getClass() ) ) {
+			return type.cast( constraintValidatorPayload );
+		}
+		else {
+			return null;
+		}
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/AbstractValidationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/validationcontext/AbstractValidationContext.java
@@ -296,7 +296,8 @@ abstract class AbstractValidationContext<T> implements BaseBeanValidationContext
 				messageParameters,
 				expressionVariables,
 				expressionLanguageFeatureLevel,
-				customViolation
+				customViolation,
+				validatorScopedContext.getConstraintValidatorPayload()
 		);
 
 		try {

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/HibernateMessageInterpolatorContext.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/HibernateMessageInterpolatorContext.java
@@ -11,6 +11,7 @@ import jakarta.validation.Path;
 
 import org.hibernate.validator.HibernateValidatorConfiguration;
 import org.hibernate.validator.HibernateValidatorContext;
+import org.hibernate.validator.Incubating;
 
 /**
  * Extension to {@code MessageInterpolator.Context} which provides functionality
@@ -70,5 +71,6 @@ public interface HibernateMessageInterpolatorContext extends MessageInterpolator
 	 *
 	 * @since 9.2
 	 */
+	@Incubating
 	<C> C getConstraintValidatorPayload(Class<C> type);
 }

--- a/engine/src/main/java/org/hibernate/validator/messageinterpolation/HibernateMessageInterpolatorContext.java
+++ b/engine/src/main/java/org/hibernate/validator/messageinterpolation/HibernateMessageInterpolatorContext.java
@@ -9,6 +9,9 @@ import java.util.Map;
 import jakarta.validation.MessageInterpolator;
 import jakarta.validation.Path;
 
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.HibernateValidatorContext;
+
 /**
  * Extension to {@code MessageInterpolator.Context} which provides functionality
  * specific to Hibernate Validator.
@@ -53,4 +56,19 @@ public interface HibernateMessageInterpolatorContext extends MessageInterpolator
 	 * @since 6.2
 	 */
 	ExpressionLanguageFeatureLevel getExpressionLanguageFeatureLevel();
+
+	/**
+	 * Returns an instance of the specified type or {@code null} if the constraint validator payload assigned to
+	 * the validator isn't of the given type.
+	 * <p>
+	 * This is the payload configured through {@link HibernateValidatorConfiguration#constraintValidatorPayload(Object)}
+	 * or {@link HibernateValidatorContext#constraintValidatorPayload(Object)}.
+	 *
+	 * @param type the type of payload to retrieve
+	 * @return an instance of the specified type or {@code null} if the constraint validator payload isn't of the
+	 * given type
+	 *
+	 * @since 9.2
+	 */
+	<C> C getConstraintValidatorPayload(Class<C> type);
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/ExpressionLanguageMessageInterpolationTest.java
@@ -70,7 +70,8 @@ public class ExpressionLanguageMessageInterpolationTest {
 				Collections.<String, Object>emptyMap(),
 				Collections.<String, Object>emptyMap(),
 				ExpressionLanguageFeatureLevel.BEAN_METHODS,
-				false );
+				false,
+				null );
 
 		String expected = "18";
 		String actual = interpolatorUnderTest.interpolate( "${validatedValue.age}", context );
@@ -89,7 +90,8 @@ public class ExpressionLanguageMessageInterpolationTest {
 				Collections.<String, Object>emptyMap(),
 				Collections.<String, Object>emptyMap(),
 				ExpressionLanguageFeatureLevel.BEAN_PROPERTIES,
-				false );
+				false,
+				null );
 
 		String expected = "18";
 		String actual = interpolatorUnderTest.interpolate( "${validatedValue.age}", context );
@@ -108,7 +110,8 @@ public class ExpressionLanguageMessageInterpolationTest {
 				Collections.<String, Object>emptyMap(),
 				Collections.<String, Object>emptyMap(),
 				ExpressionLanguageFeatureLevel.VARIABLES,
-				false );
+				false,
+				null );
 
 		String expected = "${validatedValue.age}";
 		String actual = interpolatorUnderTest.interpolate( "${validatedValue.age}", context );
@@ -125,7 +128,8 @@ public class ExpressionLanguageMessageInterpolationTest {
 				Collections.<String, Object>emptyMap(),
 				Collections.<String, Object>emptyMap(),
 				ExpressionLanguageFeatureLevel.BEAN_METHODS,
-				false );
+				false,
+				null );
 
 		String expected = "${validatedValue.foo}";
 		String actual = interpolatorUnderTest.interpolate( "${validatedValue.foo}", context );
@@ -217,7 +221,8 @@ public class ExpressionLanguageMessageInterpolationTest {
 				Collections.<String, Object>emptyMap(),
 				Collections.<String, Object>emptyMap(),
 				ExpressionLanguageFeatureLevel.VARIABLES,
-				false );
+				false,
+				null );
 
 		// german locale
 		String expected = "42,00";
@@ -297,7 +302,8 @@ public class ExpressionLanguageMessageInterpolationTest {
 				Collections.<String, Object>emptyMap(),
 				Collections.<String, Object>emptyMap(),
 				ExpressionLanguageFeatureLevel.BEAN_METHODS,
-				false );
+				false,
+				null );
 
 		String expected = "${formatter.foo('%1$.2f', validatedValue)}";
 		String actual = interpolatorUnderTest.interpolate(
@@ -380,6 +386,7 @@ public class ExpressionLanguageMessageInterpolationTest {
 				Collections.<String, Object>emptyMap(),
 				Collections.<String, Object>emptyMap(),
 				expressionLanguageFeatureLevel,
-				false );
+				false,
+				null );
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/MessageInterpolatorContextTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/MessageInterpolatorContextTest.java
@@ -12,6 +12,7 @@ import static org.easymock.EasyMock.verify;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
 import static org.hibernate.validator.testutils.ValidatorUtil.getConfiguration;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
@@ -38,6 +39,7 @@ import jakarta.validation.metadata.BeanDescriptor;
 import jakarta.validation.metadata.ConstraintDescriptor;
 import jakarta.validation.metadata.PropertyDescriptor;
 
+import org.hibernate.validator.HibernateValidatorFactory;
 import org.hibernate.validator.internal.engine.MessageInterpolatorContext;
 import org.hibernate.validator.messageinterpolation.ExpressionLanguageFeatureLevel;
 import org.hibernate.validator.messageinterpolation.HibernateMessageInterpolatorContext;
@@ -95,7 +97,8 @@ public class MessageInterpolatorContextTest {
 								Collections.<String, Object>emptyMap(),
 								Collections.<String, Object>emptyMap(),
 								ExpressionLanguageFeatureLevel.BEAN_METHODS,
-								false )
+								false,
+								null )
 				)
 		)
 				.andReturn( "invalid" );
@@ -113,14 +116,14 @@ public class MessageInterpolatorContextTest {
 	@Test(expectedExceptions = ValidationException.class)
 	public void testUnwrapToImplementationCausesValidationException() {
 		Context context = new MessageInterpolatorContext( null, null, null, null, Collections.<String, Object>emptyMap(),
-				Collections.<String, Object>emptyMap(), ExpressionLanguageFeatureLevel.BEAN_METHODS, false );
+				Collections.<String, Object>emptyMap(), ExpressionLanguageFeatureLevel.BEAN_METHODS, false, null );
 		context.unwrap( MessageInterpolatorContext.class );
 	}
 
 	@Test
 	public void testUnwrapToInterfaceTypesSucceeds() {
 		Context context = new MessageInterpolatorContext( null, null, null, null, Collections.<String, Object>emptyMap(),
-				Collections.<String, Object>emptyMap(), ExpressionLanguageFeatureLevel.BEAN_METHODS, false );
+				Collections.<String, Object>emptyMap(), ExpressionLanguageFeatureLevel.BEAN_METHODS, false, null );
 
 		MessageInterpolator.Context asMessageInterpolatorContext = context.unwrap( MessageInterpolator.Context.class );
 		assertSame( asMessageInterpolatorContext, context );
@@ -145,7 +148,8 @@ public class MessageInterpolatorContextTest {
 				Collections.<String, Object>emptyMap(),
 				Collections.<String, Object>emptyMap(),
 				ExpressionLanguageFeatureLevel.BEAN_METHODS,
-				false );
+				false,
+				null );
 
 		assertSame( context.unwrap( HibernateMessageInterpolatorContext.class ).getRootBeanType(), rootBeanType );
 	}
@@ -162,9 +166,64 @@ public class MessageInterpolatorContextTest {
 				Collections.<String, Object>emptyMap(),
 				Collections.<String, Object>emptyMap(),
 				ExpressionLanguageFeatureLevel.BEAN_METHODS,
-				false );
+				false,
+				null );
 
 		assertSame( context.unwrap( HibernateMessageInterpolatorContext.class ).getPropertyPath(), pathMock );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-2219")
+	public void testGetConstraintValidatorPayload() {
+		String constraintValidatorPayload = "payload";
+		MessageInterpolator.Context context = new MessageInterpolatorContext(
+				null,
+				null,
+				null,
+				null,
+				Collections.<String, Object>emptyMap(),
+				Collections.<String, Object>emptyMap(),
+				ExpressionLanguageFeatureLevel.BEAN_METHODS,
+				false,
+				constraintValidatorPayload );
+
+		assertSame( context.unwrap( HibernateMessageInterpolatorContext.class ).getConstraintValidatorPayload( String.class ), constraintValidatorPayload );
+		assertNull( context.unwrap( HibernateMessageInterpolatorContext.class ).getConstraintValidatorPayload( Integer.class ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-2219")
+	public void testGetConstraintValidatorPayloadReturnsNullWhenUnset() {
+		MessageInterpolator.Context context = new MessageInterpolatorContext(
+				null,
+				null,
+				null,
+				null,
+				Collections.<String, Object>emptyMap(),
+				Collections.<String, Object>emptyMap(),
+				ExpressionLanguageFeatureLevel.BEAN_METHODS,
+				false,
+				null );
+
+		assertNull( context.unwrap( HibernateMessageInterpolatorContext.class ).getConstraintValidatorPayload( Object.class ) );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-2219")
+	public void testConstraintValidatorPayloadIsPassedToMessageInterpolator() {
+		HibernateValidatorFactory validatorFactory = ValidatorUtil.getConfiguration()
+				.messageInterpolator( new ConstraintValidatorPayloadMessageInterpolator() )
+				.buildValidatorFactory()
+				.unwrap( HibernateValidatorFactory.class );
+		Validator validator = validatorFactory.usingContext()
+				.constraintValidatorPayload( "payload" )
+				.getValidator();
+
+		Set<ConstraintViolation<TestBean>> violations = validator.validate( new TestBean( "value" ) );
+
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Size.class ).withMessage( "payload" )
+		);
 	}
 
 	@Test
@@ -221,6 +280,19 @@ public class MessageInterpolatorContextTest {
 			return baseNodeBuilder.toString();
 		}
 
+	}
+
+	private static class ConstraintValidatorPayloadMessageInterpolator implements MessageInterpolator {
+
+		@Override
+		public String interpolate(String messageTemplate, Context context) {
+			return context.unwrap( HibernateMessageInterpolatorContext.class ).getConstraintValidatorPayload( String.class );
+		}
+
+		@Override
+		public String interpolate(String messageTemplate, Context context, Locale locale) {
+			return interpolate( messageTemplate, context );
+		}
 	}
 
 	/**

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/ResourceBundleMessageInterpolatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/ResourceBundleMessageInterpolatorTest.java
@@ -282,7 +282,8 @@ public class ResourceBundleMessageInterpolatorTest {
 				Collections.<String, Object>emptyMap(),
 				Collections.<String, Object>emptyMap(),
 				ExpressionLanguageFeatureLevel.BEAN_METHODS,
-				false );
+				false,
+				null );
 	}
 
 	private void runInterpolation(boolean cachingEnabled) {


### PR DESCRIPTION
> [!NOTE]  
> I originally contributed the constraint validator payload feature in:
> - 4220a576e44e5307b74db47d46cc7929a9201ee6- HV-1529 Allow to pass a payload to constraint validators
> - aac76a91447dff2fe7db6416ad1470f7faa4528e - HV-1595 Move ConstraintValidatorPayload to ConstraintValidatorContext
> 
> Related follow-up work around validator caching:
> - 36f7aa2b21a8345cceb55a1e1d8f1b19342549fb - HV-1589 Take initializationContext into account when caching constraint validators
> - 3b26affd8a741d629d869aa3936e2c6ba257dc62 - HV-1589 Caching of HibernateConstraintValidator is handled by ConstraintValidatorManager only
> - 4186c93310ff5e0cc4d7a60ee0f9bb279a41af3e - HV-1589 Tests for the caching behaviour of HibernateConstraintValidator
> 
> This PR extends that existing payload support to message interpolation.

<hr>

https://hibernate.atlassian.net/browse/HV-2219

This PR exposes the validator-scoped constraint validator payload to custom message interpolators.

A payload configured through:

```java
validatorFactory
        .unwrap( HibernateValidatorFactory.class )
        .usingContext()
        .constraintValidatorPayload( payload )
        .getValidator();
```

can now be accessed from a custom `MessageInterpolator` via:

```java
context.unwrap( HibernateMessageInterpolatorContext.class )
        .getConstraintValidatorPayload( MyPayload.class );
```

The new accessor follows the same typed/null-returning semantics as `HibernateConstraintValidatorContext#getConstraintValidatorPayload(Class<C>)`.

The PR also adds tests covering:
- retrieving the payload from `HibernateMessageInterpolatorContext`;
- returning `null` when no payload is configured;
- returning `null` when the requested type does not match;
- accessing a payload configured through `HibernateValidatorFactory#usingContext().constraintValidatorPayload(...)` from a custom `MessageInterpolator`.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------