### PR TITLE
Disable DTD support when parsing XML descriptors

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/xml/XmlParserHelper.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/xml/XmlParserHelper.java
@@ -51,7 +51,7 @@ public class XmlParserHelper {
 
 	// xmlInputFactory used to be static in order to cache the factory, but that introduced a leakage of
 	// class loader in WildFly. See HV-842
-	private final XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+	private final XMLInputFactory xmlInputFactory = createXmlInputFactory();
 
 	private static final ConcurrentMap<String, Schema> schemaCache = new ConcurrentHashMap<String, Schema>(
 			NUMBER_OF_SCHEMAS
@@ -90,6 +90,17 @@ public class XmlParserHelper {
 		catch (Exception e) {
 			throw LOG.getUnableToCreateXMLEventReader( resourceName, e );
 		}
+	}
+
+	private static XMLInputFactory createXmlInputFactory() {
+		XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();
+		// The validation and constraint mapping descriptors never rely on a DTD, so refuse doctype
+		// declarations and external entities. Otherwise an external parameter entity in the internal
+		// subset is fetched while reading the schema version, before the schema itself gets a chance to
+		// reject the document, which lets an untrusted descriptor reach out to a local file or a remote host.
+		xmlInputFactory.setProperty( XMLInputFactory.SUPPORT_DTD, false );
+		xmlInputFactory.setProperty( XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false );
+		return xmlInputFactory;
 	}
 
 	private String getVersionValue(StartElement startElement) {

--- a/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlParserHelperTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/internal/xml/XmlParserHelperTest.java
@@ -6,7 +6,11 @@ package org.hibernate.validator.test.internal.xml;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import javax.xml.stream.XMLEventReader;
 
@@ -53,5 +57,30 @@ public class XmlParserHelperTest {
 		);
 
 		assertThat( version ).isEqualTo( "1.0" );
+	}
+
+	@Test
+	public void shouldNotResolveExternalEntitiesWhenReadingSchemaVersion() throws Exception {
+		// An external parameter entity in the internal subset is expanded while the DTD is read, which
+		// happens before the schema gets a chance to reject the document. Point it at a resource that does
+		// not exist: if the parser reaches out for it, reading the version fails. It must be ignored instead.
+		Path missing = Files.createTempFile( "hv-external-entity", ".dtd" );
+		Files.delete( missing );
+
+		String xml = "<?xml version=\"1.0\"?>\n"
+				+ "<!DOCTYPE constraint-mappings [\n"
+				+ "  <!ENTITY % ext SYSTEM \"" + missing.toUri() + "\">\n"
+				+ "  %ext;\n"
+				+ "]>\n"
+				+ "<constraint-mappings version=\"3.1\"/>";
+
+		XMLEventReader xmlEventReader = xmlParserHelper.createXmlEventReader(
+				"constraint mapping file",
+				new ByteArrayInputStream( xml.getBytes( StandardCharsets.UTF_8 ) )
+		);
+
+		String version = xmlParserHelper.getSchemaVersion( "constraint mapping file", xmlEventReader );
+
+		assertThat( version ).isEqualTo( "3.1" );
 	}
 }


### PR DESCRIPTION
Hibernate Validator reads the schema version from a constraint-mapping or `validation.xml` document before it validates that document against the XSD, and that first read goes through a StAX `XMLInputFactory` created with `newInstance()` and nothing else. With DTD support left on, an external parameter entity declared in the internal subset is expanded while the version is being read, so a descriptor along the lines of `<!DOCTYPE constraint-mappings [ <!ENTITY % ext SYSTEM "http://host/x"> %ext; ]>` makes the parser reach out to that URL or local file. Since this expansion happens during the version read, it runs before the schema's secure-processing check that otherwise refuses the external access, so an untrusted mapping handed to `Configuration.addMapping` can drive a server-side request or read a local file (an XML external entity issue). I ran into it while tracing why schema validation was the only layer refusing external entities. The descriptors never rely on a DTD, so I turned off doctype declarations and external entities on the factory itself. I kept the change inside `XmlParserHelper` so the version read and the later parsing pass share the same hardened factory, and added a test that reads the version of a document whose external parameter entity points at a missing file: it now succeeds instead of trying to fetch it.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
