### PR TITLE
[8.0] Adjust build to be runnable with JDK 25

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -70,7 +70,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-jsr223</artifactId>
             <scope>test</scope>
         </dependency>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -154,7 +154,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-jsr223</artifactId>
             <scope>test</scope>
         </dependency>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -89,6 +89,17 @@
             <artifactId>jakarta.annotation-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <!--
+            wildfly-arquillian 5.1.0.Beta9 requires jboss-logging 3.6.x
+            this is fine though as we've already compiled validator classes
+            and generated the loggers at this point with the default version (3.4)
+         -->
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.6.3.Final</version>
+            <scope>test</scope>
+        </dependency>
         <!-- For RestEasy -->
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
@@ -352,8 +363,111 @@
                 </property>
             </activation>
             <properties>
-                <skip.failsafe.execution>true</skip.failsafe.execution>
+                <wildfly.target-dir>${project.build.directory}/wildfly-${version.wildfly.jdk25}</wildfly.target-dir>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <!-- Override: unpack WF 36 instead of WF 27 -->
+                            <execution>
+                                <id>unpack-wildfly-current</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>unpack</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>org.wildfly</groupId>
+                                            <artifactId>wildfly-dist</artifactId>
+                                            <version>${version.wildfly.jdk25}</version>
+                                            <type>tar.gz</type>
+                                            <overWrite>false</overWrite>
+                                            <outputDirectory>${project.build.directory}</outputDirectory>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                            <!-- Skip: no patch zip needed with groovy approach -->
+                            <execution>
+                                <id>copy-patch-current</id>
+                                <phase>none</phase>
+                            </execution>
+                            <!-- Copy HV artifacts directly into WF modules -->
+                            <execution>
+                                <id>copy-hv-artifacts-jdk25</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>jakarta.validation</groupId>
+                                            <artifactId>jakarta.validation-api</artifactId>
+                                            <version>${version.jakarta.validation-api}</version>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${wildfly.modules-dir}/jakarta/validation/api/main</outputDirectory>
+                                            <destFileName>jakarta.validation-api-${version.jakarta.validation-api}.jar</destFileName>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>hibernate-validator</artifactId>
+                                            <version>${project.version}</version>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${wildfly.modules-dir}/org/hibernate/validator/main</outputDirectory>
+                                            <destFileName>hibernate-validator-${project.version}.jar</destFileName>
+                                        </artifactItem>
+                                        <artifactItem>
+                                            <groupId>${project.groupId}</groupId>
+                                            <artifactId>hibernate-validator-cdi</artifactId>
+                                            <version>${project.version}</version>
+                                            <overWrite>true</overWrite>
+                                            <outputDirectory>${wildfly.modules-dir}/org/hibernate/validator/cdi/main</outputDirectory>
+                                            <destFileName>hibernate-validator-cdi-${project.version}.jar</destFileName>
+                                        </artifactItem>
+                                    </artifactItems>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Skip: no wildfly-maven-plugin patch application needed, we've applied the patch with groovy -->
+                    <plugin>
+                        <groupId>org.wildfly.plugins</groupId>
+                        <artifactId>wildfly-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>apply-wildfly-current-patch-file</id>
+                                <phase>none</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- Run groovy script to update WF module.xml descriptors -->
+                    <plugin>
+                        <groupId>org.codehaus.gmavenplus</groupId>
+                        <artifactId>gmavenplus-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>update-wildfly-jdk25-modules</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <scripts>
+                                        <script>file:///${pom.basedir}/src/script/setupModulesJdk25.groovy</script>
+                                    </scripts>
+                                    <properties>
+                                        <wildflyPatchedTargetDir>${wildfly.target-dir}</wildflyPatchedTargetDir>
+                                    </properties>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/integration/src/script/setupModulesJdk25.groovy
+++ b/integration/src/script/setupModulesJdk25.groovy
@@ -7,12 +7,6 @@ def processFileInplace(File file, Closure processText) {
     file.write( processText( text ) )
 }
 
-def deleteFiles(List<String> filePaths) {
-    for ( String filePath : filePaths ) {
-        new File( filePath ).delete();
-    }
-}
-
 def appendDependency(File file, String dependencyToAppend, boolean optional) {
     file.write( file.text.replaceAll( /<\/dependencies>/, '  <module name="' + dependencyToAppend + '"' + ( optional ? ' optional="true"' : '' ) + '/>\n  </dependencies>' ) )
 }
