### PR TITLE
[6.2] HV-2231 Fix NPE in RegexpURLValidator when URL has no host

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/constraintvalidators/RegexpURLValidator.java
+++ b/engine/src/main/java/org/hibernate/validator/constraintvalidators/RegexpURLValidator.java
@@ -55,7 +55,7 @@ public class RegexpURLValidator implements ConstraintValidator<URL, CharSequence
 			return false;
 		}
 
-		if ( !DomainNameUtil.isValidDomainAddress( values.getHost() ) ) {
+		if ( values.getHost() == null || !DomainNameUtil.isValidDomainAddress( values.getHost() ) ) {
 			return false;
 		}
 

--- a/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/URLValidatorTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/constraintvalidators/hv/URLValidatorTest.java
@@ -243,6 +243,15 @@ public class URLValidatorTest {
 		assertDefaultURLConstraintValidatorOverridden( config, constraintValidatorFactory );
 	}
 
+	@Test
+	@TestForIssue(jiraKey = "HV-2231")
+	public void url_without_authority_component_is_invalid_and_does_not_throw() {
+		URL url = descriptorBuilder.build().getAnnotation();
+		regexpURLValidator.initialize( url );
+
+		assertFalse( regexpURLValidator.isValid( "http:host.com", null ) );
+	}
+
 	private void assertDefaultURLConstraintValidatorOverridden(Configuration config,
 			DelegatingConstraintValidatorFactory constraintValidatorFactory) {
 		Validator validator = config.buildValidatorFactory().getValidator();


### PR DESCRIPTION
(cherry picked from commit dd874f0fabfa21bc25b0d49d3b55ca66105fed6b)

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
