### PR TITLE
[6.2] HV-2244 Tune the content of javadoc jars to reduce the size of files published to Maven Central

### DIFF
--- a/annotation-processor/pom.xml
+++ b/annotation-processor/pom.xml
@@ -163,6 +163,59 @@
 
     <profiles>
         <profile>
+            <id>dist</id>
+            <activation>
+                <property>
+                    <name>disableDistributionBuild</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <properties>
+                <maven.javadoc.skip>false</maven.javadoc.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-javadoc</id>
+                                <goals>
+                                    <goal>javadoc-no-fork</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                            </execution>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <phase>${javadoc.generate.jar.phase}</phase>
+                                <!--
+                                    Reduce the size of per-module javadoc jars published to Maven Central.
+                                    These options are intentionally NOT in the shared pluginManagement configuration,
+                                    so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+                                 -->
+                                <configuration>
+                                    <!--
+                                        Use a separate output directory so that the reduced javadoc
+                                        does not get mixed with the full javadoc from the generate-javadoc execution.
+                                     -->
+                                    <outputDirectory>${project.build.directory}/javadoc-jar</outputDirectory>
+                                    <!-- Don't repeat inherited method docs; link to the declaring type instead -->
+                                    <additionalOptions>--override-methods summary</additionalOptions>
+                                    <!-- class-use pages add significant size; IDEs provide better "find usages" -->
+                                    <use>false</use>
+                                    <!-- Class hierarchy tree adds bulk; IDEs show this better -->
+                                    <notree>true</notree>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>java17-mr-build</id>
             <activation>
                 <jdk>[17,)</jdk>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -225,6 +225,59 @@
     </build>
     <profiles>
         <profile>
+            <id>dist</id>
+            <activation>
+                <property>
+                    <name>disableDistributionBuild</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <properties>
+                <maven.javadoc.skip>false</maven.javadoc.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-javadoc</id>
+                                <goals>
+                                    <goal>javadoc-no-fork</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                            </execution>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <phase>${javadoc.generate.jar.phase}</phase>
+                                <!--
+                                    Reduce the size of per-module javadoc jars published to Maven Central.
+                                    These options are intentionally NOT in the shared pluginManagement configuration,
+                                    so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+                                 -->
+                                <configuration>
+                                    <!--
+                                        Use a separate output directory so that the reduced javadoc
+                                        does not get mixed with the full javadoc from the generate-javadoc execution.
+                                     -->
+                                    <outputDirectory>${project.build.directory}/javadoc-jar</outputDirectory>
+                                    <!-- Don't repeat inherited method docs; link to the declaring type instead -->
+                                    <additionalOptions>--override-methods summary</additionalOptions>
+                                    <!-- class-use pages add significant size; IDEs provide better "find usages" -->
+                                    <use>false</use>
+                                    <!-- Class hierarchy tree adds bulk; IDEs show this better -->
+                                    <notree>true</notree>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>testWithJdk11+</id>
             <activation>
                 <property>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -212,7 +212,7 @@
                 </property>
             </activation>
             <properties>
-                <javadoc.additional.options>-html5 -source 8</javadoc.additional.options>
+                <javadoc.additional.options>-html5</javadoc.additional.options>
             </properties>
         </profile>
         <profile>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -342,6 +342,59 @@
     </build>
     <profiles>
         <profile>
+            <id>dist</id>
+            <activation>
+                <property>
+                    <name>disableDistributionBuild</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <properties>
+                <maven.javadoc.skip>false</maven.javadoc.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-javadoc</id>
+                                <goals>
+                                    <goal>javadoc-no-fork</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                            </execution>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <phase>${javadoc.generate.jar.phase}</phase>
+                                <!--
+                                    Reduce the size of per-module javadoc jars published to Maven Central.
+                                    These options are intentionally NOT in the shared pluginManagement configuration,
+                                    so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+                                 -->
+                                <configuration>
+                                    <!--
+                                        Use a separate output directory so that the reduced javadoc
+                                        does not get mixed with the full javadoc from the generate-javadoc execution.
+                                     -->
+                                    <outputDirectory>${project.build.directory}/javadoc-jar</outputDirectory>
+                                    <!-- Don't repeat inherited method docs; link to the declaring type instead -->
+                                    <additionalOptions>--override-methods summary</additionalOptions>
+                                    <!-- class-use pages add significant size; IDEs provide better "find usages" -->
+                                    <use>false</use>
+                                    <!-- Class hierarchy tree adds bulk; IDEs show this better -->
+                                    <notree>true</notree>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>testWithJdk11+</id>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <version.japicmp.plugin>0.11.1</version.japicmp.plugin>
         <version.jar.plugin>3.0.2</version.jar.plugin>
         <version.jqassistant.plugin>1.11.1</version.jqassistant.plugin>
