### PR TITLE
[8.0] HV-2244 Tune the content of javadoc jars to reduce the size of files published to Maven Central

### DIFF
--- a/annotation-processor/pom.xml
+++ b/annotation-processor/pom.xml
@@ -251,6 +251,28 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <phase>${javadoc.generate.jar.phase}</phase>
+                                <!--
+                                    Reduce the size of per-module javadoc jars published to Maven Central.
+                                    These options are intentionally NOT in the shared pluginManagement configuration,
+                                    so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+                                 -->
+                                <configuration>
+                                    <!--
+                                        Use a separate output directory so that the reduced javadoc
+                                        does not get mixed with the full javadoc from the generate-javadoc execution.
+                                     -->
+                                    <outputDirectory>${project.build.directory}/javadoc-jar</outputDirectory>
+                                    <additionalOptions>
+                                        <additionalOption>-html5</additionalOption>
+                                        <additionalOption>-Xdoclint:all,-missing</additionalOption>
+                                        <!-- Don't repeat inherited method docs; link to the declaring type instead -->
+                                        <additionalOption>--override-methods summary</additionalOption>
+                                    </additionalOptions>
+                                    <!-- class-use pages add significant size; IDEs provide better "find usages" -->
+                                    <use>false</use>
+                                    <!-- Class hierarchy tree adds bulk; IDEs show this better -->
+                                    <notree>true</notree>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/cdi/pom.xml
+++ b/cdi/pom.xml
@@ -292,6 +292,28 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <phase>${javadoc.generate.jar.phase}</phase>
+                                <!--
+                                    Reduce the size of per-module javadoc jars published to Maven Central.
+                                    These options are intentionally NOT in the shared pluginManagement configuration,
+                                    so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+                                 -->
+                                <configuration>
+                                    <!--
+                                        Use a separate output directory so that the reduced javadoc
+                                        does not get mixed with the full javadoc from the generate-javadoc execution.
+                                     -->
+                                    <outputDirectory>${project.build.directory}/javadoc-jar</outputDirectory>
+                                    <additionalOptions>
+                                        <additionalOption>-html5</additionalOption>
+                                        <additionalOption>-Xdoclint:all,-missing</additionalOption>
+                                        <!-- Don't repeat inherited method docs; link to the declaring type instead -->
+                                        <additionalOption>--override-methods summary</additionalOption>
+                                    </additionalOptions>
+                                    <!-- class-use pages add significant size; IDEs provide better "find usages" -->
+                                    <use>false</use>
+                                    <!-- Class hierarchy tree adds bulk; IDEs show this better -->
+                                    <notree>true</notree>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -435,6 +435,28 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <phase>${javadoc.generate.jar.phase}</phase>
+                                <!--
+                                    Reduce the size of per-module javadoc jars published to Maven Central.
+                                    These options are intentionally NOT in the shared pluginManagement configuration,
+                                    so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+                                 -->
+                                <configuration>
+                                    <!--
+                                        Use a separate output directory so that the reduced javadoc
+                                        does not get mixed with the full javadoc from the generate-javadoc execution.
+                                     -->
+                                    <outputDirectory>${project.build.directory}/javadoc-jar</outputDirectory>
+                                    <additionalOptions>
+                                        <additionalOption>-html5</additionalOption>
+                                        <additionalOption>-Xdoclint:all,-missing</additionalOption>
+                                        <!-- Don't repeat inherited method docs; link to the declaring type instead -->
+                                        <additionalOption>--override-methods summary</additionalOption>
+                                    </additionalOptions>
+                                    <!-- class-use pages add significant size; IDEs provide better "find usages" -->
+                                    <use>false</use>
+                                    <!-- Class hierarchy tree adds bulk; IDEs show this better -->
+                                    <notree>true</notree>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -147,6 +147,28 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <phase>${javadoc.generate.jar.phase}</phase>
+                                <!--
+                                    Reduce the size of per-module javadoc jars published to Maven Central.
+                                    These options are intentionally NOT in the shared pluginManagement configuration,
+                                    so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+                                 -->
+                                <configuration>
+                                    <!--
+                                        Use a separate output directory so that the reduced javadoc
+                                        does not get mixed with the full javadoc from the generate-javadoc execution.
+                                     -->
+                                    <outputDirectory>${project.build.directory}/javadoc-jar</outputDirectory>
+                                    <additionalOptions>
+                                        <additionalOption>-html5</additionalOption>
+                                        <additionalOption>-Xdoclint:all,-missing</additionalOption>
+                                        <!-- Don't repeat inherited method docs; link to the declaring type instead -->
+                                        <additionalOption>--override-methods summary</additionalOption>
+                                    </additionalOptions>
+                                    <!-- class-use pages add significant size; IDEs provide better "find usages" -->
+                                    <use>false</use>
+                                    <!-- Class hierarchy tree adds bulk; IDEs show this better -->
+                                    <notree>true</notree>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HV-2244

<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
