### PR TITLE
Fix an issue with skipping tests during -Preproducibility-check builds

### DIFF
--- a/integrationtest/wildfly/pom.xml
+++ b/integrationtest/wildfly/pom.xml
@@ -248,6 +248,12 @@
     </build>
     <profiles>
         <profile>
+            <id>reproducibility-check</id>
+            <properties>
+                <skip.failsafe.execution>true</skip.failsafe.execution>
+            </properties>
+        </profile>
+        <profile>
             <id>testWithJdk11+</id>
             <activation>
                 <property>


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, 
please consider reviewing https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md

Please include a link to the Jira issue solved by this PR in the description;
see https://hibernate.atlassian.net/browse/HV.

Remember to prepend the title of this PR, as well as all commit messages,
with the key of the Jira issue (`HV-<digits>`).
-->

[Please describe here what your change is about]

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt).
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-validator/blob/main/CONTRIBUTING.md#legal).

----------------------
