### PR TITLE
HV-2237 Added jqassistant rule to enforce @Incubating on Def classes

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/DurationMaxDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/DurationMaxDef.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.validator.cfg.defs;
 
+import org.hibernate.validator.Incubating;
 import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.time.DurationMax;
 
@@ -11,6 +12,7 @@ import org.hibernate.validator.constraints.time.DurationMax;
  * A {@link DurationMax} constraint definition.
  * @author Marko Bekhta
  */
+@Incubating
 public class DurationMaxDef extends ConstraintDef<DurationMaxDef, DurationMax> {
 
 	public DurationMaxDef() {

--- a/engine/src/main/java/org/hibernate/validator/cfg/defs/DurationMinDef.java
+++ b/engine/src/main/java/org/hibernate/validator/cfg/defs/DurationMinDef.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.validator.cfg.defs;
 
+import org.hibernate.validator.Incubating;
 import org.hibernate.validator.cfg.ConstraintDef;
 import org.hibernate.validator.constraints.time.DurationMin;
 
@@ -12,6 +13,7 @@ import org.hibernate.validator.constraints.time.DurationMin;
  *
  * @author Marko Bekhta
  */
+@Incubating
 public class DurationMinDef extends ConstraintDef<DurationMinDef, DurationMin> {
 
 	public DurationMinDef() {

--- a/jqassistant/rules/rules.xml
+++ b/jqassistant/rules/rules.xml
@@ -90,11 +90,29 @@
         ]]></cypher>
     </constraint>
 
+    <constraint id="my-rules:IncubatingConstraintAnnotationsMustHaveIncubatingDefs">
+        <description>If a constraint annotation is marked @Incubating, its corresponding Def class must also be marked @Incubating.</description>
+        <cypher><![CDATA[
+            MATCH
+                (defClass)-[:EXTENDS_GENERIC]->(paramType)-[:OF_RAW_TYPE]->(rawType),
+                (paramType)-[:HAS_ACTUAL_TYPE_ARGUMENT {index: 1}]->(bound)-[:OF_RAW_TYPE]->(annotationType),
+                (annotationType)-[:ANNOTATED_BY]->()-[:OF_TYPE]->(incubatingType)
+            WHERE
+                rawType.fqn = "org.hibernate.validator.cfg.ConstraintDef"
+                AND incubatingType.fqn = "org.hibernate.validator.Incubating"
+                AND defClass.fqn =~ "^org\\.hibernate\\.validator\\.cfg\\.defs\\..*"
+                AND NOT (defClass)-[:ANNOTATED_BY]->()-[:OF_TYPE]->({fqn: "org.hibernate.validator.Incubating"})
+            RETURN
+                annotationType.fqn AS ConstraintAnnotation, defClass.fqn AS DefClass, "Def class missing @Incubating" AS Issue
+        ]]></cypher>
+    </constraint>
+
     <group id="default">
         <includeConstraint refId="my-rules:PublicTypesMayNotExtendInternalTypes" />
         <includeConstraint refId="my-rules:PublicMethodsMayNotExposeInternalTypes" />
         <includeConstraint refId="my-rules:PublicFieldsMayNotExposeInternalTypes" />
         <includeConstraint refId="my-rules:ConstraintAnnotationsMustBeDocumentedAndRepeatable" />
+        <includeConstraint refId="my-rules:IncubatingConstraintAnnotationsMustHaveIncubatingDefs" />
     </group>
 
 </jqa:jqassistant-rules>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2237

Adds a jqassistant constraint that verifies if a constraint annotation is marked @Incubating, its corresponding programmatic definition (Def class) must also be marked @Incubating.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