-        <version.javadoc.plugin>3.0.1</version.javadoc.plugin>
+        <version.javadoc.plugin>3.11.3</version.javadoc.plugin>
         <version.license.plugin>3.0</version.license.plugin>
         <version.release.plugin>2.5.3</version.release.plugin>
         <version.resources.plugin>3.0.2</version.resources.plugin>
@@ -279,9 +279,9 @@
         <java-version.test.launcher>${java-version.test.launcher.java_home}/bin/java</java-version.test.launcher>
         <java-version.test.java17.add-test-source-phase>generate-test-sources</java-version.test.java17.add-test-source-phase>
 
-        <!-- No need to build the javadocs per module. Aggregated javadocs are build in the distribution module. See also HV-894 -->
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <deploy.skip>false</deploy.skip>
+        <javadoc.generate.jar.phase>none</javadoc.generate.jar.phase>
 
         <!-- maven.compiler.release and maven.compiler.testRelease are set in a profile; see below -->
         <!-- Also set source/target, because several other plugins rely on this and don't understand release -->
@@ -1012,7 +1012,11 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${version.javadoc.plugin}</version>
                     <configuration>
+                        <skip>${maven.javadoc.skip}</skip>
                         <quiet>true</quiet>
+                        <failOnError>true</failOnError>
+                        <excludePackageNames>*.impl,*.impl.*,*.internal,*.internal.*</excludePackageNames>
+                        <detectOfflineLinks>false</detectOfflineLinks>
                         <docfilessubdirs>true</docfilessubdirs>
                         <bottom>
                             <![CDATA[Copyright &copy; ${project.inceptionYear}-{currentYear} <a href="http://redhat.com">Red Hat, Inc.</a> All Rights Reserved]]></bottom>
@@ -1316,6 +1320,9 @@
         </profile>
         <profile>
             <id>release</id>
+            <properties>
+                <javadoc.generate.jar.phase>prepare-package</javadoc.generate.jar.phase>
+            </properties>
             <build>
                 <plugins>
                     <plugin>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -73,4 +73,60 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>dist</id>
+            <activation>
+                <property>
+                    <name>disableDistributionBuild</name>
+                    <value>!true</value>
+                </property>
+            </activation>
+            <properties>
+                <maven.javadoc.skip>false</maven.javadoc.skip>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>generate-javadoc</id>
+                                <goals>
+                                    <goal>javadoc-no-fork</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                            </execution>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <phase>${javadoc.generate.jar.phase}</phase>
+                                <!--
+                                    Reduce the size of per-module javadoc jars published to Maven Central.
+                                    These options are intentionally NOT in the shared pluginManagement configuration,
+                                    so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+                                 -->
+                                <configuration>
+                                    <!--
+                                        Use a separate output directory so that the reduced javadoc
+                                        does not get mixed with the full javadoc from the generate-javadoc execution.
+                                     -->
+                                    <outputDirectory>${project.build.directory}/javadoc-jar</outputDirectory>
+                                    <!-- Don't repeat inherited method docs; link to the declaring type instead -->
+                                    <additionalOptions>--override-methods summary</additionalOptions>
+                                    <!-- class-use pages add significant size; IDEs provide better "find usages" -->
+                                    <use>false</use>
+                                    <!-- Class hierarchy tree adds bulk; IDEs show this better -->
+                                    <notree>true</notree>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2244

and use the same config as on 8.0

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