@@ -29,8 +23,6 @@ processFileInplace( bvModuleXml ) { text ->
     text.replaceAll( /<resource-root path=".*validation-api.*jar/, '<resource-root path="' + bvArtifactName )
 }
 
-deleteFiles( new FileNameByRegexFinder().getFileNames( wildflyPatchedTargetDir + '/modules/system/layers/base/jakarta/validation/api/main', '.*\\.jar' ) )
-
 // HV
 hvModuleXml = new File( wildflyPatchedTargetDir, 'modules/system/layers/base/org/hibernate/validator/main/module.xml' )
 def hvArtifactName = 'hibernate-validator-' + project.version + '.jar';
@@ -46,8 +38,6 @@ appendDependency( hvModuleXml, "javax.api", false )
 appendDependency( hvModuleXml, "javax.money.api", true )
 appendDependency( hvModuleXml, "javafx.api", true )
 
-deleteFiles( new FileNameByRegexFinder().getFileNames( wildflyPatchedTargetDir + '/modules/system/layers/base/org/hibernate/validator/main', 'hibernate-validator-.*\\.jar' ) )
-
 // HV CDI
 hvCdiModuleXml = new File( wildflyPatchedTargetDir, 'modules/system/layers/base/org/hibernate/validator/cdi/main/module.xml' )
 def hvCdiArtifactName = 'hibernate-validator-cdi-' + project.version + '.jar';
@@ -55,7 +45,5 @@ println "[INFO] Using HV CDI Portable Extension version " + hvCdiArtifactName;
 processFileInplace( hvCdiModuleXml ) { text ->
     text.replaceAll( /hibernate-validator-cdi.*jar/, hvCdiArtifactName )
 }
-
-deleteFiles( new FileNameByRegexFinder().getFileNames( wildflyPatchedTargetDir + '/modules/system/layers/base/org/hibernate/validator/cdi/main', 'hibernate-validator-cdi-.*\\.jar' ) )
 
 println "[INFO] ------------------------------------------------------------------------";

--- a/integration/src/test/java/org/hibernate/validator/integration/util/MyValidationProvider.java
+++ b/integration/src/test/java/org/hibernate/validator/integration/util/MyValidationProvider.java
@@ -63,7 +63,8 @@ public class MyValidationProvider implements ValidationProvider<MyValidatorConfi
 
 		@Override
 		public ConstraintValidatorFactory getConstraintValidatorFactory() {
-			throw new UnsupportedOperationException();
+			return jakarta.validation.Validation.byDefaultProvider().configure()
+					.getDefaultConstraintValidatorFactory();
 		}
 
 		@Override

--- a/osgi/integrationtest/pom.xml
+++ b/osgi/integrationtest/pom.xml
@@ -84,7 +84,7 @@
 
         <!-- script engines -->
         <dependency>
-            <groupId>org.codehaus.groovy</groupId>
+            <groupId>org.apache.groovy</groupId>
             <artifactId>groovy-jsr223</artifactId>
             <scope>test</scope>
         </dependency>

--- a/osgi/karaf-features/src/main/features/features.xml
+++ b/osgi/karaf-features/src/main/features/features.xml
@@ -30,7 +30,7 @@
     </feature>
     <feature name="hibernate-validator-groovy" version="${project.version}">
         <feature>hibernate-validator</feature>
-        <bundle>mvn:org.codehaus.groovy/groovy-all/${version.org.codehaus.groovy}</bundle>
+        <bundle>mvn:org.apache.groovy/groovy/${version.org.apache.groovy}</bundle>
     </feature>
     <feature name="hibernate-validator-paranamer" version="${project.version}">
         <feature prerequisite="true">wrap</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,8 @@
 
         <!-- Currently supported version of WildFly -->
         <version.wildfly>27.0.1.Final</version.wildfly>
+        <!-- WildFly version used for integration tests on JDK 25+ (SM-free, EE 10 compatible) -->
+        <version.wildfly.jdk25>36.0.1.Final</version.wildfly.jdk25>
         <!-- Used to create a patch file for the second version of WildFly we support -->
         <!--<version.wildfly.secondary>18.0.1.Final</version.wildfly.secondary>-->
         <!-- Version used to run the TCK in incontainer mode -->
@@ -150,7 +152,7 @@
         -->
         <version.jakarta.enterprise.cdi-api>4.0.1</version.jakarta.enterprise.cdi-api>
         <version.org.jboss.weld.weld>5.1.1.Final</version.org.jboss.weld.weld>
-        <version.org.wildfly.arquillian>5.0.0.Alpha3</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>5.1.0.Beta9</version.org.wildfly.arquillian>
         <version.jakarta.ejb-api>4.0.1</version.jakarta.ejb-api>
         <version.jakarta.interceptor-api>2.1.0</version.jakarta.interceptor-api>
         <version.jakarta.annotation-api>2.1.1</version.jakarta.annotation-api>
@@ -177,13 +179,13 @@
         <version.junit>4.13.2</version.junit>
         <version.org.easymock>3.4</version.org.easymock>
         <version.io.rest-assured>4.1.2</version.io.rest-assured>
-        <version.org.codehaus.groovy>2.4.21</version.org.codehaus.groovy>
+        <version.org.apache.groovy>5.0.6</version.org.apache.groovy>
         <version.com.google.guava>31.1-jre</version.com.google.guava>
         <version.org.springframework.spring-expression>5.3.39</version.org.springframework.spring-expression>
         <version.org.jboss.arquillian.container.arquillian-weld-embedded>3.0.2.Final</version.org.jboss.arquillian.container.arquillian-weld-embedded>
         <version.com.fasterxml.jackson.core.jackson-databind>2.13.5</version.com.fasterxml.jackson.core.jackson-databind>
         <version.com.fasterxml.jackson.core.jackson-annotations>2.13.5</version.com.fasterxml.jackson.core.jackson-annotations>
-        <version.net.bytebuddy.byte-buddy>1.13.0</version.net.bytebuddy.byte-buddy>
+        <version.net.bytebuddy.byte-buddy>1.18.10</version.net.bytebuddy.byte-buddy>
 
         <!-- OSGi dependencies -->
         <version.org.apache.karaf>4.2.0</version.org.apache.karaf>
@@ -219,14 +221,14 @@
         <version.bundle.plugin>5.1.9</version.bundle.plugin>
         <version.checkstyle.plugin>3.1.2</version.checkstyle.plugin>
         <version.clean.plugin>3.0.0</version.clean.plugin>
-        <version.compiler.plugin>3.8.1</version.compiler.plugin>
+        <version.compiler.plugin>3.15.0</version.compiler.plugin>
         <version.copy.plugin>0.0.6</version.copy.plugin>
         <version.dependency.plugin>3.0.2</version.dependency.plugin>
         <version.depends.plugin>1.4.0</version.depends.plugin>
         <version.deploy.plugin>3.1.4</version.deploy.plugin>
         <version.enforcer.plugin>3.0.0</version.enforcer.plugin>
         <version.forbiddenapis.plugin>3.2</version.forbiddenapis.plugin>
-        <version.gmavenplus.plugin>1.6.3</version.gmavenplus.plugin>
+        <version.gmavenplus.plugin>5.0.0</version.gmavenplus.plugin>
         <version.install.plugin>2.5.2</version.install.plugin>
         <version.japicmp.plugin>0.11.1</version.japicmp.plugin>
         <version.jar.plugin>3.0.2</version.jar.plugin>
@@ -239,7 +241,7 @@
         <version.sigtest.plugin>1.6</version.sigtest.plugin>
         <version.source.plugin>3.0.1</version.source.plugin>
         <version.surefire.plugin>2.21.0</version.surefire.plugin>
-        <version.surefire.plugin.java-version.asm>9.2</version.surefire.plugin.java-version.asm>
+        <version.surefire.plugin.java-version.asm>9.10.1</version.surefire.plugin.java-version.asm>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.wildfly.plugin>1.2.2.Final</version.wildfly.plugin>
         <version.org.wildfly.core>14.0.1.Final</version.org.wildfly.core>
@@ -495,9 +497,9 @@
                 <version>${version.org.testng}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.groovy</groupId>
+                <groupId>org.apache.groovy</groupId>
                 <artifactId>groovy-jsr223</artifactId>
-                <version>${version.org.codehaus.groovy}</version>
+                <version>${version.org.apache.groovy}</version>
             </dependency>
             <dependency>
                 <groupId>org.easymock</groupId>
@@ -737,6 +739,18 @@
                             <compilerArg>-Aorg.jboss.logging.tools.addGeneratedAnnotation=false</compilerArg>
                         </compilerArgs>
                         <testCompilerArgument>-parameters</testCompilerArgument>
+                        <annotationProcessorPaths>
+                            <path>
+                                <groupId>org.jboss.logging</groupId>
+                                <artifactId>jboss-logging-processor</artifactId>
+                                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+                            </path>
+                            <path>
+                                <groupId>org.jboss.logging</groupId>
+                                <artifactId>jboss-logging</artifactId>
+                                <version>${version.org.jboss.logging.jboss-logging}</version>
+                            </path>
+                        </annotationProcessorPaths>
                     </configuration>
                     <executions>
                         <execution>
@@ -1194,9 +1208,9 @@
                     <version>${version.gmavenplus.plugin}</version>
                     <dependencies>
                         <dependency>
-                            <groupId>org.codehaus.groovy</groupId>
-                            <artifactId>groovy-all</artifactId>
-                            <version>${version.org.codehaus.groovy}</version>
+                            <groupId>org.apache.groovy</groupId>
+                            <artifactId>groovy</artifactId>
+                            <version>${version.org.apache.groovy}</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
- run WF tests on a WF that can actually run on JDk 25
- switch to groovy that can run on JDK 25
- update compiler plugin that has issue with annotation processing and explicitly list the processors
- other plugin updates

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
