### PR TITLE
Make the license agreement optional for some team members

### DIFF
--- a/.github/hibernate-github-bot.yml
+++ b/.github/hibernate-github-bot.yml
@@ -50,9 +50,13 @@ develocity:
 licenseAgreement:
   enabled: true
   ignore:
-    # We ignore all dependabot PRs for a license check:
     - user: dependabot[bot]
-      titlePattern: ".*Bump.*"
+      titlePattern: "Bump.*"
+    # Members of this team already agreed to both LGPL and ASL2 for all their contributions.
+    - team:
+        name: license-agreement
+        organization: hibernate
+      titlePattern: ".*"
 branches:
   enabled: true
   titlePrefix: "[%s]"


### PR DESCRIPTION
These team members have some sort of CLA already, e.g. through their employer, so we don't need this.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
