### PR TITLE
[9.1] HV-2217 Allow null-valued expression variable and message parameter

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintValidatorContextImpl.java
@@ -178,8 +178,8 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 				defaultConstraintExpressionLanguageFeatureLevel,
 				false,
 				basePath,
-				messageParameters != null ? Map.copyOf( messageParameters ) : Collections.emptyMap(),
-				expressionVariables != null ? Map.copyOf( expressionVariables ) : Collections.emptyMap(),
+				messageParameters,
+				expressionVariables,
 				dynamicPayload
 		);
 	}
@@ -214,8 +214,8 @@ public class ConstraintValidatorContextImpl implements HibernateConstraintValida
 							expressionLanguageFeatureLevel,
 							true,
 							propertyPath,
-							messageParameters != null ? Map.copyOf( messageParameters ) : Collections.emptyMap(),
-							expressionVariables != null ? Map.copyOf( expressionVariables ) : Collections.emptyMap(),
+							messageParameters,
+							expressionVariables,
 							dynamicPayload
 					)
 			);

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintViolationCreationContext.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/constraintvalidation/ConstraintViolationCreationContext.java
@@ -4,6 +4,8 @@
  */
 package org.hibernate.validator.internal.engine.constraintvalidation;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import jakarta.validation.Path;
@@ -42,8 +44,8 @@ public class ConstraintViolationCreationContext {
 		this.customViolation = customViolation;
 		// at this point we make a copy of the path to avoid side effects
 		this.propertyPath = property.materialize();
-		this.messageParameters = messageParameters;
-		this.expressionVariables = expressionVariables;
+		this.messageParameters = messageParameters != null ? Collections.unmodifiableMap( new HashMap<>( messageParameters ) ) : Collections.emptyMap();
+		this.expressionVariables = expressionVariables != null ? Collections.unmodifiableMap( new HashMap<>( expressionVariables ) ) : Collections.emptyMap();
 		this.dynamicPayload = dynamicPayload;
 	}
 

--- a/engine/src/test/java/org/hibernate/validator/test/el/ExpressionVariableTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/el/ExpressionVariableTest.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.validator.test.el;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hibernate.validator.messageinterpolation.ExpressionLanguageFeatureLevel.BEAN_METHODS;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+import jakarta.validation.Validator;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ValidatorUtil;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Tom Gottfried
+ */
+@TestForIssue(jiraKey = "HV-2217")
+public class ExpressionVariableTest {
+
+	private Validator validator;
+
+	@BeforeMethod
+	public void init() {
+		this.validator = ValidatorUtil.getValidator();
+	}
+
+	@Test
+	public void nonNullValuedExpressionVariable() {
+		assertThat( validator.validate( new TestBean( "value" ) ) )
+				.containsOnlyViolations( violationOf( ExpressionVariableConstraint.class ).withMessage( "Variable value: value" ) );
+	}
+
+	@Test
+	public void nullValuedExpressionVariable() {
+		assertThat( validator.validate( new TestBean( null ) ) )
+				.containsOnlyViolations( violationOf( ExpressionVariableConstraint.class ).withMessage( "Variable value: empty" ) );
+	}
+
+
+	@Target(FIELD)
+	@Retention(RUNTIME)
+	@Documented
+	@Constraint(validatedBy = { ExpressionVariableConstraintValidator.class })
+	private @interface ExpressionVariableConstraint {
+		String message() default "Variable value: ${empty v ? 'empty' : v}";
+
+		Class<?>[] groups() default { };
+
+		Class<? extends Payload>[] payload() default { };
+	}
+
+	public static class ExpressionVariableConstraintValidator implements ConstraintValidator<ExpressionVariableConstraint, String> {
+
+		private String message;
+
+		@Override
+		public void initialize(ExpressionVariableConstraint constraintAnnotation) {
+			this.message = constraintAnnotation.message();
+		}
+
+		@Override
+		public boolean isValid(String value, ConstraintValidatorContext context) {
+			HibernateConstraintValidatorContext hibernateCtx = context.unwrap(
+					HibernateConstraintValidatorContext.class
+			);
+			hibernateCtx.disableDefaultConstraintViolation();
+			hibernateCtx
+					.addExpressionVariable( "v", value )
+					.buildConstraintViolationWithTemplate( this.message )
+					.enableExpressionLanguage( BEAN_METHODS )
+					.addConstraintViolation();
+			return false;
+		}
+	}
+
+	public static class TestBean {
+
+		public TestBean(String value) {
+			this.value = value;
+		}
+
+		@ExpressionVariableConstraint
+		public String value;
+	}
+}

--- a/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/MessageParameterTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/engine/messageinterpolation/MessageParameterTest.java
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.validator.test.internal.engine.messageinterpolation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertThat;
+import static org.hibernate.validator.testutil.ConstraintViolationAssert.violationOf;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import jakarta.validation.Payload;
+import jakarta.validation.Validator;
+
+import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
+import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ValidatorUtil;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * @author Tom Gottfried
+ */
+@TestForIssue(jiraKey = "HV-2217")
+public class MessageParameterTest {
+
+	private Validator validator;
+
+	@BeforeMethod
+	public void init() {
+		this.validator = ValidatorUtil.getValidator();
+	}
+
+	@Test
+	public void nonNullValuedMessageParamter() {
+		assertThat( validator.validate( new TestBean( "value" ) ) )
+				.containsOnlyViolations( violationOf( MessageParameterConstraint.class ).withMessage( "Variable value: value" ) );
+	}
+
+	@Test
+	public void nullValuedMessageParameter() {
+		assertThat( validator.validate( new TestBean( null ) ) )
+				.containsOnlyViolations( violationOf( MessageParameterConstraint.class ).withMessage( "Variable value: {v}" ) );
+	}
+
+
+	@Target(FIELD)
+	@Retention(RUNTIME)
+	@Documented
+	@Constraint(validatedBy = { MessageParameterConstraintValidator.class })
+	private @interface MessageParameterConstraint {
+		String message() default "Variable value: {v}";
+
+		Class<?>[] groups() default { };
+
+		Class<? extends Payload>[] payload() default { };
+	}
+
+	public static class MessageParameterConstraintValidator implements ConstraintValidator<MessageParameterConstraint, String> {
+
+		private String message;
+
+		@Override
+		public void initialize(MessageParameterConstraint constraintAnnotation) {
+			this.message = constraintAnnotation.message();
+		}
+
+		@Override
+		public boolean isValid(String value, ConstraintValidatorContext context) {
+			HibernateConstraintValidatorContext hibernateCtx = context.unwrap(
+					HibernateConstraintValidatorContext.class
+			);
+			hibernateCtx.disableDefaultConstraintViolation();
+			hibernateCtx
+					.addMessageParameter( "v", value )
+					.buildConstraintViolationWithTemplate( this.message )
+					.addConstraintViolation();
+			return false;
+		}
+	}
+
+	public static class TestBean {
+
+		public TestBean(String value) {
+			this.value = value;
+		}
+
+		@MessageParameterConstraint
+		public String value;
+	}
+}


### PR DESCRIPTION
(cherry picked from commit 7edd0a1d4b03270ab0643949bb36f6020ebb52eb)

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
