### PR TITLE
HV-1916 Do not write container information to the shared root path node

### DIFF
--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/MutableNode.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/MutableNode.java
@@ -102,6 +102,10 @@ public class MutableNode
 		this.typeArgumentIndex = typeArgumentIndex;
 	}
 
+	static MutableNode createRootNode() {
+		return createBeanNode( null );
+	}
+
 	public static MutableNode createNode(MutableNode parent) {
 		return new MutableNode(
 				null,

--- a/engine/src/main/java/org/hibernate/validator/internal/engine/path/MutablePath.java
+++ b/engine/src/main/java/org/hibernate/validator/internal/engine/path/MutablePath.java
@@ -157,14 +157,17 @@ public final class MutablePath implements Path, Serializable {
 	}
 
 	public void makeLeafNodeIterable() {
+		detachSharedRootNode();
 		currentLeafNode.makeIterable();
 	}
 
 	public void makeLeafNodeIterableAndSetIndex(Integer index) {
+		detachSharedRootNode();
 		currentLeafNode.makeIterableAndSetIndex( index );
 	}
 
 	public void makeLeafNodeIterableAndSetMapKey(Object key) {
+		detachSharedRootNode();
 		currentLeafNode.makeIterableAndSetMapKey( key );
 	}
 
@@ -176,7 +179,20 @@ public final class MutablePath implements Path, Serializable {
 	}
 
 	public void setLeafNodeTypeParameter(Class<?> containerClass, Integer typeArgumentIndex) {
+		detachSharedRootNode();
 		currentLeafNode.setTypeParameter( containerClass, typeArgumentIndex );
+	}
+
+	/**
+	 * The root node is a singleton shared by every path, so it has to be replaced with a private copy before any
+	 * of the mutators above writes container information to it. Otherwise that write stays there for the lifetime
+	 * of the JVM and every path created later reports it on its first node. The current leaf node is the root node
+	 * for violations built from a class-level constraint, where the leaf bean node is dropped.
+	 */
+	private void detachSharedRootNode() {
+		if ( currentLeafNode == MutableNode.ROOT_NODE ) {
+			currentLeafNode = MutableNode.createRootNode();
+		}
 	}
 
 	public void removeLeafNode() {

--- a/engine/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextImplTest.java
+++ b/engine/src/test/java/org/hibernate/validator/test/constraints/ConstraintValidatorContextImplTest.java
@@ -7,6 +7,8 @@ package org.hibernate.validator.test.constraints;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.assertPathEquals;
 import static org.hibernate.validator.testutil.ConstraintViolationAssert.pathWith;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
@@ -220,6 +222,20 @@ public class ConstraintValidatorContextImplTest {
 				.property( "bar", true, "test", null, Map.class, 0 )
 				.containerElement( "<map value>", true, "key", null, Map.class, 1 )
 				.containerElement( "<list element>", true, null, 3, List.class, 0 ) );
+	}
+
+	@Test
+	public void testCustomizingTheFirstNodeDoesNotAlterPathsCreatedLater() {
+		ConstraintValidatorContextImpl context = createEmptyHibernateConstraintValidatorReusableContext();
+		context.buildConstraintViolationWithTemplate( message )
+				.addPropertyNode( "foo" ).inIterable().atIndex( 3 )
+				.addConstraintViolation();
+
+		MutablePath path = MutablePath.createRootPath();
+		path.addPropertyNode( "bar" );
+
+		assertFalse( path.getLeafNode().isInIterable() );
+		assertNull( path.getLeafNode().getIndex() );
 	}
 
 	private ConstraintValidatorContextImpl createEmptyHibernateConstraintValidatorReusableContext() {


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-1916

**Reduced after review.** The reported symptom is indeed a misuse of the API — see the discussion below. What is left here is the one defect the investigation turned up, which is independent of it.

`MutableNode.ROOT_NODE` is a singleton shared by every path. `inIterable()` / `atIndex()` / `atKey()` / `inContainer()` write the container information onto the current leaf node of the path being built, and for a violation built from a class-level constraint — where `ConstraintViolationBuilderImpl#dropLeafNodeIfRequired` drops the leaf bean node — that current leaf *is* the shared root when the first node of the path is customized:

```java
context.buildConstraintViolationWithTemplate( message )
        .addPropertyNode( "jobs" ).inIterable().atIndex( 3 )
        .addConstraintViolation();
```

The write then stays on the singleton for the lifetime of the JVM. It never shows up in the violation path itself, because the first node is re-parented to the pristine materialized root on the way out, but every path built afterwards hands the flags out on its first node. A `TraversableResolver` sees it:

| `traversableProperty` for a plain `@NotNull` property of an unrelated bean | |
|---|---|
| before the violation above is built | `name inIterable=false index=null` |
| after it | `name inIterable=true index=3` |

### Fix

`MutablePath` replaces the shared root with a private copy before any of those mutators writes to it. Violation paths come out exactly as they do today; the only thing that changes is that the write no longer escapes the path it belongs to.

### Verification

The added test fails on `main` (`expected [false] but found [true]`) and passes with the fix. Full `engine` suite green — 2485 tests, JDK 25 — and `spotless:check` / `checkstyle:check` clean.

I used Claude Code while working on this; the analysis and the change are mine and I can walk through them.

----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
