### PR TITLE
Fix ConstraintValidationProcessorIT on JDK 27+

### DIFF
--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorIT.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorIT.java
@@ -267,15 +267,26 @@ public class ConstraintValidationProcessorIT extends ConstraintValidationProcess
 
 		assertFalse( compilationResult );
 
-		assertThatDiagnosticsMatch(
-				diagnostics,
-				new DiagnosticExpectation( Kind.ERROR, 9 ),
-				new DiagnosticExpectation( Kind.ERROR, 10 ),
-				new DiagnosticExpectation( Kind.ERROR, 17 ),
-				new DiagnosticExpectation( Kind.ERROR, 18 ),
-				new DiagnosticExpectation( Kind.ERROR, 21 ),
-				new DiagnosticExpectation( Kind.ERROR, 22 )
-		);
+		// JDK 27+ javac no longer reports redundant errors for usages of types
+		// from a package that already failed to import
+		if ( Runtime.version().feature() >= 27 ) {
+			assertThatDiagnosticsMatch(
+					diagnostics,
+					new DiagnosticExpectation( Kind.ERROR, 9 ),
+					new DiagnosticExpectation( Kind.ERROR, 10 )
+			);
+		}
+		else {
+			assertThatDiagnosticsMatch(
+					diagnostics,
+					new DiagnosticExpectation( Kind.ERROR, 9 ),
+					new DiagnosticExpectation( Kind.ERROR, 10 ),
+					new DiagnosticExpectation( Kind.ERROR, 17 ),
+					new DiagnosticExpectation( Kind.ERROR, 18 ),
+					new DiagnosticExpectation( Kind.ERROR, 21 ),
+					new DiagnosticExpectation( Kind.ERROR, 22 )
+			);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
JDK 27 reports "missing" annotations differently

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
