### PR TITLE
HV-1852 Add enum validation warning regression test

### DIFF
--- a/engine/src/test/java/org/hibernate/validator/test/internal/properties/javabean/JavaBeanExecutableTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/properties/javabean/JavaBeanExecutableTest.java
@@ -10,9 +10,17 @@ import java.lang.reflect.ParameterizedType;
 import java.util.List;
 import java.util.Map;
 
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+
 import org.hibernate.validator.internal.properties.javabean.JavaBeanConstructor;
 import org.hibernate.validator.testutil.TestForIssue;
+import org.hibernate.validator.testutils.ListAppender;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.testng.annotations.Test;
 
 public class JavaBeanExecutableTest {
@@ -59,6 +67,41 @@ public class JavaBeanExecutableTest {
 		assertThat( parameterizedType2.getRawType() ).isEqualTo( List.class );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HV-1852")
+	public void validatingEnumConstantDoesNotLogMissingParameterMetadataWarning() {
+		LoggerContext context = LoggerContext.getContext( false );
+		Logger logger = context.getLogger( "org.hibernate.validator" );
+		Level originalLogLevel = logger.getLevel();
+		ListAppender logAppender = new ListAppender( "hv-1852" );
+		logAppender.start();
+		logger.addAppender( logAppender );
+
+		try {
+			if ( logger.getLevel().isMoreSpecificThan( Level.WARN ) ) {
+				Configurator.setLevel( "org.hibernate.validator", Level.WARN );
+				context.updateLoggers();
+			}
+
+			try ( ValidatorFactory factory = Validation.buildDefaultValidatorFactory() ) {
+				factory.getValidator().validate( SecurityProtocol.VALUE1 );
+			}
+
+			assertThat( logAppender.getMessages( Level.WARN ) )
+					.noneMatch( message -> message.contains( "HV000254" )
+							|| message.contains( "Missing parameter metadata" ) );
+		}
+		finally {
+			logger.removeAppender( logAppender );
+			logAppender.stop();
+
+			if ( originalLogLevel != null ) {
+				Configurator.setLevel( "org.hibernate.validator", originalLogLevel );
+				context.updateLoggers();
+			}
+		}
+	}
+
 	private class Bean {
 
 		private Bean(Map<String, String> map, List<Integer> list) {
@@ -76,6 +119,17 @@ public class JavaBeanExecutableTest {
 		;
 
 		private MyEnum(Map<String, String> map, List<Integer> list) {
+		}
+	}
+
+	private enum SecurityProtocol {
+		VALUE1( false );
+
+		@SuppressWarnings("unused")
+		private final boolean param1;
+
+		SecurityProtocol(boolean param1) {
+			this.param1 = param1;
 		}
 	}
 }

--- a/engine/src/test/java/org/hibernate/validator/test/internal/properties/javabean/JavaBeanExecutableTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/properties/javabean/JavaBeanExecutableTest.java
@@ -6,9 +6,21 @@ package org.hibernate.validator.test.internal.properties.javabean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.lang.reflect.ParameterizedType;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
+
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
 
 import jakarta.validation.Validation;
 import jakarta.validation.ValidatorFactory;
@@ -69,7 +81,61 @@ public class JavaBeanExecutableTest {
 
 	@Test
 	@TestForIssue(jiraKey = "HV-1852")
-	public void validatingEnumConstantDoesNotLogMissingParameterMetadataWarning() {
+	public void validatingEnumConstantDoesNotLogMissingParameterMetadataWarning() throws Exception {
+		assertValidatingDoesNotLogMissingParameterMetadataWarning( SecurityProtocol.VALUE1 );
+	}
+
+	@Test
+	@TestForIssue(jiraKey = "HV-1852")
+	public void validatingEnumConstantWithoutParameterMetadataDoesNotLogMissingParameterMetadataWarning() throws Exception {
+		Path outputDirectory = Files.createTempDirectory( "hv-1852" );
+		try {
+			Class<?> enumClass = compileSecurityProtocolWithoutParameterMetadata( outputDirectory );
+			Object enumConstant = enumClass.getEnumConstants()[0];
+
+			assertValidatingDoesNotLogMissingParameterMetadataWarning( enumConstant );
+		}
+		finally {
+			deleteRecursively( outputDirectory );
+		}
+	}
+
+	private static Class<?> compileSecurityProtocolWithoutParameterMetadata(Path outputDirectory) throws Exception {
+		Path sourceDirectory = outputDirectory.resolve( "hv1852" );
+		Path source = sourceDirectory.resolve( "SecurityProtocol.java" );
+		Files.createDirectories( sourceDirectory );
+		Files.writeString( source, """
+				package hv1852;
+
+				public enum SecurityProtocol {
+					VALUE1( false );
+
+					@SuppressWarnings(\"unused\")
+					private final boolean param1;
+
+					SecurityProtocol(boolean param1) {
+						this.param1 = param1;
+					}
+				}
+				""" );
+
+		JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+		assertThat( compiler ).isNotNull();
+		try ( StandardJavaFileManager fileManager = compiler.getStandardFileManager( null, null, null ) ) {
+			Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjects( source.toFile() );
+			Boolean compiled = compiler.getTask( null, fileManager, null, List.of( "-d", outputDirectory.toString() ),
+					null, compilationUnits )
+					.call();
+			assertThat( compiled ).isTrue();
+		}
+
+		try ( URLClassLoader classLoader = new URLClassLoader( new URL[] { outputDirectory.toUri().toURL() },
+				JavaBeanExecutableTest.class.getClassLoader() ) ) {
+			return classLoader.loadClass( "hv1852.SecurityProtocol" );
+		}
+	}
+
+	private static void assertValidatingDoesNotLogMissingParameterMetadataWarning(Object value) throws Exception {
 		LoggerContext context = LoggerContext.getContext( false );
 		Logger logger = context.getLogger( "org.hibernate.validator" );
 		Level originalLogLevel = logger.getLevel();
@@ -84,7 +150,7 @@ public class JavaBeanExecutableTest {
 			}
 
 			try ( ValidatorFactory factory = Validation.buildDefaultValidatorFactory() ) {
-				factory.getValidator().validate( SecurityProtocol.VALUE1 );
+				factory.getValidator().validate( value );
 			}
 
 			assertThat( logAppender.getMessages( Level.WARN ) )
@@ -99,6 +165,13 @@ public class JavaBeanExecutableTest {
 				Configurator.setLevel( "org.hibernate.validator", originalLogLevel );
 				context.updateLoggers();
 			}
+		}
+	}
+
+	private static void deleteRecursively(Path path) throws IOException {
+		try ( Stream<Path> paths = Files.walk( path ) ) {
+			paths.sorted( Comparator.reverseOrder() )
+					.forEach( file -> file.toFile().delete() );
 		}
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1852

This adds regression coverage for validating enum constants whose constructors have the implicit enum parameters. The test validates an enum constant and captures Hibernate Validator WARN logs to ensure the old `HV000254: Missing parameter metadata` warning is not emitted.

Validation:
- `./mvnw -pl engine -am -Dtest=org.hibernate.validator.test.internal.properties.javabean.JavaBeanExecutableTest test -DskipITs -DdisableDistributionBuild=true -Dformat.skip=true -Dsurefire.failIfNoSpecifiedTests=false`
- `git diff --check`

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
