### PR TITLE
Address issues with ByteBuddy test on JDK26+ where Unsafe is disabled by default

### DIFF
--- a/engine/src/test/java/org/hibernate/validator/test/internal/metadata/bytebuddy/ByteBuddyWrapperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/metadata/bytebuddy/ByteBuddyWrapperTest.java
@@ -49,7 +49,7 @@ public class ByteBuddyWrapperTest {
 
 		ClassLoader classLoader = new ByteArrayClassLoader(
 				ClassLoadingStrategy.BOOTSTRAP_LOADER,
-				ClassFileLocator.ForClassLoader.readToNames( Foo.class, HibernateValidatorEnhancedBean.class,
+				ClassFileLocator.ForClassLoader.readToNames( HibernateValidatorEnhancedBean.class,
 						MyContracts.class, StringHelper.class ) );
 
 		Class<?> aClass = new ByteBuddy().rebase( clazz )
@@ -67,7 +67,7 @@ public class ByteBuddyWrapperTest {
 				)
 				.intercept( new Implementation.Simple( new GetGetterValue( clazz ) ) )
 				.make()
-				.load( classLoader, ClassLoadingStrategy.Default.INJECTION )
+				.load( classLoader, ClassLoadingStrategy.Default.WRAPPER )
 				.getLoaded();
 
 		Object object = aClass.getConstructor().newInstance();


### PR DESCRIPTION

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
