### PR TITLE
HV-2220 Add @Port constraint

### DIFF
--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorIT.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/ConstraintValidationProcessorIT.java
@@ -160,8 +160,6 @@ public class ConstraintValidationProcessorIT extends ConstraintValidationProcess
 		assertFalse( compilationResult );
 		assertThatDiagnosticsMatch(
 				diagnostics,
-				new DiagnosticExpectation( Kind.ERROR, 55 ),
-				new DiagnosticExpectation( Kind.ERROR, 56 ),
 				new DiagnosticExpectation( Kind.ERROR, 57 ),
 				new DiagnosticExpectation( Kind.ERROR, 58 ),
 				new DiagnosticExpectation( Kind.ERROR, 59 ),
@@ -174,7 +172,10 @@ public class ConstraintValidationProcessorIT extends ConstraintValidationProcess
 				new DiagnosticExpectation( Kind.ERROR, 66 ),
 				new DiagnosticExpectation( Kind.ERROR, 67 ),
 				new DiagnosticExpectation( Kind.ERROR, 68 ),
-				new DiagnosticExpectation( Kind.ERROR, 69 )
+				new DiagnosticExpectation( Kind.ERROR, 69 ),
+				new DiagnosticExpectation( Kind.ERROR, 70 ),
+				new DiagnosticExpectation( Kind.ERROR, 71 ),
+				new DiagnosticExpectation( Kind.ERROR, 72 )
 		);
 	}
 

--- a/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/customconstraints/HibernateValidatorProvidedCustomConstraints.java
+++ b/annotation-processor/src/test/java/org/hibernate/validator/ap/testmodel/customconstraints/HibernateValidatorProvidedCustomConstraints.java
@@ -12,6 +12,7 @@ import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.LuhnCheck;
 import org.hibernate.validator.constraints.Mod10Check;
 import org.hibernate.validator.constraints.Mod11Check;
+import org.hibernate.validator.constraints.Port;
 import org.hibernate.validator.constraints.Range;
 import org.hibernate.validator.constraints.ScriptAssert;
 import org.hibernate.validator.constraints.URL;
