### PR TITLE
HV-2227 adding rule for Repeatable and Documented annotations for constraints.

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/constraints/BitcoinAddress.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/BitcoinAddress.java
@@ -13,6 +13,7 @@ import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -20,6 +21,7 @@ import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
 import org.hibernate.validator.Incubating;
+import org.hibernate.validator.constraints.BitcoinAddress.List;
 
 /**
  * The string has to be a well-formed BTC (Bitcoin) Mainnet address. Accepts {@code CharSequence}.
@@ -36,6 +38,7 @@ import org.hibernate.validator.Incubating;
 @Constraint(validatedBy = { })
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
+@Repeatable(List.class)
 public @interface BitcoinAddress {
 
 	String message() default "{org.hibernate.validator.constraints.BitcoinAddress.message}";
@@ -52,5 +55,15 @@ public @interface BitcoinAddress {
 
 	enum BitcoinAddressType {
 		ANY, P2PKH, P2SH, BECH32, P2WSH, P2WPKH, P2TR;
+	}
+
+	/**
+	 * Defines several {@code @BitcoinAddress} annotations on the same element.
+	 */
+	@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+	@Retention(RUNTIME)
+	@Documented
+	public @interface List {
+		BitcoinAddress[] value();
 	}
 }

--- a/engine/src/main/java/org/hibernate/validator/constraints/IpAddress.java
+++ b/engine/src/main/java/org/hibernate/validator/constraints/IpAddress.java
@@ -13,6 +13,7 @@ import static java.lang.annotation.ElementType.TYPE_USE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -20,6 +21,7 @@ import jakarta.validation.Constraint;
 import jakarta.validation.Payload;
 
 import org.hibernate.validator.Incubating;
+import org.hibernate.validator.constraints.IpAddress.List;
 
 /**
  * Checks that the annotated character sequence is a valid
@@ -34,6 +36,7 @@ import org.hibernate.validator.Incubating;
 @Constraint(validatedBy = { })
 @Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
 @Retention(RUNTIME)
+@Repeatable(List.class)
 public @interface IpAddress {
 
 	String message() default "{org.hibernate.validator.constraints.IpAddress.message}";
@@ -59,5 +62,15 @@ public @interface IpAddress {
 		IPv4,
 		IPv6,
 		ANY
+	}
+
+	/**
+	 * Defines several {@code @IpAddress} annotations on the same element.
+	 */
+	@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER, TYPE_USE })
+	@Retention(RUNTIME)
+	@Documented
+	public @interface List {
+		IpAddress[] value();
 	}
 }

--- a/jqassistant/rules/rules.xml
+++ b/jqassistant/rules/rules.xml
@@ -66,10 +66,35 @@
         ]]></cypher>
     </constraint>
 
+    <constraint id="my-rules:ConstraintAnnotationsMustBeDocumentedAndRepeatable">
+        <description>Constraint annotations must be annotated with both @Documented and @Repeatable.</description>
+        <cypher><![CDATA[
+            MATCH
+                (annotationType)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(constraintType)
+            WHERE
+                constraintType.fqn = "jakarta.validation.Constraint"
+                AND annotationType.fqn =~ "^org\\.hibernate\\.validator\\.constraints\\..*"
+                AND NOT (annotationType)-[:ANNOTATED_BY]->()-[:OF_TYPE]->({fqn: "java.lang.annotation.Documented"})
+            RETURN
+                annotationType.fqn AS ConstraintAnnotation, "Missing @Documented" AS Issue
+
+            UNION ALL
+            MATCH
+                (annotationType)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(constraintType)
+            WHERE
+                constraintType.fqn = "jakarta.validation.Constraint"
+                AND annotationType.fqn =~ "^org\\.hibernate\\.validator\\.constraints\\..*"
+                AND NOT (annotationType)-[:ANNOTATED_BY]->()-[:OF_TYPE]->({fqn: "java.lang.annotation.Repeatable"})
+            RETURN
+                annotationType.fqn AS ConstraintAnnotation, "Missing @Repeatable" AS Issue
+        ]]></cypher>
+    </constraint>
+
     <group id="default">
         <includeConstraint refId="my-rules:PublicTypesMayNotExtendInternalTypes" />
         <includeConstraint refId="my-rules:PublicMethodsMayNotExposeInternalTypes" />
         <includeConstraint refId="my-rules:PublicFieldsMayNotExposeInternalTypes" />
+        <includeConstraint refId="my-rules:ConstraintAnnotationsMustBeDocumentedAndRepeatable" />
     </group>
 
 </jqa:jqassistant-rules>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2227

Added a rule using JQassistant to verify that a constraint includes the @Documented and the @Repeatable annotations.

Added the repeatable tag to IpAddress and BitcoinAddress constraint annotation class.
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