@@ -35,6 +36,7 @@ public class HibernateValidatorProvidedCustomConstraints {
 	@LuhnCheck
 	@Mod10Check
 	@Mod11Check
+	@Port
 	@Range
 	@URL
 	@CNPJ
@@ -57,6 +59,7 @@ public class HibernateValidatorProvidedCustomConstraints {
 	@LuhnCheck
 	@Mod10Check
 	@Mod11Check
+	@Port
 	@Range
 	@URL
 	@CNPJ

--- a/documentation/src/main/asciidoc/reference/_ch02.adoc
+++ b/documentation/src/main/asciidoc/reference/_ch02.adoc
@@ -726,6 +726,10 @@ The default is `ANY`, which means both IPv4 and IPv6 addresses are considered va
 	Supported data types::: `CharSequence`, `Collection`, `Map` and arrays
 	Hibernate metadata impact::: None
 
+`@Port`:: Validates that the annotated element is a valid port number (between 0 and 65535 inclusive).
+	Supported data types::: `BigDecimal`, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types
+	Hibernate metadata impact::: None
+
 `@Range(min=, max=)`:: Checks whether the annotated value lies between (inclusive) the specified minimum and maximum
 	Supported data types::: `BigDecimal`, `BigInteger`, `CharSequence`, `byte`, `short`, `int`, `long` and the respective wrappers of the primitive types
 	Hibernate metadata impact::: None

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/PortDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/PortDef.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+
+package org.hibernate.validator.cfg.defs;
+
+import org.hibernate.validator.cfg.ConstraintDef;
+import org.hibernate.validator.constraints.Port;
+
+/**
+ * Constraint definition for {@link Port}.
+ * @author Koen Aers
+ * @since 9.2
+ */
+public class PortDef extends ConstraintDef<PortDef, Port> {
+
+	public PortDef() {
+		super( Port.class );
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/constraints/Port.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/Port.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.validator.constraints;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE_USE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraintvalidation.SupportedValidationTarget;
+import jakarta.validation.constraintvalidation.ValidationTarget;
+
+import org.hibernate.validator.constraints.Port.List;
+
+/**
+ * The annotated element must be a valid port number (between 0 and 65535 inclusive).
+ * {@code null} elements are considered valid.
+ * <p>
+ * Accepts any numeric type supported by {@link Min @Min} and {@link Max @Max}.
+ *
+ * @author Koen Aers
+ * @since 9.2
+ */
+@Documented
+@Constraint(validatedBy = { })
+@SupportedValidationTarget(ValidationTarget.ANNOTATED_ELEMENT)
+@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+@Retention(RUNTIME)
+@Repeatable(List.class)
+@Min(0)
+@Max(65535)
+@ReportAsSingleViolation
+public @interface Port {
+
+	String message() default "{org.hibernate.validator.constraints.Port.message}";
+
+	Class<?>[] groups() default { };
+
+	Class<? extends Payload>[] payload() default { };
+
+	/**
+	 * Defines several {@code @Port} annotations on the same element.
+	 */
+	@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+	@Retention(RUNTIME)
+	@Documented
+	public @interface List {
+		Port[] value();
+	}
+}

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/BuiltinConstraint.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/BuiltinConstraint.java
@@ -66,6 +66,8 @@ enum BuiltinConstraint {
 	ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_NULL_OR_NOT_EMPTY( "org.hibernate.validator.constraints.NullOrNotEmpty" ),
 	ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_EAN( "org.hibernate.validator.constraints.EAN", Arrays.asList( ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_MOD10_CHECK ) ),
 	ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_PARAMETER_SCRIPT_ASSERT( "org.hibernate.validator.constraints.ParameterScriptAssert" ),
+	ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_PORT( "org.hibernate.validator.constraints.Port",
+			Arrays.asList( JAKARTA_VALIDATION_CONSTRAINTS_MIN, JAKARTA_VALIDATION_CONSTRAINTS_MAX ) ),
 	ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_RANGE( "org.hibernate.validator.constraints.Range",
 			Arrays.asList( JAKARTA_VALIDATION_CONSTRAINTS_MIN, JAKARTA_VALIDATION_CONSTRAINTS_MAX ) ),
 	ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_SCRIPT_ASSERT( "org.hibernate.validator.constraints.ScriptAssert" ),

--- a/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/metadata/core/ConstraintHelper.java
@@ -48,6 +48,7 @@ import static org.hibernate.validator.internal.metadata.core.BuiltinConstraint.O
 import static org.hibernate.validator.internal.metadata.core.BuiltinConstraint.ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_PL_NIP;
 import static org.hibernate.validator.internal.metadata.core.BuiltinConstraint.ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_PL_PESEL;
 import static org.hibernate.validator.internal.metadata.core.BuiltinConstraint.ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_PL_REGON;
+import static org.hibernate.validator.internal.metadata.core.BuiltinConstraint.ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_PORT;
 import static org.hibernate.validator.internal.metadata.core.BuiltinConstraint.ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_RANGE;
 import static org.hibernate.validator.internal.metadata.core.BuiltinConstraint.ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_RU_INN;
 import static org.hibernate.validator.internal.metadata.core.BuiltinConstraint.ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_SCRIPT_ASSERT;
@@ -119,6 +120,7 @@ import org.hibernate.validator.constraints.Normalized;
 import org.hibernate.validator.constraints.NullOrNotBlank;
 import org.hibernate.validator.constraints.NullOrNotEmpty;
 import org.hibernate.validator.constraints.ParameterScriptAssert;
+import org.hibernate.validator.constraints.Port;
 import org.hibernate.validator.constraints.Range;
 import org.hibernate.validator.constraints.ScriptAssert;
 import org.hibernate.validator.constraints.URL;
@@ -825,6 +827,9 @@ public abstract class ConstraintHelper {
 		}
 		if ( enabledBuiltinConstraints.contains( ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_PL_PESEL ) ) {
 			putBuiltinConstraint( tmpConstraints, PESEL.class, PESELValidator.class );
+		}
+		if ( enabledBuiltinConstraints.contains( ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_PORT ) ) {
+			putBuiltinConstraint( tmpConstraints, Port.class );
 		}
 		if ( enabledBuiltinConstraints.contains( ORG_HIBERNATE_VALIDATOR_CONSTRAINTS_RANGE ) ) {
 			putBuiltinConstraint( tmpConstraints, Range.class );

--- a/engine/src/main/resources/org/hibernate/validator/ValidationMessages.properties
+++ b/engine/src/main/resources/org/hibernate/validator/ValidationMessages.properties
@@ -35,6 +35,7 @@ org.hibernate.validator.constraints.Normalized.message              = must be no
 org.hibernate.validator.constraints.NullOrNotBlank.message          = must be null or not blank
 org.hibernate.validator.constraints.NullOrNotEmpty.message          = must be null or not empty
 org.hibernate.validator.constraints.ParametersScriptAssert.message  = script expression "{script}" didn't evaluate to true
+org.hibernate.validator.constraints.Port.message                    = must be a valid port number
 org.hibernate.validator.constraints.Range.message                   = must be between {min} and {max}
 org.hibernate.validator.constraints.ScriptAssert.message            = script expression "{script}" didn't evaluate to true
 org.hibernate.validator.constraints.UniqueElements.message          = must only contain unique elements

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/PortConstrainedTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/annotations/hv/PortConstrainedTest.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.validator.test.constraints.annotations.hv;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
+import java.util.Set;
+
+import jakarta.validation.ConstraintViolation;
+
+import org.hibernate.validator.constraints.Port;
+import org.hibernate.validator.test.constraints.annotations.AbstractConstrainedTest;
+import org.hibernate.validator.testutil.TestForIssue;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author Koen Aers
+ */
+@TestForIssue(jiraKey = "HV-2220")
+public class PortConstrainedTest extends AbstractConstrainedTest {
+
+	@Test
+	public void nullIsValid() {
+		Set<ConstraintViolation<Foo>> violations =
+				validator.validate( new Foo( null ) );
+		assertNoViolations( violations );
+	}
+
+	@Test
+	public void validPortIsValid() {
+		Set<ConstraintViolation<Foo>> violations =
+				validator.validate( new Foo( 8080 ) );
+		assertNoViolations( violations );
+	}
+
+	@Test
+	public void zeroIsValid() {
+		Set<ConstraintViolation<Foo>> violations =
+				validator.validate( new Foo( 0 ) );
+		assertNoViolations( violations );
+	}
+
+	@Test
+	public void maxPortIsValid() {
+		Set<ConstraintViolation<Foo>> violations =
+				validator.validate( new Foo( 65535 ) );
+		assertNoViolations( violations );
+	}
+
+	@Test
+	public void negativePortIsInvalid() {
+		Set<ConstraintViolation<Foo>> violations =
+				validator.validate( new Foo( -1 ) );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Port.class )
+		);
+	}
+
+	@Test
+	public void portAboveMaxIsInvalid() {
+		Set<ConstraintViolation<Foo>> violations =
+				validator.validate( new Foo( 65536 ) );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Port.class )
+		);
+	}
+
+	private static class Foo {
+
+		@Port
+		private final Integer port;
+
+		public Foo(Integer port) {
+			this.port = port;
+		}
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/MessagePropertiesTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/MessagePropertiesTest.java
@@ -58,6 +58,7 @@ import org.hibernate.validator.constraints.Normalized;
 import org.hibernate.validator.constraints.NullOrNotBlank;
 import org.hibernate.validator.constraints.NullOrNotEmpty;
 import org.hibernate.validator.constraints.ParameterScriptAssert;
+import org.hibernate.validator.constraints.Port;
 import org.hibernate.validator.constraints.Range;
 import org.hibernate.validator.constraints.ScriptAssert;
 import org.hibernate.validator.constraints.URL;
@@ -160,6 +161,7 @@ public class MessagePropertiesTest {
 							violationOf( Normalized.class ),
 							violationOf( NullOrNotBlank.class ),
 							violationOf( NullOrNotEmpty.class ),
+							violationOf( Port.class ),
 							violationOf( Range.class ),
 							violationOf( UniqueElements.class ),
 							violationOf( URL.class ),
@@ -312,6 +314,9 @@ public class MessagePropertiesTest {
 
 		@NullOrNotEmpty
 		private String nullOrNotEmpty = "";
+
+		@Port
+		private int port = 70000;
 
 		@Range(min = 2, max = 4)
 		private int range = 6;

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/PredefinedScopeAllConstraintsTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/PredefinedScopeAllConstraintsTest.java
@@ -57,6 +57,7 @@ import org.hibernate.validator.constraints.Normalized;
 import org.hibernate.validator.constraints.NullOrNotBlank;
 import org.hibernate.validator.constraints.NullOrNotEmpty;
 import org.hibernate.validator.constraints.ParameterScriptAssert;
+import org.hibernate.validator.constraints.Port;
 import org.hibernate.validator.constraints.Range;
 import org.hibernate.validator.constraints.ScriptAssert;
 import org.hibernate.validator.constraints.URL;
@@ -119,6 +120,7 @@ public class PredefinedScopeAllConstraintsTest {
 		testConstraint( Normalized.class, new NormalizedBean() );
 		testConstraint( NullOrNotBlank.class, new NullOrNotBlankBean() );
 		testConstraint( NullOrNotEmpty.class, new NullOrNotEmptyBean() );
+		testConstraint( Port.class, new PortBean() );
 		testConstraint( Range.class, new RangeBean() );
 		testConstraint( UniqueElements.class, new UniqueElementsBean() );
 		testConstraint( URL.class, new URLBean() );
@@ -365,6 +367,12 @@ public class PredefinedScopeAllConstraintsTest {
 		@NullOrNotEmpty
 		private String nullOrNotEmpty = "";
 
+	}
+
+	private static class PortBean {
+
+		@Port
+		private int port = 70000;
 	}
 
 	private static class RangeBean {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/PortConstraintTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/PortConstraintTest.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.validator.test.internal.constraintvalidators.hv;
+
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertNoViolations;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
+import java.util.Set;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+
+import org.hibernate.validator.HibernateValidator;
+import org.hibernate.validator.HibernateValidatorConfiguration;
+import org.hibernate.validator.cfg.ConstraintMapping;
+import org.hibernate.validator.cfg.defs.PortDef;
+import org.hibernate.validator.constraints.Port;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ValidatorUtil;
+
+import org.testng.annotations.Test;
+
+/**
+ * Tests for the {@link Port} constraint.
+ *
+ * @author Koen Aers
+ */
+@TestForIssue(jiraKey = "HV-2220")
+public class PortConstraintTest {
+
+	private final Validator validator = ValidatorUtil.getValidator();
+
+	@Test
+	public void nullIsValid() {
+		Set<ConstraintViolation<Foo>> violations =
+				validator.validate( new Foo( null ) );
+		assertNoViolations( violations );
+	}
+
+	@Test
+	public void validPorts() {
+		assertNoViolations( validator.validate( new Foo( 0 ) ) );
+		assertNoViolations( validator.validate( new Foo( 80 ) ) );
+		assertNoViolations( validator.validate( new Foo( 443 ) ) );
+		assertNoViolations( validator.validate( new Foo( 8080 ) ) );
+		assertNoViolations( validator.validate( new Foo( 65535 ) ) );
+	}
+
+	@Test
+	public void invalidPorts() {
+		assertThat( validator.validate( new Foo( -1 ) ) ).containsOnlyViolations(
+				violationOf( Port.class )
+		);
+		assertThat( validator.validate( new Foo( 65536 ) ) ).containsOnlyViolations(
+				violationOf( Port.class )
+		);
+		assertThat( validator.validate( new Foo( 100000 ) ) ).containsOnlyViolations(
+				violationOf( Port.class )
+		);
+	}
+
+	@Test
+	public void testProgrammaticDefinition() throws Exception {
+		HibernateValidatorConfiguration config = ValidatorUtil.getConfiguration( HibernateValidator.class );
+		ConstraintMapping mapping = config.createConstraintMapping();
+		mapping.type( Bar.class )
+				.field( "port" )
+				.constraint( new PortDef() );
+		config.addMapping( mapping );
+		Validator programmaticValidator = config.buildValidatorFactory().getValidator();
+
+		Set<ConstraintViolation<Bar>> violations = programmaticValidator.validate( new Bar( 8080 ) );
+		assertNoViolations( violations );
+
+		violations = programmaticValidator.validate( new Bar( null ) );
+		assertNoViolations( violations );
+
+		violations = programmaticValidator.validate( new Bar( 70000 ) );
+		assertThat( violations ).containsOnlyViolations(
+				violationOf( Port.class )
+		);
+	}
+
+	private static class Foo {
+
+		@Port
+		private final Integer port;
+
+		public Foo(Integer port) {
+			this.port = port;
+		}
+	}
+
+	private static class Bar {
+
+		private final Integer port;
+
+		public Bar(Integer port) {
+			this.port = port;
+		}
+	}
+}


### PR DESCRIPTION
Add a new `@Port` constraint that validates whether a numeric value is a valid port number (0-65535 inclusive).

This is a composed constraint using `@Min(0)` and `@Max(65535)` with `@ReportAsSingleViolation`, so it supports all numeric types out of the box without a dedicated validator class.

Null values are considered valid, consistent with Bean Validation conventions.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
